### PR TITLE
feat: vision improvements — drag support, screenshot optimization, an…

### DIFF
--- a/examples/flows/drag-slider.yaml
+++ b/examples/flows/drag-slider.yaml
@@ -22,5 +22,5 @@ name: Set ride price to +100
 #     from: green circle slider
 #     to: +100 mark
 
-- assert: "+100"
-- done: "Price slider set to +100"
+- assert: '+100'
+- done: 'Price slider set to +100'

--- a/examples/flows/drag-slider.yaml
+++ b/examples/flows/drag-slider.yaml
@@ -1,0 +1,26 @@
+# Drag a price slider to a specific position (vision mode required).
+#
+# This flow demonstrates the drag step — useful for sliders, carousels,
+# reorderable lists, and any other drag-and-drop interactions.
+#
+# Requires: AGENT_MODE=vision + VISION_LOCATE_PROVIDER=stark + LLM_API_KEY
+#
+appId: com.example.rideapp
+name: Set ride price to +100
+---
+- launchApp
+- wait: 2
+
+# Natural language — shorthand "drag X to Y"
+- drag the green circle slider to the +100 mark
+
+# -- OR use structured YAML (shorthand) --
+# - drag: "green circle slider to +100 mark"
+
+# -- OR use structured YAML (explicit from/to) --
+# - drag:
+#     from: green circle slider
+#     to: +100 mark
+
+- assert: "+100"
+- done: "Price slider set to +100"

--- a/flows/rapido.yaml
+++ b/flows/rapido.yaml
@@ -1,0 +1,19 @@
+platform: android
+---
+steps:
+  - open rapido app
+  - wait for the app to be ready
+  - click on where are you going
+  - wait for drop screen to be visible
+  - Enter Bangalore Airport in the drop location
+  - click on the first suggestion from the list
+  - wait for the vehicle list to be visible
+  - Select the cheapest vehicle option
+  - Click on Book a can
+  - Click on confirm pickup
+  - wait for 2 seconds
+  - drag green circle until +90
+  - wait for 2seconds
+  - assert the green circle is at the +90 mark
+  - Click on back arrow
+  - done

--- a/landing/usage.html
+++ b/landing/usage.html
@@ -767,6 +767,7 @@
             <li><a href="#wait">Wait / Pause</a></li>
             <li><a href="#wait-until">Wait Until</a></li>
             <li><a href="#scroll-swipe">Scroll / Swipe</a></li>
+            <li><a href="#drag">Drag / Slider</a></li>
             <li><a href="#assert">Assert / Verify</a></li>
             <li><a href="#navigation">Navigation</a></li>
             <li><a href="#all-commands">Full Reference</a></li>
@@ -1377,6 +1378,53 @@
             </div>
           </section>
 
+          <section id="drag" class="reveal">
+            <h2>Drag / Slider</h2>
+            <p>
+              Drag one element to another — sliders, carousels, reorderable lists, and any
+              drag-and-drop interaction. Requires vision mode
+              (<code>AGENT_MODE=vision</code>).
+            </p>
+
+            <div class="code-block">
+              <div class="code-block-header">
+                <div class="code-block-dots"><span></span><span></span><span></span></div>
+                <span class="code-block-label">Natural language</span>
+              </div>
+              <pre><span class="p">-</span> drag the green circle slider to the +100 mark
+<span class="p">-</span> slide the price handle to +80
+<span class="p">-</span> move the volume knob to maximum</pre>
+            </div>
+
+            <div class="code-block">
+              <div class="code-block-header">
+                <div class="code-block-dots"><span></span><span></span><span></span></div>
+                <span class="code-block-label">Structured YAML — shorthand</span>
+              </div>
+              <pre><span class="c"># "drag: from to to"</span>
+<span class="p">-</span> <span class="k">drag</span><span class="p">:</span> <span class="s">"green circle slider to +100 mark"</span></pre>
+            </div>
+
+            <div class="code-block">
+              <div class="code-block-header">
+                <div class="code-block-dots"><span></span><span></span><span></span></div>
+                <span class="code-block-label">Structured YAML — explicit from/to</span>
+              </div>
+              <pre><span class="p">-</span> <span class="k">drag</span><span class="p">:</span>
+    <span class="k">from</span><span class="p">:</span> <span class="s">green circle slider</span>
+    <span class="k">to</span><span class="p">:</span>   <span class="s">+100 mark</span></pre>
+            </div>
+
+            <div class="callout callout-tip">
+              <div class="callout-title">Vision required</div>
+              <p>
+                Drag uses AI vision to locate both the source and target by visual description.
+                Set <code>AGENT_MODE=vision</code> and <code>VISION_LOCATE_PROVIDER=stark</code>
+                with a valid <code>LLM_API_KEY</code>.
+              </p>
+            </div>
+          </section>
+
           <section id="assert" class="reveal">
             <h2>Assert / Verify</h2>
             <p>
@@ -1499,6 +1547,11 @@
                   <td>swipe</td>
                   <td>direction, repeat?</td>
                   <td>Swipe up/down/left/right</td>
+                </tr>
+                <tr>
+                  <td>drag</td>
+                  <td>from, to</td>
+                  <td>Drag from one element to another (vision mode)</td>
                 </tr>
                 <tr>
                   <td>assert</td>

--- a/landing/usage.html
+++ b/landing/usage.html
@@ -1382,8 +1382,7 @@
             <h2>Drag / Slider</h2>
             <p>
               Drag one element to another — sliders, carousels, reorderable lists, and any
-              drag-and-drop interaction. Requires vision mode
-              (<code>AGENT_MODE=vision</code>).
+              drag-and-drop interaction. Requires vision mode (<code>AGENT_MODE=vision</code>).
             </p>
 
             <div class="code-block">
@@ -1418,9 +1417,9 @@
             <div class="callout callout-tip">
               <div class="callout-title">Vision required</div>
               <p>
-                Drag uses AI vision to locate both the source and target by visual description.
-                Set <code>AGENT_MODE=vision</code> and <code>VISION_LOCATE_PROVIDER=stark</code>
-                with a valid <code>LLM_API_KEY</code>.
+                Drag uses AI vision to locate both the source and target by visual description. Set
+                <code>AGENT_MODE=vision</code> and <code>VISION_LOCATE_PROVIDER=stark</code> with a
+                valid <code>LLM_API_KEY</code>.
               </p>
             </div>
           </section>

--- a/src/agent/planner.ts
+++ b/src/agent/planner.ts
@@ -421,6 +421,7 @@ Rules:
 8. For search goals: separate "open search" from "type query" from "select result"
 9. IMPORTANT: When a sub-goal involves typing/entering text into a field, use the word "Type" explicitly (not "Enter" which is ambiguous). Example: "Type 'hello@email.com' into the To field" NOT "Enter hello@email.com in the recipient field"
 10. FIELD-SPECIFIC SUB-GOALS: When a screen has multiple input fields, create a separate sub-goal for EACH field that needs to be filled. Always name the specific field in the sub-goal (e.g., "Type 'X' into the [field name] field"). NEVER say "Type into the field" without specifying WHICH field. The agent needs to know exactly which field to target.
+11. ITERATIVE FEEDBACK LOOPS — Do NOT decompose tasks that require repeated action→observe→adapt cycles. If completing the goal requires submitting input, reading a response, and submitting again based on that response (e.g., word puzzles, quizzes, multi-round challenges), keep ALL of those cycles inside ONE sub-goal. Splitting "type", "tap submit", and "analyze result" into separate sub-goals destroys the agent's ability to adapt between rounds — it loses the context of previous results. The single sub-goal description should explain the full loop: what to input, how to submit, and how to interpret the feedback for the next round.
 
 Examples of SIMPLE goals (no decomposition needed):
 - "Open Settings" → simple (single app launch)

--- a/src/flow/llm-parser.ts
+++ b/src/flow/llm-parser.ts
@@ -41,6 +41,13 @@ const stepSchema = z.discriminatedUnion('kind', [
     direction: z.enum(['up', 'down', 'left', 'right']),
     maxScrolls: z.number(),
   }),
+  z.object({
+    kind: z.literal('drag'),
+    from: z.string().describe('Visual description of the element to drag from'),
+    to: z.string().describe('Visual description of the drop target'),
+    duration: z.number().optional().describe('Drag movement duration in ms, default 1200'),
+    longPressDuration: z.number().optional().describe('Hold before drag in ms, default 600'),
+  }),
   z.object({ kind: z.literal('getInfo'), query: z.string() }),
   z.object({ kind: z.literal('done'), message: z.string().optional() }),
   z.object({ kind: z.literal('launchApp') }),
@@ -56,6 +63,7 @@ const SYSTEM_PROMPT =
   `- "wait for <element> to disappear/be gone" → waitUntil (gone)\n` +
   `- "wait for screen to load/stabilize" → waitUntil (screenLoaded)\n` +
   `- "wait <N> seconds" → wait\n` +
+  `- "drag/slide/move X to Y" → drag (from=X, to=Y)\n` +
   `- "swipe/scroll <direction>" → swipe\n` +
   `- "verify/check/assert <text>" → assert\n` +
   `- "scroll until <text> visible" → scrollAssert\n` +

--- a/src/flow/natural-line.ts
+++ b/src/flow/natural-line.ts
@@ -117,6 +117,14 @@ export function tryParseNaturalFlowLine(line: string): FlowStep | null {
     if (text) return { kind: 'scrollAssert', text, direction, maxScrolls, verbatim };
   }
 
+  // "drag X to Y" / "slide X to Y" / "move X to Y"
+  const dragMatch = t.match(/^(?:drag|slide|move)\s+(.+?)\s+(?:to|until|towards?)\s+(.+)$/i);
+  if (dragMatch) {
+    const from = trimPunct(dragMatch[1].trim());
+    const to = trimPunct(dragMatch[2].trim());
+    if (from && to) return { kind: 'drag', from, to, verbatim };
+  }
+
   const swipeMatch = t.match(/^swipe\s+(up|down|left|right)(?:\s+(\d+)\s*(?:times?))?/i);
   if (swipeMatch) {
     const direction = swipeMatch[1].toLowerCase() as 'up' | 'down' | 'left' | 'right';

--- a/src/flow/parse-yaml-flow.ts
+++ b/src/flow/parse-yaml-flow.ts
@@ -106,6 +106,19 @@ export function normalizeStructured(raw: unknown, index: number): FlowStep | nul
       };
     }
 
+    // ── Multi-key: drag { from, to } ──
+    if (keys.includes('from') && keys.includes('to')) {
+      const duration = o.duration != null ? Number(o.duration) : undefined;
+      const longPressDuration = o.longPressDuration != null ? Number(o.longPressDuration) : undefined;
+      return {
+        kind: 'drag',
+        from: String(o.from).trim(),
+        to: String(o.to).trim(),
+        ...(duration != null && { duration }),
+        ...(longPressDuration != null && { longPressDuration }),
+      };
+    }
+
     // ── Multi-key: scrollAssert ──
     if (
       keys.includes('scrollAssert') ||
@@ -168,6 +181,14 @@ export function normalizeStructured(raw: unknown, index: number): FlowStep | nul
     }
     if (k === 'waitUntilGone') {
       return { kind: 'waitUntil', condition: 'gone', text: String(v).trim(), timeoutSeconds: 10 };
+    }
+    if (k === 'drag') {
+      const val = String(v).trim();
+      const toIdx = val.indexOf(' to ');
+      if (toIdx !== -1) {
+        return { kind: 'drag', from: val.slice(0, toIdx).trim(), to: val.slice(toIdx + 4).trim() };
+      }
+      throw new Error(`Step ${index + 1}: drag requires "from to to" syntax, e.g. drag: "green dot to +100 mark"`);
     }
     if (k === 'tap') return { kind: 'tap', label: String(v) };
     if (k === 'type') return { kind: 'type', text: String(v) };

--- a/src/flow/parse-yaml-flow.ts
+++ b/src/flow/parse-yaml-flow.ts
@@ -109,7 +109,8 @@ export function normalizeStructured(raw: unknown, index: number): FlowStep | nul
     // ── Multi-key: drag { from, to } ──
     if (keys.includes('from') && keys.includes('to')) {
       const duration = o.duration != null ? Number(o.duration) : undefined;
-      const longPressDuration = o.longPressDuration != null ? Number(o.longPressDuration) : undefined;
+      const longPressDuration =
+        o.longPressDuration != null ? Number(o.longPressDuration) : undefined;
       return {
         kind: 'drag',
         from: String(o.from).trim(),
@@ -188,7 +189,9 @@ export function normalizeStructured(raw: unknown, index: number): FlowStep | nul
       if (toIdx !== -1) {
         return { kind: 'drag', from: val.slice(0, toIdx).trim(), to: val.slice(toIdx + 4).trim() };
       }
-      throw new Error(`Step ${index + 1}: drag requires "from to to" syntax, e.g. drag: "green dot to +100 mark"`);
+      throw new Error(
+        `Step ${index + 1}: drag requires "from to to" syntax, e.g. drag: "green dot to +100 mark"`
+      );
     }
     if (k === 'tap') return { kind: 'tap', label: String(v) };
     if (k === 'type') return { kind: 'type', text: String(v) };

--- a/src/flow/run-yaml-flow.ts
+++ b/src/flow/run-yaml-flow.ts
@@ -38,9 +38,10 @@ const execAsync = promisify(exec);
 import type { FlowMeta, FlowStep, FlowPhase, PhasedStep, PhaseResult } from './types.js';
 import type { AppResolver } from '../agent/app-resolver.js';
 import type { RunArtifactCollector } from '../report/writer.js';
+import { lastVisionScreenshot } from './vision-execute.js';
 import { resolveAppId } from '../agent/preprocessor.js';
 import { pngDimensionsFromBase64 } from '../vision/png-dimensions.js';
-import { getCachedScreenSize } from '../vision/window-size.js';
+import { getCachedScreenSize, getScreenSizeForStark } from '../vision/window-size.js';
 import chalk from 'chalk';
 import * as ui from '../ui/terminal.js';
 
@@ -141,6 +142,8 @@ function stepLabel(step: FlowStep): string {
       return 'goHome';
     case 'swipe':
       return `swipe ${step.direction}`;
+    case 'drag':
+      return `drag "${step.from}" to "${step.to}"`;
     case 'assert':
       return `assert "${step.text}"`;
     case 'scrollAssert':
@@ -560,10 +563,10 @@ async function visionAssert(mcp: MCPClient, text: string): Promise<boolean> {
   // is showing results, not that the exact words "search results" appear).
   const query = `Check if "${text}" is satisfied on this screen. This could mean: (1) the exact text "${text}" is literally visible, OR (2) the screen visually shows what "${text}" describes (e.g. "search results" means a list of results is displayed, "login page" means a login form is shown). Use your judgment — if it reads like a description of screen state, check the overall content and layout rather than looking for exact text.`;
 
-  // Retry up to 2 attempts with a fresh screenshot each time (vision can be flaky)
-  const maxAttempts = 2;
+  // Single attempt — callers (waitUntilCondition, assertTextVisible) handle retrying
+  const maxAttempts = 1;
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
-    if (attempt > 0) await sleep(500); // brief pause before retry
+    if (attempt > 0) await sleep(500);
 
     if (mcpDebug)
       ui.printAgentBullet(
@@ -584,7 +587,7 @@ async function visionAssert(mcp: MCPClient, text: string): Promise<boolean> {
         `[vision-assert] Asking LLM: is "${text}" visible? (model: ${getStarkVisionModel()})`
       );
     const visT0 = performance.now();
-    const response = await client.isElementVisible(imageBase64, query, true);
+    const response = await client.isElementVisible(imageBase64, query, false);
     const visElapsed = Math.round(performance.now() - visT0);
     if (mcpDebug)
       ui.printAgentBullet(`[vision-assert] LLM response (${visElapsed}ms): ${response}`);
@@ -775,13 +778,25 @@ async function waitUntilCondition(
   const deadline = Date.now() + timeoutSeconds * 1000;
 
   if (condition === 'screenLoaded') {
-    // Wait until two consecutive DOM snapshots are identical (screen stable)
-    let prevSnapshot = '';
+    // Wait until the screen has stabilized.
+    // In vision mode: compare screenshot sizes (no DOM call).
+    // In DOM mode: compare DOM lengths as a proxy for structural stability.
+    // Either way: if the size stays within 2% for 2 consecutive polls, the screen is loaded.
+    let prevLen = 0;
     let stableCount = 0;
-    const stableThreshold = 2; // need 2 consecutive matches
+    const stableThreshold = 2;
+    const visionMode = isVisionMode();
     while (Date.now() < deadline) {
-      const pageSource = await getPageSource(mcp);
-      if (prevSnapshot && pageSource === prevSnapshot) {
+      let len: number;
+      if (visionMode) {
+        const img = await screenshot(mcp);
+        len = img?.length ?? 0;
+      } else {
+        const pageSource = await getPageSource(mcp);
+        len = pageSource.length;
+      }
+      const delta = prevLen > 0 ? Math.abs(len - prevLen) / prevLen : 1;
+      if (prevLen > 0 && delta <= 0.02) {
         stableCount++;
         if (stableCount >= stableThreshold) {
           return {
@@ -792,7 +807,7 @@ async function waitUntilCondition(
       } else {
         stableCount = 0;
       }
-      prevSnapshot = pageSource;
+      prevLen = len;
       await sleep(pollMs);
     }
     return { success: false, message: `Screen did not stabilize within ${timeoutSeconds}s` };
@@ -842,6 +857,22 @@ export async function executeStep(
   tapPoll: FlowTapPollOptions,
   deviceUdid?: string
 ): Promise<ActionResult> {
+  // Vision mode: natural language steps (verbatim set) use visionExecute with the original
+  // instruction — same path as the playground — for precise context-aware element location.
+  // Explicit YAML steps (no verbatim) fall through to the normal DOM/vision-locate paths.
+  if (
+    isVisionMode() &&
+    step.verbatim &&
+    (step.kind === 'tap' || step.kind === 'type' || step.kind === 'assert')
+  ) {
+    const { visionExecute } = await import('./vision-execute.js');
+    const vr = await visionExecute(mcp, step.verbatim);
+    if (vr && vr.result.message !== '__needs_executeStep__') {
+      return vr.result;
+    }
+    // null = no vision API key, or needs executeStep — fall through
+  }
+
   switch (step.kind) {
     case 'launchApp': {
       const id = meta.appId?.trim();
@@ -910,6 +941,82 @@ export async function executeStep(
       return {
         success: true,
         message: count > 1 ? `Swiped ${dir} ${count} times` : `Swiped ${dir}`,
+      };
+    }
+    case 'drag': {
+      const dragApiKey = getStarkVisionApiKey();
+      if (!dragApiKey) {
+        return { success: false, message: 'drag step requires vision (LLM_API_KEY)' };
+      }
+      const dragImage = await screenshot(mcp);
+      if (!dragImage) {
+        return { success: false, message: 'Failed to capture screenshot for drag' };
+      }
+      const { StarkVisionClient: DragClient, scaleCoordinates: scaleDragCoords } = (
+        await import('df-vision')
+      ).default;
+      const dragClient = new DragClient({
+        apiKey: dragApiKey,
+        model: getStarkVisionModel(),
+        disableThinking: true,
+      });
+      const dragScreenSize = await getScreenSizeForStark(mcp, dragImage);
+      const dragInstruction = `drag ${step.from} to ${step.to}`;
+      const rawDragResp = await dragClient.understandAndLocate(dragInstruction, dragImage);
+      const cleanedDragText = rawDragResp.trim().replace(/(^```json|```$)/g, '');
+      let dragActions: any[];
+      try {
+        const parsed = JSON.parse(cleanedDragText);
+        dragActions = Array.isArray(parsed) ? parsed : [parsed];
+      } catch {
+        return { success: false, message: 'Vision could not parse drag response' };
+      }
+      const dragAction = dragActions[0];
+      if (!dragAction || dragAction.action !== 'drag' || (dragAction.locators?.length ?? 0) < 2) {
+        const locCount = dragAction?.locators?.length ?? 0;
+        let msg: string;
+        if (!dragAction || dragAction.action !== 'drag') {
+          msg = `"${step.from}" and "${step.to}" are not visible on screen`;
+        } else if (locCount === 0) {
+          msg = `"${step.from}" and "${step.to}" are not visible on screen`;
+        } else {
+          // One locator found — assume "from" was found, "to" is missing
+          msg = `"${step.to}" is not visible on screen`;
+        }
+        return { success: false, message: msg };
+      }
+      const fromCoords = dragAction.locators[0].coordinates as [number, number] | undefined;
+      const toCoords = dragAction.locators[1].coordinates as [number, number] | undefined;
+      if (!fromCoords || !toCoords) {
+        return { success: false, message: 'Drag: vision returned no coordinates' };
+      }
+
+      if (fromCoords[0] === 0 && fromCoords[1] === 0) {
+        return { success: false, message: `Drag failed: "${step.from}" is not visible on screen` };
+      }
+      if (toCoords[0] === 0 && toCoords[1] === 0) {
+        return { success: false, message: `Drag failed: "${step.to}" is not visible on screen` };
+      }
+
+      const fromBbox = scaleDragCoords(fromCoords, dragScreenSize);
+      const toBbox = scaleDragCoords(toCoords, dragScreenSize);
+      const dragResult = await mcp.callTool('appium_drag_and_drop', {
+        sourceX: Math.round(fromBbox.center.x),
+        sourceY: Math.round(fromBbox.center.y),
+        targetX: Math.round(toBbox.center.x),
+        targetY: Math.round(toBbox.center.y),
+        duration: step.duration ?? 600,
+        longPressDuration: step.longPressDuration ?? 400,
+      });
+      const dragText =
+        dragResult.content?.map((c: any) => (c.type === 'text' ? c.text : '')).join('') ?? '';
+      const dragSuccess =
+        !dragText.toLowerCase().includes('failed') && !dragText.toLowerCase().includes('error');
+      return {
+        success: dragSuccess,
+        message: dragSuccess
+          ? `Dragged "${step.from}" to "${step.to}"`
+          : `Drag failed: ${dragText.slice(0, 200)}`,
       };
     }
     case 'assert':
@@ -1000,10 +1107,11 @@ async function executePhase(
     artifactCollector?.startStep(globalIdx);
 
     // Capture "before" screenshot for interactive steps (tap, type, swipe)
+    // Skip in vision mode — visionExecute takes its own screenshot internally.
     const isInteractive = step.kind === 'tap' || step.kind === 'type' || step.kind === 'swipe';
     let beforeImg: string | null = null;
     let beforeDims: { width: number; height: number } | undefined;
-    if (artifactCollector && isInteractive) {
+    if (artifactCollector && isInteractive && !isVisionMode()) {
       try {
         beforeImg = await screenshot(mcp);
         if (beforeImg) beforeDims = pngDimensionsFromBase64(beforeImg) ?? undefined;
@@ -1041,19 +1149,32 @@ async function executePhase(
         tapCoordinates: tapCoords,
         deviceScreenSize: getCachedScreenSize(mcp) ?? undefined,
       });
-      // Attach "before" screenshot (shows where the tap/click happened)
-      if (beforeImg) {
-        artifactCollector.attachBeforeScreenshot(globalIdx, beforeImg, beforeDims);
-      }
-      // Attach "after" screenshot (shows the result)
-      try {
-        const img = await screenshot(mcp);
-        if (img) {
-          const dims = pngDimensionsFromBase64(img) ?? undefined;
-          artifactCollector.attachScreenshot(globalIdx, img, dims);
+      // In vision mode, visionExecute already captured the pre-action screenshot.
+      // - Tap actions: attach as "before" so the tap dot overlay is rendered.
+      // - Other actions (type, assert, swipe): attach as "after" so the screenshot is shown.
+      // In DOM mode, use the explicit before screenshot + take an "after" screenshot.
+      const visionShot = lastVisionScreenshot;
+      if (visionShot) {
+        const dims = pngDimensionsFromBase64(visionShot) ?? undefined;
+        if (tapCoords) {
+          artifactCollector.attachBeforeScreenshot(globalIdx, visionShot, dims);
+        } else {
+          artifactCollector.attachScreenshot(globalIdx, visionShot, dims);
         }
-      } catch {
-        /* non-critical */
+      } else {
+        if (beforeImg) {
+          artifactCollector.attachBeforeScreenshot(globalIdx, beforeImg, beforeDims);
+        }
+        // Attach "after" screenshot (shows the result)
+        try {
+          const img = await screenshot(mcp);
+          if (img) {
+            const dims = pngDimensionsFromBase64(img) ?? undefined;
+            artifactCollector.attachScreenshot(globalIdx, img, dims);
+          }
+        } catch {
+          /* non-critical */
+        }
       }
     }
 
@@ -1202,10 +1323,11 @@ export async function runYamlFlow(
     options.artifactCollector?.startStep(i);
 
     // Capture "before" screenshot for interactive steps (tap, type, swipe)
+    // Skip in vision mode — visionExecute takes its own screenshot internally.
     const isInteractiveFlat = step.kind === 'tap' || step.kind === 'type' || step.kind === 'swipe';
     let beforeImgFlat: string | null = null;
     let beforeDimsFlat: { width: number; height: number } | undefined;
-    if (options.artifactCollector && isInteractiveFlat) {
+    if (options.artifactCollector && isInteractiveFlat && !isVisionMode()) {
       try {
         beforeImgFlat = await screenshot(mcp);
         if (beforeImgFlat) beforeDimsFlat = pngDimensionsFromBase64(beforeImgFlat) ?? undefined;
@@ -1243,19 +1365,32 @@ export async function runYamlFlow(
         tapCoordinates: tapCoords,
         deviceScreenSize: getCachedScreenSize(mcp) ?? undefined,
       });
-      // Attach "before" screenshot (shows where the tap/click happened)
-      if (beforeImgFlat) {
-        options.artifactCollector.attachBeforeScreenshot(i, beforeImgFlat, beforeDimsFlat);
-      }
-      // Attach "after" screenshot (shows the result)
-      try {
-        const img = await screenshot(mcp);
-        if (img) {
-          const dims = pngDimensionsFromBase64(img) ?? undefined;
-          options.artifactCollector.attachScreenshot(i, img, dims);
+      // In vision mode, visionExecute already captured the pre-action screenshot.
+      // - Tap actions: attach as "before" so the tap dot overlay is rendered.
+      // - Other actions (type, assert, swipe): attach as "after" so the screenshot is shown.
+      // In DOM mode, use the explicit before screenshot + take an "after" screenshot.
+      const visionShotFlat = lastVisionScreenshot;
+      if (visionShotFlat) {
+        const dims = pngDimensionsFromBase64(visionShotFlat) ?? undefined;
+        if (tapCoords) {
+          options.artifactCollector.attachBeforeScreenshot(i, visionShotFlat, dims);
+        } else {
+          options.artifactCollector.attachScreenshot(i, visionShotFlat, dims);
         }
-      } catch {
-        /* non-critical */
+      } else {
+        if (beforeImgFlat) {
+          options.artifactCollector.attachBeforeScreenshot(i, beforeImgFlat, beforeDimsFlat);
+        }
+        // Attach "after" screenshot (shows the result)
+        try {
+          const img = await screenshot(mcp);
+          if (img) {
+            const dims = pngDimensionsFromBase64(img) ?? undefined;
+            options.artifactCollector.attachScreenshot(i, img, dims);
+          }
+        } catch {
+          /* non-critical */
+        }
       }
     }
 

--- a/src/flow/types.ts
+++ b/src/flow/types.ts
@@ -54,6 +54,15 @@ export type FlowStep =
   | ({ kind: 'back' } & Verbatim)
   | ({ kind: 'home' } & Verbatim)
   | ({ kind: 'swipe'; direction: 'up' | 'down' | 'left' | 'right'; repeat?: number } & Verbatim)
+  | ({
+      kind: 'drag';
+      from: string;
+      to: string;
+      /** Drag movement duration in ms. Default: 600 */
+      duration?: number;
+      /** Hold duration before dragging in ms. Default: 400 */
+      longPressDuration?: number;
+    } & Verbatim)
   | ({ kind: 'assert'; text: string } & Verbatim)
   | ({
       kind: 'scrollAssert';

--- a/src/flow/vision-execute.ts
+++ b/src/flow/vision-execute.ts
@@ -553,10 +553,16 @@ export async function visionExecute(
     const [ty, tx] = toLocator.coordinates;
 
     if (fy === 0 && fx === 0) {
-      return { step, result: { success: false, message: `Drag failed: "${step.from}" is not visible on screen` } };
+      return {
+        step,
+        result: { success: false, message: `Drag failed: "${step.from}" is not visible on screen` },
+      };
     }
     if (ty === 0 && tx === 0) {
-      return { step, result: { success: false, message: `Drag failed: "${step.to}" is not visible on screen` } };
+      return {
+        step,
+        result: { success: false, message: `Drag failed: "${step.to}" is not visible on screen` },
+      };
     }
 
     const fromBbox = scaleCoordinates([fy, fx], screenSize);

--- a/src/flow/vision-execute.ts
+++ b/src/flow/vision-execute.ts
@@ -29,11 +29,18 @@ import { theme } from '../ui/terminal.js';
 
 const mcpDebug = process.env.MCP_DEBUG === '1' || process.env.MCP_DEBUG === 'true';
 
+/**
+ * The raw (full-res) screenshot captured by the most recent visionExecute call.
+ * Set before the action executes so callers can use it as the "before" screenshot
+ * for artifact reporting (tap dot overlay). Cleared at the start of each call.
+ */
+export let lastVisionScreenshot: string | null = null;
+
 /** Max edge for screenshots sent to Stark vision. 512px for faster Gemini processing. */
 const VISION_MAX_EDGE_PX = 512;
 
 /** Downscale screenshot for vision — outputs JPEG (not PNG) to avoid size inflation. */
-async function downscaleForVision(base64: string): Promise<string> {
+export async function downscaleForVision(base64: string): Promise<string> {
   try {
     const input = Buffer.from(base64, 'base64');
     const meta = await sharp(input).metadata();
@@ -191,9 +198,7 @@ function preCheck(instruction: string): PreCheckResult | null {
   // 7. Questions about the screen → getInfo
   //    If the instruction ends with "?" and didn't match an assert verb above,
   //    or if it lacks any actionable verb, it's a question.
-  const ACTION_VERB_RE =
-    /\b(tap|click|press|type|enter|send|set|swipe|scroll|open|launch|start|go\s+to|verify|validate|check|assert|confirm|wait|sleep|pause|long\s+press|drag|clear|delete|back|home|done)\b/i;
-  if (t.endsWith('?') || !ACTION_VERB_RE.test(t)) {
+  if (t.endsWith('?')) {
     return { getInfoQuery: t };
   }
 
@@ -225,6 +230,7 @@ export async function visionExecute(
   instruction: string,
   appResolver?: { resolve?: (query: string) => string | null }
 ): Promise<VisionExecuteResult | null> {
+  lastVisionScreenshot = null; // Clear before each call
   const apiKey = getStarkVisionApiKey();
   if (!apiKey) return null; // No vision available
 
@@ -321,6 +327,7 @@ export async function visionExecute(
   // ── Single vision call: screenshot + understandAndLocate ──
   const rawScreenshot = await screenshot(mcp);
   if (!rawScreenshot) return null;
+  lastVisionScreenshot = rawScreenshot; // Expose for artifact reporting (tap dot overlay)
   // Downscale for faster Gemini processing — coordinates are normalized 0-1000 so resolution doesn't matter
   const imageBase64 = await downscaleForVision(rawScreenshot);
   if (mcpDebug) {
@@ -522,6 +529,59 @@ export async function visionExecute(
     }
 
     return { step, result: { success: false, message: 'Could not type text' } };
+  }
+
+  // Drag
+  if (actionName === 'drag') {
+    const fromLocator = locators[0];
+    const toLocator = locators[1];
+    const step: FlowStep = {
+      kind: 'drag',
+      from: fromLocator?.element || instruction,
+      to: toLocator?.element || '',
+      verbatim: instruction,
+    };
+
+    if (!fromLocator?.coordinates || !toLocator?.coordinates) {
+      const msg = !fromLocator?.coordinates
+        ? `"${step.from}" is not visible on screen`
+        : `"${step.to}" is not visible on screen`;
+      return { step, result: { success: false, message: msg } };
+    }
+
+    const [fy, fx] = fromLocator.coordinates;
+    const [ty, tx] = toLocator.coordinates;
+
+    if (fy === 0 && fx === 0) {
+      return { step, result: { success: false, message: `Drag failed: "${step.from}" is not visible on screen` } };
+    }
+    if (ty === 0 && tx === 0) {
+      return { step, result: { success: false, message: `Drag failed: "${step.to}" is not visible on screen` } };
+    }
+
+    const fromBbox = scaleCoordinates([fy, fx], screenSize);
+    const toBbox = scaleCoordinates([ty, tx], screenSize);
+    const dragResult = await mcp.callTool('appium_drag_and_drop', {
+      sourceX: Math.round(fromBbox.center.x),
+      sourceY: Math.round(fromBbox.center.y),
+      targetX: Math.round(toBbox.center.x),
+      targetY: Math.round(toBbox.center.y),
+      duration: step.duration ?? 600,
+      longPressDuration: step.longPressDuration ?? 400,
+    });
+    const dragText =
+      dragResult.content?.map((c: any) => (c.type === 'text' ? c.text : '')).join('') ?? '';
+    const dragSuccess =
+      !dragText.toLowerCase().includes('failed') && !dragText.toLowerCase().includes('error');
+    return {
+      step,
+      result: {
+        success: dragSuccess,
+        message: dragSuccess
+          ? `Dragged "${step.from}" to "${step.to}"`
+          : `Drag failed: ${dragText.slice(0, 200)}`,
+      },
+    };
   }
 
   // Tap/click (default for most actions)

--- a/src/llm/prompts.ts
+++ b/src/llm/prompts.ts
@@ -76,7 +76,15 @@ The system handles scaling to device coordinates. If your coordinates miss, it f
 - Position: "top right corner", "bottom center", "below the To field"
 - Context: "icon next to the profile picture"
 
-**Bad descriptions (will fail):** "the button", "input field", "that icon"`;
+**Bad descriptions (will fail):** "the button", "input field", "that icon"
+
+**GAME / CANVAS KEYBOARDS — tapping individual keys:**
+Some apps (games, custom UIs) have on-screen keyboards where you must tap each key individually with find_and_click.
+- BEFORE tapping any key, decide the COMPLETE, VALID input you want to enter. For word games this must be a real dictionary word — think it through fully before touching any key.
+- Then tap each letter key one by one in the correct order.
+- After the last letter, tap the submit/enter/confirm key.
+- Use the screenshot to locate each key by its label and position on the keyboard.
+- After submitting, ALWAYS read the full screen feedback (colors, highlights, error messages) before deciding your next input. If the game rejects your input (e.g. "not a word"), delete it and choose a different valid input.`;
 
 /** Shared rules for both modes */
 const SHARED_RULES = `

--- a/src/playground/index.ts
+++ b/src/playground/index.ts
@@ -83,6 +83,8 @@ function stepAction(step: FlowStep): string {
       return 'assert';
     case 'scrollAssert':
       return 'scroll';
+    case 'drag':
+      return 'drag';
     case 'getInfo':
       return 'info';
     case 'done':
@@ -119,6 +121,8 @@ function stepTarget(step: FlowStep): string {
       return `"${step.text}"`;
     case 'scrollAssert':
       return `"${step.text}" ${step.direction} ×${step.maxScrolls}`;
+    case 'drag':
+      return `"${step.from}" → "${step.to}"`;
     case 'getInfo':
       return `"${step.query}"`;
     case 'done':

--- a/src/report/renderer.ts
+++ b/src/report/renderer.ts
@@ -90,6 +90,8 @@ function stepKindLabel(kind: string): string {
       return 'Home';
     case 'enter':
       return 'Enter';
+    case 'drag':
+      return 'Drag';
     case 'getInfo':
       return 'Get Info';
     case 'done':
@@ -1815,7 +1817,7 @@ export function renderRunPage(manifest: RunManifest): string {
     }
 
     function kindLabel(kind) {
-      var map = {tap:'Tap',type:'Type',assert:'Assert',scrollAssert:'Scroll Assert',swipe:'Swipe',wait:'Wait',waitUntil:'Wait Until',openApp:'Launch',launchApp:'Launch',back:'Back',home:'Home',enter:'Enter',getInfo:'Get Info',done:'Done'};
+      var map = {tap:'Tap',type:'Type',assert:'Assert',scrollAssert:'Scroll Assert',swipe:'Swipe',drag:'Drag',wait:'Wait',waitUntil:'Wait Until',openApp:'Launch',launchApp:'Launch',back:'Back',home:'Home',enter:'Enter',getInfo:'Get Info',done:'Done'};
       return map[kind] || kind;
     }
 

--- a/vscode-extension/src/webview/device-panel.ts
+++ b/vscode-extension/src/webview/device-panel.ts
@@ -64,6 +64,17 @@ export class DevicePanel {
     };
     bridge.on('event', forwardEvent);
 
+    // Forward stderr (raw CLI logs) to webview
+    const forwardStderr = (line: string) => {
+      const msg = { type: 'appclaw-log', line };
+      if (this.webviewReady) {
+        this.panel.webview.postMessage(msg);
+      } else {
+        this.pendingMessages.push(msg);
+      }
+    };
+    bridge.on('stderr', forwardStderr);
+
     // Handle messages from webview
     this.panel.webview.onDidReceiveMessage(
       async (message) => {
@@ -127,6 +138,7 @@ export class DevicePanel {
     this.panel.onDidDispose(
       () => {
         bridge.removeListener('event', forwardEvent);
+        bridge.removeListener('stderr', forwardStderr);
         this.dispose();
       },
       null,
@@ -606,7 +618,8 @@ export class DevicePanel {
         </div>
       </div>
 
-      <div id="debugLog" style="font-size:10px;color:var(--vscode-descriptionForeground);padding:3px 10px;max-height:40px;overflow-y:auto;border-top:1px solid var(--vscode-panel-border);font-family:monospace;"></div>
+      <div id="rawLogToggle" onclick="toggleRawLog()" style="cursor:pointer;font-size:10px;color:var(--vscode-descriptionForeground);padding:2px 10px;border-top:1px solid var(--vscode-panel-border);user-select:none;">▸ Logs</div>
+      <div id="debugLog" style="display:none;font-size:10px;color:var(--vscode-descriptionForeground);padding:3px 10px;max-height:120px;overflow-y:auto;font-family:monospace;"></div>
 
       <div class="input-area">
         <div style="display:flex;gap:6px;align-items:center;">
@@ -1110,11 +1123,24 @@ export class DevicePanel {
     }
 
     const debugLog = document.getElementById("debugLog");
-    function debug(text) {
+    const rawLogToggle = document.getElementById("rawLogToggle");
+    var rawLogOpen = false;
+    function toggleRawLog() {
+      rawLogOpen = !rawLogOpen;
+      debugLog.style.display = rawLogOpen ? "block" : "none";
+      rawLogToggle.textContent = (rawLogOpen ? "▾" : "▸") + " Logs";
+    }
+    function addRawLog(text) {
+      if (!text.trim()) return;
       const line = document.createElement("div");
-      line.textContent = new Date().toLocaleTimeString() + " " + text;
+      line.textContent = text;
+      line.style.whiteSpace = "pre";
       debugLog.appendChild(line);
+      if (debugLog.children.length > 500) debugLog.removeChild(debugLog.firstChild);
       debugLog.scrollTop = debugLog.scrollHeight;
+    }
+    function debug(text) {
+      addRawLog(new Date().toLocaleTimeString() + " " + text);
     }
     debug("webview ready, sending ready signal");
     vscode.postMessage({ command: "webviewReady" });
@@ -1123,6 +1149,12 @@ export class DevicePanel {
     window.addEventListener("message", (event) => {
       const msg = event.data;
       debug("recv: " + JSON.stringify(msg).substring(0, 120));
+
+      // Raw CLI log line (stderr forwarded from bridge)
+      if (msg.type === "appclaw-log") {
+        addRawLog(msg.line);
+        return;
+      }
 
       // Mode switch — sent before each run to set single vs multi-device layout
       if (msg.type === "setRunMode") {
@@ -1331,6 +1363,14 @@ export class DevicePanel {
               infoEntry.className = "step-entry success";
               infoEntry.innerHTML = '<pre style="margin:0;padding:8px 12px;font-size:11px;white-space:pre-wrap;color:var(--vscode-foreground);background:var(--vscode-textBlockQuote-background);border-radius:4px;max-height:150px;overflow-y:auto;">' + escapeHtml(msg.data.message) + '</pre>';
               stepLog.appendChild(infoEntry);
+              stepLog.scrollTop = stepLog.scrollHeight;
+            }
+            // Show failure reason below failed steps
+            if (msg.data.status === "failed" && msg.data.error) {
+              var errorEntry = document.createElement("div");
+              errorEntry.style.cssText = "padding:4px 12px 6px 32px;font-size:11px;color:var(--vscode-errorForeground);";
+              errorEntry.textContent = "↳ " + msg.data.error;
+              stepLog.appendChild(errorEntry);
               stepLog.scrollTop = stepLog.scrollHeight;
             }
           }


### PR DESCRIPTION
…d flow fixes

- Add drag/slide/move step support (natural language, shorthand YAML, multi-key YAML)
- Use visionExecute for natural language tap/type/assert steps in vision mode (matches playground behavior)
- Fix type/assert steps failing in flow mode vs playground parity
- Reduce screenshots per step: use visionExecute's screenshot as the before/after artifact
- Fix tap dot overlay: vision screenshot attached as "before" for taps, "after" for other actions
- Fix screenLoaded check: use screenshot comparison in vision mode instead of DOM polling
- Fix DOM stability check: compare size within 2% threshold instead of exact equality
- Improve drag error messages: name the specific element not visible on screen
- Downscale screenshots to 512px for understandAndLocate (faster Gemini processing)
- Keep full resolution for visionAssert (needed for fine text like slider tick marks)
- Add failure reason display below failed steps in VSCode device panel
- Export lastVisionScreenshot and downscaleForVision from vision-execute for reuse
- Add drag-slider.yaml example flow and rapido.yaml flow