### PR TITLE
fix(vision): locate input field by kind when a type target label can't be matched

### DIFF
--- a/src/flow/run-yaml-flow.ts
+++ b/src/flow/run-yaml-flow.ts
@@ -597,6 +597,30 @@ async function longPressByLabel(
   return { success: true, message: `Long-pressed "${label}" (${duration}ms)` };
 }
 
+/**
+ * Vision: locate a text input field by KIND (not by literal label) and tap to focus it.
+ * Returns true if a field was tapped. A literal label like "search box"/"textbox" rarely
+ * matches a field whose only visible text is a placeholder (e.g. "Search Fox Sports"), so
+ * describing the element kind is far more reliable for the type path.
+ *
+ * When `hint` is given (the user's target field), it's folded into the query so a screen
+ * with several fields still resolves the RIGHT one (e.g. "password field") instead of
+ * blindly grabbing the first input — this keeps the targeted fallback from mis-focusing.
+ */
+async function focusInputFieldByVision(mcp: MCPClient, hint?: string): Promise<boolean> {
+  const query = hint
+    ? `text input field or search box for "${hint}"`
+    : 'text input field, search box, or editable area';
+  const visionUuid = await findByVision(mcp, query);
+  if (!visionUuid) return false;
+  if (isAIElement(visionUuid)) {
+    const coords = parseAIElementCoords(visionUuid);
+    return coords ? await tapAtCoordinates(mcp, coords.x, coords.y) : false;
+  }
+  await mcp.callTool('appium_gesture', { action: 'tap', elementUUID: visionUuid });
+  return true;
+}
+
 async function flowTypeText(
   mcp: MCPClient,
   text: string,
@@ -608,7 +632,12 @@ async function flowTypeText(
   // ── If a target field is specified, tap it first to focus (implicit wait) ──
   if (target) {
     const tapResult = await tapByLabel(mcp, target, poll);
-    if (!tapResult.success) {
+    // Vision mode: a literal label like "search box"/"textbox" usually won't match a field
+    // that only shows a placeholder. Fall back to locating the input field by kind before
+    // giving up, so `type "x" → search box` works the same as the no-target path.
+    const focused =
+      tapResult.success || (isVisionMode() && (await focusInputFieldByVision(mcp, target)));
+    if (!focused) {
       return { success: false, message: `Could not find target field "${target}" to type into` };
     }
     await sleep(Config.CLOUD_PROVIDER ? 1200 : 300); // Cloud needs longer to settle focus
@@ -618,15 +647,7 @@ async function flowTypeText(
   if (isVisionMode()) {
     // If no target was specified, use vision to find and tap an input field
     if (!target) {
-      const visionUuid = await findByVision(mcp, 'text input field, search box, or editable area');
-      if (visionUuid) {
-        if (isAIElement(visionUuid)) {
-          const coords = parseAIElementCoords(visionUuid);
-          if (coords) await tapAtCoordinates(mcp, coords.x, coords.y);
-        } else {
-          await mcp.callTool('appium_gesture', { action: 'tap', elementUUID: visionUuid });
-        }
-      }
+      await focusInputFieldByVision(mcp);
     }
     // Type via W3C Actions — works on local and cloud, Android and iOS
     const sv = await typeViaSetValue(mcp, text);


### PR DESCRIPTION
## Problem

In vision mode, `type "x" → <field>` (e.g. `type "world" → search box`) focuses the target by calling `tapByLabel`, which asks vision for an element **literally "labeled or showing"** the target string. A field whose only visible text is a **placeholder** (e.g. "Search Fox Sports") never matches a generic label like `"search box"`/`"textbox"`, so `flowTypeText` returned **"Could not find target field … to type into"** and the type failed.

The no-target path already used a smarter *kind*-based query (`'text input field, search box, or editable area'`); the targeted path never got that fallback.

## Fix (`src/flow/run-yaml-flow.ts`)

- Add `focusInputFieldByVision(mcp, hint?)` — locates a field **by kind**, optionally folding the target in as a hint (`text input field or search box for "<hint>"`) so multi-field screens still resolve the right one and don't mis-focus.
- Targeted type path: when the literal `tapByLabel` misses **in vision mode**, fall back to `focusInputFieldByVision` before giving up — so `type "x" → search box` behaves like the no-target path.
- No-target path reuses the same helper (identical query — no behaviour change).
- DOM mode is unchanged (fallback is gated by `isVisionMode()`).

## Verification — live on an Android emulator, screenshot-confirmed

`flowTypeText` exercised deterministically via `executeStep` (no-`verbatim` step → switch → `flowTypeText`, the same call as the production hand-off):

| Case | Target | Result |
|---|---|---|
| Vision **fallback** | `qzx bogus field 99` (unmatchable) | **"wifi" typed** ✅ (the fix) |
| Vision no-target | — | **"bluetooth" typed** ✅ |
| Vision literal hit | `search` | **"display" typed** ✅ (no regression) |
| DOM valid target | `search` | typed ✅ (no regression) |
| DOM bogus target | `qzx bogus field 99` | hard-fails as before ✅ (fallback gated off) |
| **E2E** `app.run` into unfocused field | `search box` | **"wifi" typed** ✅ |

`npm run typecheck` and `npm run build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)