### PR TITLE
feat: integrate ai-sdk-ollama for LLM support and update configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,8 +284,10 @@ All configuration is via `.env`:
 | `DEVICE_NAME`         | (auto)   | Device name — partial match (e.g. `iPhone 17 Pro`)                                |
 | **LLM**               |          |                                                                                   |
 | `LLM_PROVIDER`        | `gemini` | LLM provider (`anthropic`, `openai`, `gemini`, `groq`, `ollama`)                  |
-| `LLM_API_KEY`         | —        | API key for your provider                                                         |
+| `LLM_API_KEY`         | —        | API key for your provider (not used for local Ollama; see `OLLAMA_*` for cloud URL / auth) |
 | `LLM_MODEL`           | (auto)   | Model override (e.g. `gemini-3.1-flash-lite-preview`, `claude-sonnet-4-20250514`) |
+| `OLLAMA_BASE_URL`     | (default) | Ollama API base URL (e.g. remote or Docker). Empty = `http://127.0.0.1:11434` (`LLM_PROVIDER=ollama`) |
+| `OLLAMA_API_KEY`      | —        | Optional Bearer token for Ollama Cloud or authenticated endpoints (`LLM_PROVIDER=ollama`) |
 | `AGENT_MODE`          | `vision` | `dom` (XML locators) or `vision` (screenshot-first)                               |
 | **Agent**             |          |                                                                                   |
 | `MAX_STEPS`           | `30`     | Max steps per goal                                                                |

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@ai-sdk/openai": "^1.0.0",
         "@modelcontextprotocol/sdk": "^1.22.0",
         "ai": "^6.0.72",
+        "ai-sdk-ollama": "^3.8.3",
         "boxen": "^8.0.1",
         "chalk": "^5.6.2",
         "cli-spinners": "^3.4.0",
@@ -24,7 +25,6 @@
         "marked": "^15.0.12",
         "marked-terminal": "^7.3.0",
         "mjpeg-consumer": "2.0.0",
-        "ollama-ai-provider": "^1.0.0",
         "sharp": "^0.33.5",
         "yaml": "^2.8.3",
         "zod": "^3.23.0"
@@ -80,13 +80,13 @@
       }
     },
     "node_modules/@ai-sdk/gateway": {
-      "version": "3.0.83",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.83.tgz",
-      "integrity": "sha512-LvlWujbSdEkTBXBLFtF7GS6riXdHhH0O+DpDrCaNQvXeHmSF2jKsOg7JWXiCgygAHM5cWFAO3JYmZp83DjiuBQ==",
+      "version": "3.0.95",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.95.tgz",
+      "integrity": "sha512-ZmUNNbZl3V42xwQzPaNUi+s8eqR2lnrxf0bvB6YbLXpLjHYv0k2Y78t12cNOfY0bxGeuVVTLyk856uLuQIuXEQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
-        "@ai-sdk/provider-utils": "4.0.21",
+        "@ai-sdk/provider-utils": "4.0.23",
         "@vercel/oidc": "3.1.0"
       },
       "engines": {
@@ -109,9 +109,9 @@
       }
     },
     "node_modules/@ai-sdk/gateway/node_modules/@ai-sdk/provider-utils": {
-      "version": "4.0.21",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.21.tgz",
-      "integrity": "sha512-MtFUYI1/8mgDvRmaBDjbLJPFFrMG777AvSgyIFQtZHIMzm88R/12vYBBpnk7pfiWLFE1DSZzY4WDYzGbKAcmiw==",
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.23.tgz",
+      "integrity": "sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
@@ -1648,15 +1648,62 @@
       }
     },
     "node_modules/ai": {
-      "version": "6.0.141",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.141.tgz",
-      "integrity": "sha512-+GomGQWaId3xN0wcugUW/H7xMMaFkID2PiS7K/Wugj45G3efv0BXhQ3psRZoQVoRbOpdNoUqcK/KTB+FR4h6qg==",
+      "version": "6.0.158",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.158.tgz",
+      "integrity": "sha512-gLTp1UXFtMqKUi3XHs33K7UFglbvojkxF/aq337TxnLGOhHIW9+GyP2jwW4hYX87f1es+wId3VQoPRRu9zEStQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/gateway": "3.0.83",
+        "@ai-sdk/gateway": "3.0.95",
         "@ai-sdk/provider": "3.0.8",
-        "@ai-sdk/provider-utils": "4.0.21",
+        "@ai-sdk/provider-utils": "4.0.23",
         "@opentelemetry/api": "1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/ai-sdk-ollama": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/ai-sdk-ollama/-/ai-sdk-ollama-3.8.3.tgz",
+      "integrity": "sha512-KId/S++eb0CgTPFTtHzCGCrO73kXZLK+hyyZx5k8LVqU2XOEHYKVbIwDiQ+hm3okHjnsGehn4zR4QNm14SUM3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@ai-sdk/provider": "^3.0.8",
+        "@ai-sdk/provider-utils": "^4.0.23",
+        "jsonrepair": "^3.13.3",
+        "ollama": "^0.6.3"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "ai": "^6.0.154"
+      }
+    },
+    "node_modules/ai-sdk-ollama/node_modules/@ai-sdk/provider": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ai-sdk-ollama/node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.23.tgz",
+      "integrity": "sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.6"
       },
       "engines": {
         "node": ">=18"
@@ -1678,9 +1725,9 @@
       }
     },
     "node_modules/ai/node_modules/@ai-sdk/provider-utils": {
-      "version": "4.0.21",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.21.tgz",
-      "integrity": "sha512-MtFUYI1/8mgDvRmaBDjbLJPFFrMG777AvSgyIFQtZHIMzm88R/12vYBBpnk7pfiWLFE1DSZzY4WDYzGbKAcmiw==",
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.23.tgz",
+      "integrity": "sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
@@ -2995,6 +3042,15 @@
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/jsonrepair": {
+      "version": "3.13.3",
+      "resolved": "https://registry.npmjs.org/jsonrepair/-/jsonrepair-3.13.3.tgz",
+      "integrity": "sha512-BTznj0owIt2CBAH/LTo7+1I5pMvl1e1033LRl/HUowlZmJOIhzC0zbX5bxMngLkfT4WnzPP26QnW5wMr2g9tsQ==",
+      "license": "ISC",
+      "bin": {
+        "jsonrepair": "bin/cli.js"
+      }
+    },
     "node_modules/lightningcss": {
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
@@ -3454,26 +3510,13 @@
       ],
       "license": "MIT"
     },
-    "node_modules/ollama-ai-provider": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/ollama-ai-provider/-/ollama-ai-provider-1.2.0.tgz",
-      "integrity": "sha512-jTNFruwe3O/ruJeppI/quoOUxG7NA6blG3ZyQj3lei4+NnJo7bi3eIRWqlVpRlu/mbzbFXeJSBuYQWF6pzGKww==",
-      "license": "Apache-2.0",
+    "node_modules/ollama": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/ollama/-/ollama-0.6.3.tgz",
+      "integrity": "sha512-KEWEhIqE5wtfzEIZbDCLH51VFZ6Z3ZSa6sIOg/E/tBV8S51flyqBOXi+bRxlOYKDf8i327zG9eSTb8IJxvm3Zg==",
+      "license": "MIT",
       "dependencies": {
-        "@ai-sdk/provider": "^1.0.0",
-        "@ai-sdk/provider-utils": "^2.0.0",
-        "partial-json": "0.1.7"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
+        "whatwg-fetch": "^3.6.20"
       }
     },
     "node_modules/on-finished": {
@@ -3526,12 +3569,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/partial-json": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
-      "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
-      "license": "MIT"
     },
     "node_modules/path-key": {
       "version": "3.1.1",
@@ -4453,6 +4490,12 @@
           "optional": false
         }
       }
+    },
+    "node_modules/whatwg-fetch": {
+      "version": "3.6.20",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
+      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
+      "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@ai-sdk/openai": "^1.0.0",
     "@modelcontextprotocol/sdk": "^1.22.0",
     "ai": "^6.0.72",
+    "ai-sdk-ollama": "^3.0.0",
     "boxen": "^8.0.1",
     "chalk": "^5.6.2",
     "cli-spinners": "^3.4.0",
@@ -42,7 +43,6 @@
     "marked": "^15.0.12",
     "marked-terminal": "^7.3.0",
     "mjpeg-consumer": "2.0.0",
-    "ollama-ai-provider": "^1.0.0",
     "sharp": "^0.33.5",
     "yaml": "^2.8.3",
     "zod": "^3.23.0"

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,11 @@ const envSchema = z.object({
   LLM_API_KEY: z.string().default(''),
   LLM_MODEL: z.string().default(''),
 
+  /** Ollama HTTP API base (default http://127.0.0.1:11434). Set for remote or Docker. */
+  OLLAMA_BASE_URL: z.string().default(''),
+  /** Bearer token for Ollama Cloud / authenticated endpoints (optional). */
+  OLLAMA_API_KEY: z.string().default(''),
+
   /** Target platform: "android" or "ios". Empty = prompt on macOS, default android elsewhere. */
   PLATFORM: z.enum(['android', 'ios', '']).default(''),
 

--- a/src/llm/provider.ts
+++ b/src/llm/provider.ts
@@ -11,7 +11,7 @@ import { z } from 'zod';
 import { createOpenAI } from '@ai-sdk/openai';
 import { createAnthropic } from '@ai-sdk/anthropic';
 import { createGoogleGenerativeAI } from '@ai-sdk/google';
-import { ollama } from 'ollama-ai-provider';
+import { createOllama } from 'ai-sdk-ollama';
 
 import type { AppClawConfig } from '../config.js';
 import { isVisionLocateEnabledFromConfig } from '../vision/locate-enabled.js';
@@ -108,8 +108,13 @@ export function buildModel(config: AppClawConfig): any {
         baseURL: GROQ_API_BASE_URL,
       })(modelId);
 
-    case 'ollama':
-      return ollama(modelId);
+    case 'ollama': {
+      const ollamaProvider = createOllama({
+        ...(config.OLLAMA_BASE_URL ? { baseURL: config.OLLAMA_BASE_URL } : {}),
+        ...(config.OLLAMA_API_KEY ? { apiKey: config.OLLAMA_API_KEY } : {}),
+      });
+      return ollamaProvider(modelId);
+    }
 
     default:
       throw new Error(`Unknown LLM provider: ${config.LLM_PROVIDER}`);


### PR DESCRIPTION
- Added support for the ai-sdk-ollama package to enable Ollama as an LLM provider.
- Updated package.json and package-lock.json to include ai-sdk-ollama and its dependencies.
- Enhanced README with new configuration options for Ollama API base URL and API key.
- Modified config.ts to include new environment variables for Ollama integration.
- Updated provider.ts to utilize the new ai-sdk-ollama functions for model handling.