### PR TITLE
fix(playground): correct misleading "Appium server" error; sync npx appium-mcp version

### DIFF
--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -26,7 +26,10 @@ function resolveAppiumMcp(): { command: string; args: string[] } {
     const bin = join(dirname(pkgJson), 'dist', 'index.js');
     return { command: 'node', args: [bin] };
   } catch {
-    return { command: 'npx', args: ['--yes', 'appium-mcp@1.77.0'] };
+    // Keep this pinned version in sync with the "appium-mcp" entry in package.json.
+    // A drift here means an old global install (which can't resolve the bundled copy)
+    // silently downloads a different version than the one AppClaw is tested against.
+    return { command: 'npx', args: ['--yes', 'appium-mcp@1.85.8'] };
   }
 }
 

--- a/src/playground/index.ts
+++ b/src/playground/index.ts
@@ -982,7 +982,24 @@ async function connectToDevice(): Promise<boolean> {
     process.stderr.write(`[playground] Connection failed: ${err?.message ?? err}\n`);
     if (err?.stack) process.stderr.write(`[playground] ${err.stack}\n`);
     ui.printError(`Failed to connect: ${err?.message ?? err}`);
-    ui.printInfo('Make sure Appium server is running and a device/emulator is connected.');
+    // AppClaw drives Appium through the appium-mcp subprocess, which it starts itself —
+    // there is no separate "Appium server" to launch. A timeout (-32001) almost always
+    // means appium-mcp couldn't start/handshake in time (e.g. a cold `npx` download on a
+    // global install that doesn't bundle it), NOT that a server is missing.
+    const errMsg = String(err?.message ?? err);
+    const timedOut = errMsg.includes('-32001') || /timed out/i.test(errMsg);
+    if (timedOut) {
+      ui.printInfo(
+        'AppClaw starts appium-mcp itself — no separate Appium server is needed. The MCP handshake ' +
+          'timed out: on a first run appium-mcp may still be downloading via npx. Retry, or reinstall so ' +
+          "it's bundled (e.g. npm i -g appclaw@latest). Set MCP_DEBUG=1 to see appium-mcp's startup logs."
+      );
+    } else {
+      ui.printInfo(
+        'AppClaw starts appium-mcp itself — no separate Appium server is needed. Make sure a ' +
+          'device/emulator is connected. Set MCP_DEBUG=1 to see appium-mcp’s startup logs.'
+      );
+    }
     console.log();
     return false;
   }


### PR DESCRIPTION
## Problem

When the playground fails to connect, it printed:

> Make sure Appium server is running and a device/emulator is connected.

This is misleading. AppClaw drives Appium through the **`appium-mcp` subprocess, which it starts itself** — there is no separate Appium server to launch. The actual failure in these cases is the MCP `initialize` handshake timing out (`MCP error -32001`), e.g. when a global install can't resolve the bundled `appium-mcp` and cold-downloads it via `npx` at connect time.

Verified locally: with `appium-mcp` bundled, the MCP client connects in **~1.9s** and lists **33 tools** with **nothing** running on `:4723` — confirming no standalone server is needed.

## Changes

- **`src/playground/index.ts`** — replace the misleading hint. On a timeout (`-32001`/"timed out") it now explains `appium-mcp` is started automatically (no server needed) and points at the real cause (cold `npx` download on a global install that doesn't bundle it), suggesting a retry/reinstall and `MCP_DEBUG=1` for startup logs. Non-timeout failures get an accurate "make sure a device/emulator is connected" message.
- **`src/mcp/client.ts`** — bump the `npx` fallback from `appium-mcp@1.77.0` → `1.85.8` so it matches the declared/bundled dependency. The drift meant old global installs silently downloaded an untested older version, contributing to the timeout.

## Testing

- `npm run typecheck` ✅
- `npm run build` ✅
- Reproduced a successful MCP connection from source (bundled `appium-mcp@1.85.8`): connected in 1.9s, 33 tools, no Appium server on `:4723`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)