### PR TITLE
fix: publish appclaw-agent in the unified release (use cd, not --prefix)

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -51,8 +51,8 @@
     [
       "@semantic-release/exec",
       {
-        "prepare": "npm version ${nextRelease.version} --no-git-tag-version --allow-same-version --prefix packages/appclaw-agent",
-        "publish": "npm publish --prefix packages/appclaw-agent"
+        "prepare": "cd packages/appclaw-agent && npm version ${nextRelease.version} --no-git-tag-version --allow-same-version",
+        "publish": "cd packages/appclaw-agent && npm publish"
       }
     ],
     [


### PR DESCRIPTION
The exec plugin used `--prefix packages/appclaw-agent`, but:
  - `npm publish --prefix …` ignores --prefix for selecting the package and re-packs the ROOT (appclaw) instead of the agent, and
  - `npm version --prefix …` doesn't bump the prefixed package on npm 10 (CI).

Result: appclaw published at 1.5.0 but appclaw-agent stayed at 1.0.2.

Switch both exec commands to `cd packages/appclaw-agent && …`, which unambiguously operates on the agent package. Verified: version bump targets the agent and `npm publish --dry-run` packs appclaw-agent-*.tgz.