### PR TITLE
feat(session): merge a capabilities JSON file into create_session

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -31,6 +31,16 @@ const envSchema = z.object({
    */
   APP_PATH: z.string().default(''),
 
+  /**
+   * Path to a JSON file of extra Appium capabilities to merge into create_session.
+   * The file must contain a flat JSON object of capability key/values, e.g.:
+   *   { "appium:automationName": "UiAutomator2", "appium:autoGrantPermissions": true }
+   * Merged on top of the config-derived defaults; framework-managed caps (parallel
+   * ports, pinned udid) still take final precedence. Set via CAPABILITIES_FILE env,
+   * the `--caps <path>` CLI flag, or the SDK `capabilitiesFile` option.
+   */
+  CAPABILITIES_FILE: z.string().default(''),
+
   MCP_TRANSPORT: z.enum(['stdio', 'sse']).default('stdio'),
   MCP_HOST: z.string().default('localhost'),
   MCP_PORT: z.coerce.number().default(8080),

--- a/src/device/session.ts
+++ b/src/device/session.ts
@@ -5,6 +5,8 @@
  * function that builds the right capabilities for each platform.
  */
 
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
 import type { MCPClient } from '../mcp/types.js';
 import type { AppClawConfig } from '../config.js';
 import type { Platform, DeviceType } from '../index.js';
@@ -41,26 +43,32 @@ export async function createPlatformSession(
   _deviceType?: DeviceType,
   extraCaps?: Record<string, unknown>
 ): Promise<SessionResult> {
+  // User-supplied capabilities from CAPABILITIES_FILE (if any). Loaded once and
+  // merged into whichever session path runs below.
+  const fileCaps = loadCapabilitiesFile(config);
+
   if (config.CLOUD_PROVIDER === 'lambdatest') {
-    return createLambdaTestSession(mcp, config, platform);
+    return createLambdaTestSession(mcp, config, platform, fileCaps);
   }
 
   ui.startSpinner('Creating Appium session...');
 
   const args: Record<string, unknown> = { platform };
 
-  // Add platform-specific capabilities (serialized as JSON string for appium-mcp)
+  // Capability precedence (later wins): config defaults < CAPABILITIES_FILE <
+  // extraCaps. extraCaps (parallel ports, pinned udid) must win last so concurrent
+  // workers don't collide and device pinning holds even if the file sets the same key.
   if (platform === 'android') {
-    // extraCaps wins over config defaults (e.g. parallel workers override mjpeg/system ports)
-    const caps = { ...buildAndroidCapabilities(config), ...extraCaps };
+    const caps = { ...buildAndroidCapabilities(config), ...fileCaps, ...extraCaps };
     if (Object.keys(caps).length > 0) {
       args.capabilities = JSON.stringify(caps);
     }
   } else if (platform === 'ios') {
     // For iOS, appium-mcp handles most capabilities internally (WDA setup, device selection).
-    // Merge config-level APP_PATH with extraCaps (extraCaps wins, e.g. per-flow app: overrides .env).
+    // Merge config-level APP_PATH with the caps file and extraCaps (per-flow app: overrides .env).
     const iosCaps = {
       ...(config.APP_PATH ? { 'appium:app': config.APP_PATH } : {}),
+      ...fileCaps,
       ...extraCaps,
     };
     if (Object.keys(iosCaps).length > 0) {
@@ -107,6 +115,35 @@ export async function createPlatformSession(
   }
 }
 
+/**
+ * Load extra Appium capabilities from CAPABILITIES_FILE (a JSON object), if set.
+ * Returns {} when unset. Throws a clear error when the path is set but missing,
+ * unreadable, not valid JSON, or not a plain object — fail fast rather than
+ * silently ignoring caps the user explicitly asked for.
+ */
+function loadCapabilitiesFile(config: AppClawConfig): Record<string, unknown> {
+  const path = config.CAPABILITIES_FILE?.trim();
+  if (!path) return {};
+
+  const resolved = resolve(process.cwd(), path);
+  if (!existsSync(resolved)) {
+    throw new Error(`CAPABILITIES_FILE not found: ${path} (resolved to ${resolved})`);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(resolved, 'utf8'));
+  } catch (e: any) {
+    throw new Error(`CAPABILITIES_FILE ${path} is not valid JSON: ${e?.message ?? e}`);
+  }
+
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`CAPABILITIES_FILE ${path} must be a JSON object of capabilities`);
+  }
+
+  return parsed as Record<string, unknown>;
+}
+
 /** Build Android-specific session capabilities (MJPEG, app install etc.) */
 function buildAndroidCapabilities(config: AppClawConfig): Record<string, unknown> {
   const caps: Record<string, unknown> = {};
@@ -130,7 +167,8 @@ function buildAndroidCapabilities(config: AppClawConfig): Record<string, unknown
 async function createLambdaTestSession(
   mcp: MCPClient,
   config: AppClawConfig,
-  platform: Platform
+  platform: Platform,
+  fileCaps: Record<string, unknown> = {}
 ): Promise<SessionResult> {
   ui.startSpinner('Creating LambdaTest cloud session...');
 
@@ -149,6 +187,8 @@ async function createLambdaTestSession(
     'appium:deviceName': config.LAMBDATEST_DEVICE_NAME,
     'appium:platformVersion': config.LAMBDATEST_OS_VERSION,
     'lt:options': ltOptions,
+    // User-supplied caps win over the cloud defaults above (their explicit choice).
+    ...fileCaps,
   };
 
   const args: Record<string, unknown> = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,6 +83,8 @@ interface CLIArgs {
    * reserved `--env-file` CLI flag.
    */
   envFile: string | null;
+  /** Path to a JSON file of extra Appium capabilities (maps to CAPABILITIES_FILE). */
+  capsFile: string | null;
   /** Strict YAML parsing — fail on unrecognized steps instead of LLM fallback */
   strict: boolean;
   /**
@@ -144,6 +146,9 @@ function printHelp(): void {
   );
   console.log(
     `    ${c.flag('--env-path')} ${c.arg('<path>')}            ${c.desc('Load a dotenv file into process.env (alias: --env-file, after the script)')}`
+  );
+  console.log(
+    `    ${c.flag('--caps')} ${c.arg('<path>')}                ${c.desc('JSON file of extra Appium capabilities merged into the session')}`
   );
   console.log(
     `    ${c.flag('--playground')}                    ${c.desc('Interactive REPL for building flows')}`
@@ -276,6 +281,7 @@ function parseArgs(): CLIArgs {
   let json = false;
   let env: string | null = null;
   let envFile: string | null = null;
+  let capsFile: string | null = null;
   let strict = false;
   let exportPath: string | null = null;
   let exportDir: string | null = null;
@@ -294,6 +300,10 @@ function parseArgs(): CLIArgs {
       envFile = args[++i] ?? null;
     } else if (args[i].startsWith('--env-path=') || args[i].startsWith('--env-file=')) {
       envFile = args[i].slice(args[i].indexOf('=') + 1) || null;
+    } else if (args[i] === '--caps' || args[i] === '--capabilities') {
+      capsFile = args[++i] ?? null;
+    } else if (args[i].startsWith('--caps=') || args[i].startsWith('--capabilities=')) {
+      capsFile = args[i].slice(args[i].indexOf('=') + 1) || null;
     } else if (args[i] === '--record') {
       record = true;
     } else if (args[i] === '--replay') {
@@ -376,6 +386,7 @@ function parseArgs(): CLIArgs {
     json,
     env,
     envFile,
+    capsFile,
     strict,
     exportPath,
     exportDir,
@@ -434,6 +445,11 @@ async function main() {
       process.exit(1);
     }
     ui.printSetupOk(`Loaded env file: ${cliArgs.envFile}`);
+  }
+  // `--caps <path>` overrides CAPABILITIES_FILE — set after the env file loads so
+  // the explicit flag wins, and before refreshConfig() so it reaches the singleton.
+  if (cliArgs.capsFile) {
+    process.env.CAPABILITIES_FILE = cliArgs.capsFile;
   }
   // Re-read process.env (now including any --env-file values) INTO the shared
   // Config singleton, not just into this local copy. Modules like run-yaml-flow

--- a/src/sdk/config-builder.ts
+++ b/src/sdk/config-builder.ts
@@ -15,6 +15,7 @@ const OPTION_TO_ENV_VAR: Partial<Record<keyof AppClawOptions, string>> = {
   model: 'LLM_MODEL',
   platform: 'PLATFORM',
   deviceUdid: 'DEVICE_UDID',
+  capabilitiesFile: 'CAPABILITIES_FILE',
   agentMode: 'AGENT_MODE',
   maxSteps: 'MAX_STEPS',
   stepDelay: 'STEP_DELAY',

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -58,6 +58,12 @@ export interface AppClawOptions {
    * Get Android UDIDs from: adb devices
    */
   deviceUdid?: string;
+  /**
+   * Path to a JSON file of extra Appium capabilities merged into the session
+   * (e.g. `{ "appium:automationName": "UiAutomator2", "appium:autoGrantPermissions": true }`).
+   * Maps to the CAPABILITIES_FILE env var.
+   */
+  capabilitiesFile?: string;
   /** Interaction strategy: DOM locators (default) or AI vision. */
   agentMode?: AgentMode;
   /** Maximum number of agent steps before giving up. Default: 30. */


### PR DESCRIPTION
## What

Adds a **capabilities JSON file** that gets merged into the Appium `create_session` call. Previously the session could only be influenced via individual config vars (`APP_PATH`, MJPEG ports); now any Appium capability can be supplied.

## How to use

Three ways (later wins):
- **env:** `CAPABILITIES_FILE=/path/to/caps.json`
- **CLI:** `--caps <path>` (alias `--capabilities`; overrides the env file)
- **SDK:** `new AppClaw({ capabilitiesFile: '/path/to/caps.json' })`

Example `caps.json`:
```json
{
  "appium:automationName": "UiAutomator2",
  "appium:autoGrantPermissions": true,
  "appium:newCommandTimeout": 300
}
```

## Precedence

`config defaults  <  CAPABILITIES_FILE  <  framework caps (parallel ports, pinned udid)`

Framework-managed caps win last so concurrent workers don't collide on ports and device pinning holds even if the file sets the same key. Applies to Android, iOS, and LambdaTest sessions.

## Error handling

Fails fast with a clear message when the path is set but the file is missing, unreadable, not valid JSON, or not a plain object.

## Files

- `src/config.ts` — `CAPABILITIES_FILE` config var
- `src/device/session.ts` — `loadCapabilitiesFile()` + merge into all three session paths
- `src/index.ts` — `--caps`/`--capabilities` flag + help text
- `src/sdk/types.ts`, `src/sdk/config-builder.ts` — `capabilitiesFile` SDK option

## Verification (live, Android emulator)

| Test | Result |
|---|---|
| Valid caps file | custom caps (`autoGrantPermissions`, `newCommandTimeout`) present in the sent capabilities; session created ✅ |
| Missing file | `CAPABILITIES_FILE not found: …` ✅ |
| Invalid JSON | `… is not valid JSON: …` ✅ |
| Precedence | file's `mjpegServerPort:1234` correctly overridden by the auto-assigned parallel port ✅ |

`npm run typecheck` and `npm run build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)