### PR TITLE
feat: proximity selectors for dom

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -65,7 +65,7 @@
         --cyan-glow: rgba(97, 196, 214, 0.12);
         --green: #6db970;
         --red: #e96a6a;
-        --font-display: 'Instrument Serif', 'Iowan Old Style', Georgia, serif;
+        --font-display: 'Menlo', 'SF Mono', 'JetBrains Mono', monospace;
         --font-body: 'Geist', -apple-system, BlinkMacSystemFont, 'SF Pro Text', sans-serif;
         --font-mono: 'JetBrains Mono', 'SF Mono', Menlo, monospace;
 
@@ -2058,6 +2058,65 @@
       </div>
     </section>
 
+    <!-- PROXIMITY SELECTORS -->
+    <section class="appguide-section" id="proximity">
+      <div class="container">
+        <div class="appguide-inner">
+          <!-- Left: copy + relation pills -->
+          <div class="reveal">
+            <div class="section-eyebrow">Smart Locators</div>
+            <h2>Pinpoint the right<br />element by where<br />it sits.</h2>
+            <p class="section-sub" style="margin-top: 16px">
+              Three buttons all say &ldquo;Login&rdquo;? Skip the brittle selectors — describe the
+              one you mean by its position relative to another element. AppClaw locates it
+              geometrically, the way you&rsquo;d point at the screen.
+            </p>
+            <div class="appguide-apps">
+              <div class="appguide-app-pill">below</div>
+              <div class="appguide-app-pill">above</div>
+              <div class="appguide-app-pill">left of</div>
+              <div class="appguide-app-pill">right of</div>
+              <div class="appguide-app-pill">near</div>
+              <div class="appguide-app-pill">within</div>
+            </div>
+            <div class="appguide-hint">
+              <span class="appguide-hint-icon">🎯</span>
+              <span
+                >Works on <code>tap</code> and <code>type</code>. Picks the interactive match
+                closest to your anchor — and fails loudly if nothing fits, so it never taps the
+                wrong thing.</span
+              >
+            </div>
+          </div>
+          <!-- Right: terminal showing the disambiguation -->
+          <div class="mini-term reveal reveal-delay-1">
+            <div class="mini-term-bar">
+              <div class="mdot" style="background: #ff5f57"></div>
+              <div class="mdot" style="background: #febc2e"></div>
+              <div class="mdot" style="background: #28c840"></div>
+              <span class="mini-term-title">Proximity</span>
+            </div>
+            <div class="mini-term-body">
+              <span style="color: var(--text-3)"># ambiguous — grabs the nav bar</span><br />
+              <span style="color: var(--green)">pg&gt;</span>
+              <span style="color: var(--text)">tap login button</span><br />
+              <span style="color: #ff5f57">✗</span>
+              <span style="color: var(--text-3)">Tapped "Login" (nav) — wrong element</span><br />
+              <br />
+              <span style="color: var(--text-3)"># pinpoint it by position</span><br />
+              <span style="color: var(--green)">pg&gt;</span>
+              <span style="color: var(--text)">tap login button below the password field</span
+              ><br />
+              <span style="color: var(--green)">✓</span>
+              <span style="color: var(--text-3)"
+                >Tapped "login button" (below "password field")</span
+              >
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
     <!-- APP GUIDE / CONTEXT ENGINEERING -->
     <section class="appguide-section" id="appguide">
       <div class="container">
@@ -2370,6 +2429,7 @@
               <li><a href="#features">Agent Mode</a></li>
               <li><a href="#features">YAML Flows</a></li>
               <li><a href="#features">Playground</a></li>
+              <li><a href="#proximity">Proximity Selectors</a></li>
               <li><a href="#appguide">AppGuide</a></li>
               <li><a href="#parallel">Parallel Runs</a></li>
               <li><a href="#architecture">Architecture</a></li>

--- a/landing/usage.html
+++ b/landing/usage.html
@@ -70,9 +70,9 @@
         --hover-tint-strong: var(--hover-tint-strong);
 
         /* ── type ── */
-        --font-display: 'Instrument Serif', 'Iowan Old Style', Georgia, serif;
-        --font-body: 'Geist', -apple-system, BlinkMacSystemFont, 'SF Pro Text', sans-serif;
-        --font-mono: 'JetBrains Mono', 'SF Mono', Menlo, monospace;
+        --font-display: 'Menlo', 'SF Mono', 'JetBrains Mono', monospace;
+        --font-body: 'Menlo', 'SF Mono', 'JetBrains Mono', monospace;
+        --font-mono: 'Menlo', 'SF Mono', 'JetBrains Mono', monospace;
 
         /* ── shape ── */
         --radius: 8px;
@@ -1322,7 +1322,9 @@
             </svg>
           </button>
           <ul>
+            <li><a href="#open-close-app">Open / Close App</a></li>
             <li><a href="#tap-click">Tap / Click</a></li>
+            <li><a href="#proximity">Proximity Selectors</a></li>
             <li><a href="#type-text">Type Text</a></li>
             <li><a href="#wait">Wait / Pause</a></li>
             <li><a href="#wait-until">Wait Until</a></li>
@@ -1918,6 +1920,50 @@
         <!-- ============================================ -->
         <!-- COMMANDS                                     -->
         <!-- ============================================ -->
+        <section id="open-close-app" class="reveal">
+          <h2>Open / Close App</h2>
+          <p>
+            Launch an app by name, or close (terminate) it when you&rsquo;re done. Closing uses
+            appium-mcp&rsquo;s terminate under the hood.
+          </p>
+
+          <div class="code-block">
+            <div class="code-block-header">
+              <div class="code-block-dots"><span></span><span></span><span></span></div>
+              <span class="code-block-label">Natural language</span>
+            </div>
+            <pre><span class="c"># Open</span>
+<span class="p">-</span> open YouTube
+<span class="p">-</span> launch Settings app
+
+<span class="c"># Close — by name</span>
+<span class="p">-</span> close YouTube
+<span class="p">-</span> close the YouTube app
+<span class="p">-</span> terminate Settings
+<span class="p">-</span> quit Chrome
+
+<span class="c"># Close — the current foreground app</span>
+<span class="p">-</span> close app
+<span class="p">-</span> close the app</pre>
+          </div>
+
+          <p>
+            App names resolve against the device&rsquo;s installed apps (well-known names like
+            <code>YouTube</code> work out of the box). Omitting the name closes whatever app is in
+            the foreground.
+          </p>
+
+          <div class="callout callout-info">
+            <div class="callout-title">Not an app close</div>
+            <p>
+              <code>close the dialog</code>, <code>close the keyboard</code>, and similar UI
+              dismissals are treated as taps, not app terminations &mdash; only
+              <code>close &lt;app&gt;</code>/<code>close the app</code> (or
+              <code>terminate</code>/<code>quit</code>/<code>kill</code>) end an app.
+            </p>
+          </div>
+        </section>
+
         <section id="tap-click" class="reveal">
           <h2>Tap / Click</h2>
           <p>
@@ -1954,6 +2000,87 @@
               <span class="code-block-label">Structured YAML</span>
             </div>
             <pre><span class="p">-</span> <span class="k">tap</span><span class="p">:</span> <span class="s">"Login Button"</span></pre>
+          </div>
+        </section>
+
+        <section id="proximity" class="reveal">
+          <h2>Proximity Selectors</h2>
+          <p>
+            When several elements share the same label &mdash; e.g. a &ldquo;Login&rdquo; tab, a
+            &ldquo;Login&rdquo; nav item, and the actual <code>LOGIN</code> button &mdash; add a
+            spatial qualifier to pick the right one by its position relative to another element.
+            Works on both <code>tap</code> and <code>type</code>.
+          </p>
+
+          <div class="code-block">
+            <div class="code-block-header">
+              <div class="code-block-dots"><span></span><span></span><span></span></div>
+              <span class="code-block-label">Natural language</span>
+            </div>
+            <pre><span class="p">-</span> tap the login button below the password field
+<span class="p">-</span> tap the icon to the right of the title
+<span class="p">-</span> tap the arrow to the left of the heading
+<span class="p">-</span> tap the star above the rating
+<span class="p">-</span> click the checkbox next to Terms
+<span class="p">-</span> tap the submit button within the form
+<span class="p">-</span> type <span class="s">"secret"</span> in the field below the email</pre>
+          </div>
+
+          <p>
+            The phrase after the target names the <em>relation</em> and the <em>anchor</em> element.
+            Modeled on Taiko&rsquo;s proximity selectors:
+          </p>
+
+          <table class="cmd-table">
+            <thead>
+              <tr>
+                <th>Phrase</th>
+                <th>Relation</th>
+                <th>Meaning</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>above / over</td>
+                <td>above</td>
+                <td>Target sits above the anchor</td>
+              </tr>
+              <tr>
+                <td>below / under / underneath</td>
+                <td>below</td>
+                <td>Target sits below the anchor</td>
+              </tr>
+              <tr>
+                <td>left of / to the left of</td>
+                <td>toLeftOf</td>
+                <td>Target is to the left of the anchor</td>
+              </tr>
+              <tr>
+                <td>right of / to the right of</td>
+                <td>toRightOf</td>
+                <td>Target is to the right of the anchor</td>
+              </tr>
+              <tr>
+                <td>near / next to / beside</td>
+                <td>near</td>
+                <td>Target is closest to the anchor (any direction)</td>
+              </tr>
+              <tr>
+                <td>within / inside</td>
+                <td>within</td>
+                <td>Target is contained inside the anchor (e.g. a form/card)</td>
+              </tr>
+            </tbody>
+          </table>
+
+          <div class="callout callout-tip">
+            <div class="callout-title">How it resolves</div>
+            <p>
+              Among elements matching the target label, AppClaw keeps the interactive (clickable)
+              candidates, then picks the one best satisfying the relation &mdash; ranked by distance
+              for ties. If the anchor isn&rsquo;t found or nothing satisfies the relation, the step
+              fails loudly rather than tapping the wrong element.
+            </p>
           </div>
         </section>
 
@@ -2253,6 +2380,11 @@
                 <td>Launch app defined in <code>appId</code> metadata</td>
               </tr>
               <tr>
+                <td>closeApp</td>
+                <td>query?</td>
+                <td>Close/terminate an app by name, or the current app when omitted</td>
+              </tr>
+              <tr>
                 <td>tap</td>
                 <td>label</td>
                 <td>Tap element by visible text/label</td>
@@ -2449,17 +2581,16 @@
               <tr>
                 <td>APP_PATH</td>
                 <td>
-                  Path or URL to an APK/IPA installed via <code>appium:app</code> at session
-                  start. Override per-flow via the <code>app:</code> YAML header.
+                  Path or URL to an APK/IPA installed via <code>appium:app</code> at session start.
+                  Override per-flow via the <code>app:</code> YAML header.
                 </td>
               </tr>
               <tr>
                 <td>CAPABILITIES_FILE</td>
                 <td>
                   JSON file of extra Appium capabilities merged into <code>create_session</code>.
-                  Same as <code>--caps</code> flag and the SDK
-                  <code>capabilitiesFile</code> option. See
-                  <a href="#custom-capabilities">Custom Capabilities</a>.
+                  Same as <code>--caps</code> flag and the SDK <code>capabilitiesFile</code> option.
+                  See <a href="#custom-capabilities">Custom Capabilities</a>.
                 </td>
               </tr>
             </tbody>
@@ -2593,8 +2724,8 @@
           <p>
             Sometimes the built-in capabilities aren't enough — you want to set
             <code>appium:autoGrantPermissions</code>, force a specific
-            <code>appium:automationName</code>, or pre-install an APK. AppClaw accepts a JSON
-            file of extra capabilities merged into <code>create_session</code> on every run.
+            <code>appium:automationName</code>, or pre-install an APK. AppClaw accepts a JSON file
+            of extra capabilities merged into <code>create_session</code> on every run.
           </p>
 
           <h3>Where to set it</h3>
@@ -2608,16 +2739,17 @@
               <code>.env</code> or your shell.
             </li>
             <li>
-              <strong>SDK:</strong> <code>new AppClaw({ capabilitiesFile: 'path/to/caps.json' })</code>.
+              <strong>SDK:</strong>
+              <code>new AppClaw({ capabilitiesFile: 'path/to/caps.json' })</code>.
             </li>
           </ul>
-          <p>
-            <code>--caps</code> wins over the env var when both are set.
-          </p>
+          <p><code>--caps</code> wins over the env var when both are set.</p>
 
           <h3>Flat format</h3>
-          <p>The simplest shape — a flat object of Appium capabilities. Applied to every session
-            regardless of platform.</p>
+          <p>
+            The simplest shape — a flat object of Appium capabilities. Applied to every session
+            regardless of platform.
+          </p>
 
           <div class="code-block">
             <div class="code-block-header">
@@ -2634,8 +2766,9 @@
           <h3>Platform-scoped format</h3>
           <p>
             When Android and iOS need different capabilities, split them under top-level
-            <code>android</code> and <code>ios</code> keys. Optionally use <code>common</code>
-            (alias: <code>default</code>, <code>shared</code>) for capabilities that apply to both.
+            <code>android</code> and <code>ios</code> keys. Optionally use
+            <code>common</code> (alias: <code>default</code>, <code>shared</code>) for capabilities
+            that apply to both.
           </p>
 
           <div class="code-block">
@@ -2668,21 +2801,22 @@
           </p>
 
           <h3>Precedence</h3>
-          <p>
-            When multiple sources set the same capability, later wins:
-          </p>
+          <p>When multiple sources set the same capability, later wins:</p>
           <ol>
             <li>Built-in defaults (MJPEG port, app from <code>APP_PATH</code>, etc.)</li>
-            <li>Your capabilities file (top-level / <code>common</code> / platform-specific, in that order)</li>
+            <li>
+              Your capabilities file (top-level / <code>common</code> / platform-specific, in that
+              order)
+            </li>
             <li>
               Framework-managed caps (per-parallel-worker ports, pinned UDID from
               <code>--udid</code>)
             </li>
           </ol>
           <p>
-            So your file can override defaults, but framework values (parallel ports, device pinning)
-            still take final precedence — concurrent workers won't collide even if your file sets
-            the same key.
+            So your file can override defaults, but framework values (parallel ports, device
+            pinning) still take final precedence — concurrent workers won't collide even if your
+            file sets the same key.
           </p>
 
           <div class="callout callout-warn">
@@ -2698,8 +2832,8 @@
           <h3>Notes</h3>
           <ul>
             <li>
-              The file is loaded once per session. Editing it during a long run has no effect
-              until the next session.
+              The file is loaded once per session. Editing it during a long run has no effect until
+              the next session.
             </li>
             <li>
               <code>appium:app</code> in the file takes precedence over the
@@ -2708,8 +2842,8 @@
             </li>
             <li>
               All values are sent through verbatim — AppClaw doesn't validate that
-              <code>appium:*</code> keys are recognised by your driver. Typos will surface as
-              Appium errors at session creation.
+              <code>appium:*</code> keys are recognised by your driver. Typos will surface as Appium
+              errors at session creation.
             </li>
             <li>
               <strong>LambdaTest:</strong> capabilities from this file are merged into the
@@ -3696,9 +3830,9 @@ console<span class="p">.</span>log<span class="p">(</span><span class="s">'All f
                 <td>string</td>
                 <td>—</td>
                 <td>
-                  Path to a JSON file of extra Appium capabilities merged into the session.
-                  Flat or platform-scoped (<code>android</code>/<code>ios</code>/<code>common</code>).
-                  Maps to <code>CAPABILITIES_FILE</code>. See
+                  Path to a JSON file of extra Appium capabilities merged into the session. Flat or
+                  platform-scoped (<code>android</code>/<code>ios</code>/<code>common</code>). Maps
+                  to <code>CAPABILITIES_FILE</code>. See
                   <a href="#custom-capabilities">Custom Capabilities</a>.
                 </td>
               </tr>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,9 @@
       "name": "appclaw",
       "version": "1.7.0",
       "dependencies": {
-        "@ai-sdk/anthropic": "^1.0.0",
+        "@ai-sdk/anthropic": "^3.0.0",
         "@ai-sdk/google": "^3.0.43",
-        "@ai-sdk/openai": "^1.0.0",
+        "@ai-sdk/openai": "^3.0.0",
         "@modelcontextprotocol/sdk": "^1.22.0",
         "ai": "^6.0.72",
         "ai-sdk-ollama": "3.8.3",
@@ -58,17 +58,19 @@
       }
     },
     "node_modules/@ai-sdk/anthropic": {
-      "version": "1.2.12",
+      "version": "3.0.85",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.85.tgz",
+      "integrity": "sha512-fNeDB644l5wbRNQU0FnI+F7UTtOenMnPtACfMPUJaS2zJfuBlseEa1TMg+otHkETZgaJB+6Na51NQEv0+m7czw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "1.1.3",
-        "@ai-sdk/provider-utils": "2.2.8"
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.30"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "zod": "^3.0.0"
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/gateway": {
@@ -151,21 +153,25 @@
       }
     },
     "node_modules/@ai-sdk/openai": {
-      "version": "1.3.24",
+      "version": "3.0.74",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.74.tgz",
+      "integrity": "sha512-LPDBWd2WCv0GQs29K2pHcNrGx24hm4D8QEP386HwUAUPr1URho6bNVXHNmIv0FxaW+xDkLpNMTen+mFCUBp2LA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "1.1.3",
-        "@ai-sdk/provider-utils": "2.2.8"
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.30"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "zod": "^3.0.0"
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/provider": {
-      "version": "1.1.3",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
+      "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
       "license": "Apache-2.0",
       "dependencies": {
         "json-schema": "^0.4.0"
@@ -175,18 +181,20 @@
       }
     },
     "node_modules/@ai-sdk/provider-utils": {
-      "version": "2.2.8",
+      "version": "4.0.30",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.30.tgz",
+      "integrity": "sha512-VO7I+vPffqI5sMnPoUq5DCSqKIgQIk/naJWRdQVpz2ma2zoprC/lqiJiUEl2s6DfvTD76TbhD3q39ROjlA6rGw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "1.1.3",
-        "nanoid": "^3.3.8",
-        "secure-json-parse": "^2.7.0"
+        "@ai-sdk/provider": "3.0.10",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.8"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "zod": "^3.23.8"
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@alcalzone/ansi-tokenize": {
@@ -4846,21 +4854,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/ai-sdk-ollama/node_modules/@ai-sdk/provider-utils": {
-      "version": "4.0.23",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "3.0.8",
-        "@standard-schema/spec": "^1.1.0",
-        "eventsource-parser": "^3.0.6"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
     "node_modules/ai/node_modules/@ai-sdk/provider": {
       "version": "3.0.8",
       "license": "Apache-2.0",
@@ -5910,17 +5903,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/appium-mcp/node_modules/jose": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
-      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/appium-mcp/node_modules/lru-cache": {
@@ -15272,7 +15254,9 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.6",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -18337,6 +18321,7 @@
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -22493,10 +22478,6 @@
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
-    },
-    "node_modules/secure-json-parse": {
-      "version": "2.7.0",
-      "license": "BSD-3-Clause"
     },
     "node_modules/select-hose": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
     "deploy:landing": "npm run deploy --prefix landing"
   },
   "dependencies": {
-    "@ai-sdk/anthropic": "^1.0.0",
+    "@ai-sdk/anthropic": "^3.0.0",
     "@ai-sdk/google": "^3.0.43",
-    "@ai-sdk/openai": "^1.0.0",
+    "@ai-sdk/openai": "^3.0.0",
     "@modelcontextprotocol/sdk": "^1.22.0",
     "ai": "^6.0.72",
     "ai-sdk-ollama": "3.8.3",

--- a/src/agent/app-resolver.ts
+++ b/src/agent/app-resolver.ts
@@ -114,10 +114,13 @@ export class AppResolver {
   private packageSegments: Array<{ segment: string; packageName: string }> = [];
   private initialized = false;
   private platform: 'android' | 'ios' = 'android';
+  /** Kept so the device app list can be re-fetched after init (e.g. on a resolve miss) */
+  private mcp: MCPClient | null = null;
 
   /** Fetch installed apps from device and build lookup */
   async initialize(mcp: MCPClient, platform?: 'android' | 'ios'): Promise<void> {
     if (platform) this.platform = platform;
+    this.mcp = mcp;
 
     // Populate well-known apps first (always available, even if device fetch fails)
     const wellKnownApps = this.platform === 'ios' ? WELL_KNOWN_IOS_APPS : WELL_KNOWN_ANDROID_APPS;
@@ -126,35 +129,62 @@ export class AppResolver {
     }
 
     try {
-      const result = await mcp.callTool('appium_app_lifecycle', { action: 'list' });
-      const text = result.content?.map((c: any) => c.text ?? '').join('\n') ?? '';
-
-      this.apps = parseAppList(text);
-
-      // Build name → packageName lookup from device data
-      for (const app of this.apps) {
-        if (app.label && app.label !== app.packageName) {
-          this.appsByName.set(app.label.toLowerCase(), app.packageName);
-        }
-
-        // Index all meaningful segments of the package name
-        const segments = app.packageName.split('.');
-        for (const seg of segments) {
-          if (
-            seg.length >= 3 &&
-            !['com', 'org', 'net', 'android', 'app', 'sec', 'google', 'samsung'].includes(seg)
-          ) {
-            this.appsByName.set(seg.toLowerCase(), app.packageName);
-            this.packageSegments.push({ segment: seg.toLowerCase(), packageName: app.packageName });
-          }
-        }
-      }
-
+      await this.fetchAndIndexApps(mcp);
       this.initialized = true;
       ui.printSetupOk(`Device connected (${this.apps.length} apps)`);
     } catch (err) {
       ui.printWarning(`Could not fetch app list: ${err}`);
       this.initialized = true;
+    }
+  }
+
+  /**
+   * Re-fetch the installed-app list from the device and rebuild the lookup.
+   *
+   * The list is otherwise cached at init time, so an app installed *after* the
+   * session started (the common playground case: launch → sideload app → "open X")
+   * would never resolve. Callers use this to retry once on a resolution miss.
+   * Returns true if the list was refreshed, false if no device handle is available.
+   */
+  async refresh(mcp?: MCPClient): Promise<boolean> {
+    const client = mcp ?? this.mcp;
+    if (!client) return false;
+    try {
+      await this.fetchAndIndexApps(client);
+      return true;
+    } catch (err) {
+      ui.printWarning(`Could not refresh app list: ${err}`);
+      return false;
+    }
+  }
+
+  /** Fetch the device app list and (re)build the device-derived lookup maps. */
+  private async fetchAndIndexApps(mcp: MCPClient): Promise<void> {
+    const result = await mcp.callTool('appium_app_lifecycle', { action: 'list' });
+    const text = result.content?.map((c: any) => c.text ?? '').join('\n') ?? '';
+
+    // Reset device-derived state — well-known apps are kept (populated separately).
+    this.apps = parseAppList(text);
+    this.appsByName.clear();
+    this.packageSegments = [];
+
+    // Build name → packageName lookup from device data
+    for (const app of this.apps) {
+      if (app.label && app.label !== app.packageName) {
+        this.appsByName.set(app.label.toLowerCase(), app.packageName);
+      }
+
+      // Index all meaningful segments of the package name
+      const segments = app.packageName.split('.');
+      for (const seg of segments) {
+        if (
+          seg.length >= 3 &&
+          !['com', 'org', 'net', 'android', 'app', 'sec', 'google', 'samsung'].includes(seg)
+        ) {
+          this.appsByName.set(seg.toLowerCase(), app.packageName);
+          this.packageSegments.push({ segment: seg.toLowerCase(), packageName: app.packageName });
+        }
+      }
     }
   }
 

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -1528,7 +1528,12 @@ async function executeMetaTool(
           return { success: false, message: 'No appId provided for launch_app' };
         }
         if (appResolver && !appId.includes('.')) {
-          const resolved = resolveAppId(appId, appResolver);
+          let resolved = resolveAppId(appId, appResolver);
+          // App list is cached at session start — re-fetch once if an app installed
+          // mid-session isn't found yet.
+          if (!resolved && (await appResolver.refresh())) {
+            resolved = resolveAppId(appId, appResolver);
+          }
           if (resolved) appId = resolved;
         }
         ui.printStepDetail(`activateApp("${appId}")`);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,6 @@
 // Default models per provider
 export const DEFAULT_MODELS: Record<string, string> = {
-  anthropic: 'claude-sonnet-4-20250514',
+  anthropic: 'claude-sonnet-4-6',
   openai: 'gpt-4o',
   gemini: 'gemini-3.1-flash-lite',
   groq: 'llama-3.3-70b-versatile',
@@ -43,8 +43,11 @@ export const MODEL_PRICING: Record<string, [number, number]> = {
   'gpt-4.1-mini': [0.4, 1.6],
   'gpt-4.1-nano': [0.1, 0.4],
   // Anthropic
-  'claude-sonnet-4-20250514': [3.0, 15.0],
+  'claude-sonnet-4-6': [3.0, 15.0],
+  'claude-opus-4-8': [5.0, 25.0],
   'claude-haiku-4-5-20251001': [0.8, 4.0],
+  // Retired 2026-06-15 — kept for cost lookup on historical runs only
+  'claude-sonnet-4-20250514': [3.0, 15.0],
   // Groq (free tier / no cost)
   'llama-3.3-70b-versatile': [0, 0],
 };

--- a/src/flow/llm-parser.ts
+++ b/src/flow/llm-parser.ts
@@ -11,9 +11,32 @@ import { buildModel } from '../llm/provider.js';
 import { Config } from '../config.js';
 import type { FlowStep } from './types.js';
 
+// Spatial qualifier disambiguating which matching element to act on, e.g.
+// "the login button below the password field". Set BOTH fields together or neither.
+const proximitySchema = z
+  .object({
+    relation: z
+      .enum(['above', 'below', 'toLeftOf', 'toRightOf', 'near', 'within'])
+      .describe('Spatial relation of the target element to the anchor'),
+    anchor: z.string().describe('Label/text of the reference element the target is positioned by'),
+  })
+  .optional()
+  .describe('Only when the instruction positions the target relative to another element');
+
 const stepSchema = z.discriminatedUnion('kind', [
   z.object({ kind: z.literal('openApp'), query: z.string().describe('App name to open') }),
-  z.object({ kind: z.literal('tap'), label: z.string().describe('Element label/text to tap') }),
+  z.object({
+    kind: z.literal('closeApp'),
+    query: z
+      .string()
+      .optional()
+      .describe('App name to close/terminate; omit to close the current foreground app'),
+  }),
+  z.object({
+    kind: z.literal('tap'),
+    label: z.string().describe('Element label/text to tap'),
+    proximity: proximitySchema,
+  }),
   z.object({
     kind: z.literal('longPress'),
     label: z.string().describe('Element label/text to long-press'),
@@ -23,6 +46,7 @@ const stepSchema = z.discriminatedUnion('kind', [
     kind: z.literal('type'),
     text: z.string().describe('Text to type'),
     target: z.string().optional().describe('Target field to type into'),
+    proximity: proximitySchema,
   }),
   z.object({ kind: z.literal('enter') }),
   z.object({ kind: z.literal('back') }),
@@ -71,6 +95,7 @@ const SYSTEM_PROMPT =
   `You are a mobile app test step interpreter. Convert the user's natural language instruction into a structured test step.\n\n` +
   `Rules:\n` +
   `- "open/launch/start <app>" → openApp\n` +
+  `- "close/terminate/quit/kill <app>" → closeApp (query = app name); "close the app" → closeApp with no query (closes current app)\n` +
   `- "click/tap/press/select <element>" → tap\n` +
   `- "long press/long-press/press and hold <element>" → longPress\n` +
   `- "type/enter/input <text>" or "search for <text>" → type\n` +
@@ -87,6 +112,12 @@ const SYSTEM_PROMPT =
   `- "go back" → back, "go home" → home\n` +
   `- "press enter/submit/search" → enter\n` +
   `- "done" → done\n` +
+  `When a tap/type names a target positioned relative to another element ` +
+  `("the login button below the password field", "the icon to the right of the title", ` +
+  `"the field inside the form"), set proximity={relation, anchor}: relation is one of ` +
+  `above|below|toLeftOf|toRightOf|near|within, anchor is the reference element's label. ` +
+  `Put only the target's own label in label/target — not the relation or anchor. ` +
+  `Omit proximity entirely when there is no relative positioning.\n` +
   `Extract the relevant parameters. Works with any language.`;
 
 export interface ResolvedStep {
@@ -100,9 +131,14 @@ export interface ResolvedStep {
 export async function resolveNaturalStep(instruction: string): Promise<ResolvedStep> {
   const model = buildModel(Config);
 
+  // Wrap the discriminated union in an object so the generated JSON schema has a
+  // top-level `type: "object"`. A bare top-level union serializes to `anyOf`/`oneOf`
+  // with no root `type`, which the Anthropic tool API rejects with
+  // `tools.0.custom.input_schema.type: Field required` (older provider versions
+  // silently normalized this; @ai-sdk/anthropic v3 forwards the schema verbatim).
   const { object, usage } = await generateObject({
     model: model as any,
-    schema: stepSchema,
+    schema: z.object({ step: stepSchema }),
     system: SYSTEM_PROMPT,
     prompt: instruction,
     providerOptions: {
@@ -112,7 +148,7 @@ export async function resolveNaturalStep(instruction: string): Promise<ResolvedS
   });
 
   return {
-    step: { ...object, verbatim: instruction } as FlowStep,
+    step: { ...object.step, verbatim: instruction } as FlowStep,
     usage: {
       inputTokens: usage.inputTokens ?? 0,
       outputTokens: usage.outputTokens ?? 0,

--- a/src/flow/natural-line.ts
+++ b/src/flow/natural-line.ts
@@ -3,10 +3,77 @@
  * Returns null if the line does not match any supported pattern — caller may error or fall through.
  */
 
-import type { FlowStep } from './types.js';
+import type { FlowStep, Proximity, ProximityRelation } from './types.js';
 
 function trimPunct(s: string): string {
   return s.replace(/[.!?]+$/g, '').trim();
+}
+
+// UI elements a bare "close the X" usually dismisses — not an app-close. Keeps
+// "close the dialog" out of the closeApp path (terminate/quit/kill bypass this).
+const NON_APP_CLOSE_TARGETS =
+  /^(?:dialog|popup|pop-?up|modal|menu|drawer|keyboard|notifications?|banner|sheet|bottom\s*sheet|tab|window|panel|alert|toast|overlay|ad|ads|popup\s*ad)$/i;
+
+/** Natural-language relation phrase → ProximityRelation. Order-insensitive (lowercased, single-spaced). */
+const PROXIMITY_RELATIONS: Record<string, ProximityRelation> = {
+  above: 'above',
+  over: 'above',
+  below: 'below',
+  under: 'below',
+  underneath: 'below',
+  'left of': 'toLeftOf',
+  'to the left of': 'toLeftOf',
+  'right of': 'toRightOf',
+  'to the right of': 'toRightOf',
+  near: 'near',
+  beside: 'near',
+  'next to': 'near',
+  within: 'within',
+  inside: 'within',
+  'inside of': 'within',
+};
+
+// Alternation of relation phrases, longest-first so "to the left of" wins over "left of".
+const RELATION_ALT = Object.keys(PROXIMITY_RELATIONS)
+  .sort((a, b) => b.length - a.length)
+  .map((p) => p.replace(/\s+/g, '\\s+'))
+  .join('|');
+const PROXIMITY_RE = new RegExp(`^(.+?)\\s+(${RELATION_ALT})\\s+(?:the\\s+)?(.+)$`, 'i');
+
+/**
+ * Split a "<target> <relation> <anchor>" phrase into the bare target label plus a
+ * Proximity qualifier. e.g. "login button below password field" →
+ * { label: "login button", proximity: { relation: 'below', anchor: 'password field' } }.
+ * Returns just the label unchanged when no relation phrase is present.
+ */
+export function splitProximity(label: string): { label: string; proximity?: Proximity } {
+  const m = label.match(PROXIMITY_RE);
+  if (!m) return { label };
+  const target = trimPunct(m[1].trim());
+  const relWord = m[2].toLowerCase().replace(/\s+/g, ' ');
+  const anchor = trimPunct(m[3].trim());
+  const relation = PROXIMITY_RELATIONS[relWord];
+  if (!relation || !target || !anchor) return { label };
+  return { label: target, proximity: { relation, anchor } };
+}
+
+/** Build a tap step, peeling off any trailing proximity qualifier. */
+function tapStep(label: string, verbatim: string): FlowStep {
+  const { label: bare, proximity } = splitProximity(label);
+  return { kind: 'tap', label: bare, ...(proximity ? { proximity } : {}), verbatim };
+}
+
+/** Build a type step, peeling off any trailing proximity qualifier from the target field. */
+function typeStep(text: string, rawTarget: string | undefined, verbatim: string): FlowStep {
+  if (!rawTarget) return { kind: 'type', text, verbatim };
+  const { label, proximity } = splitProximity(rawTarget);
+  return {
+    kind: 'type',
+    text,
+    target: label || undefined,
+    ...(proximity ? { proximity } : {}),
+    verbatim,
+  };
 }
 
 /** Strip common natural-language prefixes like "the text", "text", "element" from captured text. */
@@ -28,6 +95,26 @@ export function tryParseNaturalFlowLine(line: string): FlowStep | null {
   if (openMatch) {
     const query = trimPunct(openMatch[1].trim());
     if (query) return { kind: 'openApp', query, verbatim };
+  }
+
+  // "close/terminate/quit/kill [the] [<name>] [app]" → closeApp.
+  //   - bare ("close app" / "close the app" / "terminate the app") closes the current app
+  //   - named ("close youtube", "close the youtube app", "quit settings") closes that app
+  // For the `close` verb, a bare UI-element noun ("close the dialog", "close keyboard")
+  // is NOT an app-close — those stay null so they fall through to the tap/LLM path.
+  // terminate/quit/kill are unambiguous about app lifecycle, so they skip that guard.
+  const closeAppMatch = t.match(
+    /^(close|terminate|quit|kill)(?:\s+the)?\s+(.+?)(?:\s+(?:app|application))?$/i
+  );
+  if (closeAppMatch) {
+    const verb = closeAppMatch[1].toLowerCase();
+    let query: string | undefined = trimPunct(closeAppMatch[2].trim());
+    if (/^(?:app|application)$/i.test(query)) query = undefined; // "close the app" → current app
+    if (query && verb === 'close' && NON_APP_CLOSE_TARGETS.test(query)) {
+      // "close the dialog/keyboard/menu…" — a UI dismissal, not an app close.
+    } else {
+      return { kind: 'closeApp', ...(query ? { query } : {}), verbatim };
+    }
   }
 
   // "navigate to X" / "go to X screen" — tap-style navigation
@@ -60,13 +147,13 @@ export function tryParseNaturalFlowLine(line: string): FlowStep | null {
   const clickMatch = t.match(/^(?:click|tap|select|choose|pick)(?:\s+on)?\s+(?:the\s+)?(.+)$/i);
   if (clickMatch) {
     const label = trimPunct(clickMatch[1].trim());
-    if (label) return { kind: 'tap', label, verbatim };
+    if (label) return tapStep(label, verbatim);
   }
 
   const pressMatch = t.match(/^press(?:\s+on)?\s+(?:the\s+)?(.+)$/i);
   if (pressMatch) {
     const label = trimPunct(pressMatch[1].trim());
-    if (label) return { kind: 'tap', label, verbatim };
+    if (label) return tapStep(label, verbatim);
   }
 
   const typeMatch = t.match(/^(?:type|enter\s+text|input)\s+["'](.+)["']$/i);
@@ -80,7 +167,7 @@ export function tryParseNaturalFlowLine(line: string): FlowStep | null {
   if (typeQuotedInMatch) {
     const text = typeQuotedInMatch[1].trim();
     const target = trimPunct(typeQuotedInMatch[2].trim());
-    if (text) return { kind: 'type', text, target: target || undefined, verbatim };
+    if (text) return typeStep(text, target, verbatim);
   }
   // "Enter X in Y" / "Type X in Y" — unquoted text + target
   // Use greedy (.+) with \s+(?:in|into) so the last "in/into" wins.
@@ -88,7 +175,19 @@ export function tryParseNaturalFlowLine(line: string): FlowStep | null {
   if (typeInMatch) {
     const text = trimPunct(typeInMatch[1].trim());
     const target = trimPunct(typeInMatch[2].trim());
-    if (text) return { kind: 'type', text, target: target || undefined, verbatim };
+    if (text) return typeStep(text, target, verbatim);
+  }
+  // "Type the <field> as <value>" / "set the <field> to <value>" / "fill the <field> with <value>"
+  // — FIELD-first ordering, the inverse of "enter <value> in <field>" above. The leading
+  // "the" is required as the disambiguator so literal text containing "as"/"to"/"with"
+  // (e.g. `type save as draft`) still falls through to the bare-text rule below.
+  const typeFieldAssignMatch = t.match(
+    /^(?:type|enter|input|fill|set)\s+the\s+(.+?)\s+(?:as|to|with)\s+["']?(.+?)["']?$/i
+  );
+  if (typeFieldAssignMatch) {
+    const target = trimPunct(typeFieldAssignMatch[1].trim());
+    const text = trimPunct(typeFieldAssignMatch[2].trim());
+    if (text) return typeStep(text, target, verbatim);
   }
   const typeBare = t.match(/^(?:type|input)\s+(.+)$/i);
   if (typeBare && !t.match(/^type\s*:/i)) {
@@ -105,7 +204,7 @@ export function tryParseNaturalFlowLine(line: string): FlowStep | null {
     if (searchInMatch) {
       const target = trimPunct(searchInMatch[2].trim());
       text = trimPunct(searchInMatch[1].trim());
-      if (text) return { kind: 'type', text, target: target || undefined, verbatim };
+      if (text) return typeStep(text, target, verbatim);
     }
     if (text) return { kind: 'type', text, verbatim };
   }
@@ -118,7 +217,7 @@ export function tryParseNaturalFlowLine(line: string): FlowStep | null {
     if (enterInMatch) {
       const target = trimPunct(enterInMatch[2].trim());
       text = trimPunct(enterInMatch[1].trim());
-      if (text) return { kind: 'type', text, target: target || undefined, verbatim };
+      if (text) return typeStep(text, target, verbatim);
     }
     if (text) return { kind: 'type', text, verbatim };
   }

--- a/src/flow/run-yaml-flow.ts
+++ b/src/flow/run-yaml-flow.ts
@@ -10,7 +10,7 @@
 
 import type { MCPClient } from '../mcp/types.js';
 import { getPageSource, findElementByVision } from '../mcp/tools.js';
-import { activateAppWithFallback } from '../mcp/activate-app.js';
+import { activateAppWithFallback, terminateApp } from '../mcp/activate-app.js';
 import { detectDeviceUdid, typeViaKeyboard, typeViaSetValue } from '../mcp/keyboard.js';
 import { detectPlatform } from '../perception/screen.js';
 import { parseAndroidPageSource } from '../perception/android-parser.js';
@@ -54,7 +54,15 @@ import { promisify } from 'util';
 import type { ActionResult } from '../llm/schemas.js';
 
 const execAsync = promisify(exec);
-import type { FlowMeta, FlowStep, FlowPhase, PhasedStep, PhaseResult } from './types.js';
+import type {
+  FlowMeta,
+  FlowStep,
+  FlowPhase,
+  PhasedStep,
+  PhaseResult,
+  Proximity,
+  ProximityRelation,
+} from './types.js';
 import type { AppResolver } from '../agent/app-resolver.js';
 import type { RunArtifactCollector } from '../report/writer.js';
 import { lastVisionScreenshot } from './vision-execute.js';
@@ -280,6 +288,8 @@ function stepLabel(step: FlowStep): string {
       return 'launchApp';
     case 'openApp':
       return `open "${step.query}"`;
+    case 'closeApp':
+      return step.query ? `close "${step.query}"` : 'close app';
     case 'wait':
       return `wait ${step.seconds}s`;
     case 'waitUntil':
@@ -390,6 +400,249 @@ export function scoreTapMatch(el: UIElement, needle: string): number {
     }
   }
   return best;
+}
+
+// ─── Spatial / proximity ranking ─────────────────────────────────────
+//
+// Modeled on Taiko's proximity selectors
+// (https://github.com/getgauge/taiko/wiki/Taiko's-Proximity-Selector):
+// `above`, `below`, `toLeftOf`, `toRightOf`, `near`, `within`. The edge
+// comparisons follow Taiko's geometry exactly; ranking among multiple matches
+// uses Taiko's bounding-box distance (sum of the four edge differences).
+//
+// The one deliberate divergence: Taiko's `near` offset is a fixed CSS-pixel
+// constant, which is meaningless across mobile device-pixel densities (a phone
+// page source runs to ~1080–1440 × ~2400–3200). So `near` here uses an offset
+// that is RELATIVE to the anchor's own size and EXPANDS until something matches
+// — Taiko's behavior, made density-correct.
+
+interface Rect {
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+}
+
+/** Axis-aligned bounding box from an element's center + size. */
+function rectOf(el: UIElement): Rect {
+  const [cx, cy] = el.center;
+  const [w, h] = el.size;
+  return { left: cx - w / 2, right: cx + w / 2, top: cy - h / 2, bottom: cy + h / 2 };
+}
+
+/** Taiko's ranking metric: sum of |Δ| across all four edges. Lower = closer. */
+function bboxDistance(a: Rect, b: Rect): number {
+  return (
+    Math.abs(a.left - b.left) +
+    Math.abs(a.right - b.right) +
+    Math.abs(a.top - b.top) +
+    Math.abs(a.bottom - b.bottom)
+  );
+}
+
+/** Whether `cand` satisfies `relation` w.r.t. `anchor` (Taiko geometry). `tol` only used by `near`. */
+function satisfiesRelation(
+  cand: Rect,
+  anchor: Rect,
+  relation: ProximityRelation,
+  tol = 0
+): boolean {
+  switch (relation) {
+    case 'above':
+      return cand.bottom < anchor.top;
+    case 'below':
+      return cand.top > anchor.bottom;
+    case 'toLeftOf':
+      return cand.right <= anchor.left;
+    case 'toRightOf':
+      return cand.left >= anchor.right;
+    case 'within':
+      return (
+        cand.left >= anchor.left &&
+        cand.right <= anchor.right &&
+        cand.top >= anchor.top &&
+        cand.bottom <= anchor.bottom
+      );
+    case 'near': {
+      // `cand` intersects `anchor` expanded by `tol` on every side.
+      const exp: Rect = {
+        left: anchor.left - tol,
+        right: anchor.right + tol,
+        top: anchor.top - tol,
+        bottom: anchor.bottom + tol,
+      };
+      return (
+        cand.left <= exp.right &&
+        cand.right >= exp.left &&
+        cand.top <= exp.bottom &&
+        cand.bottom >= exp.top
+      );
+    }
+  }
+}
+
+/**
+ * Rank `candidates` by how well they satisfy a spatial `relation` to `anchor`,
+ * best first. Candidates that don't satisfy the relation are dropped. The anchor
+ * element itself is never returned. Returns [] when nothing qualifies.
+ *
+ * `near` starts with an offset of one anchor-dimension and grows (×1.6, capped)
+ * until at least one candidate is in range — so it adapts to element scale and
+ * device density instead of a fixed pixel constant.
+ */
+export function rankBySpatial(
+  candidates: UIElement[],
+  anchor: UIElement,
+  relation: ProximityRelation
+): UIElement[] {
+  const anchorRect = rectOf(anchor);
+  const pool = candidates.filter((c) => c !== anchor && c.enabled !== false);
+
+  const sortByDistance = (els: UIElement[]): UIElement[] =>
+    els
+      .map((el) => ({ el, d: bboxDistance(rectOf(el), anchorRect) }))
+      .sort((a, b) => a.d - b.d)
+      .map((x) => x.el);
+
+  if (relation === 'near') {
+    const base = Math.max(
+      anchorRect.right - anchorRect.left,
+      anchorRect.bottom - anchorRect.top,
+      1
+    );
+    let tol = base;
+    for (let i = 0; i < 6; i++) {
+      const hits = pool.filter((c) => satisfiesRelation(rectOf(c), anchorRect, 'near', tol));
+      if (hits.length > 0) return sortByDistance(hits);
+      tol *= 1.6;
+    }
+    return [];
+  }
+
+  const hits = pool.filter((c) => satisfiesRelation(rectOf(c), anchorRect, relation));
+  return sortByDistance(hits);
+}
+
+/** Human-readable phrase for a relation, for error messages. */
+function relationPhrase(r: ProximityRelation): string {
+  switch (r) {
+    case 'toLeftOf':
+      return 'to the left of';
+    case 'toRightOf':
+      return 'to the right of';
+    default:
+      return r; // above | below | near | within
+  }
+}
+
+/** Best textual match for an anchor label among parsed elements, or null. */
+function resolveAnchorElement(elements: UIElement[], anchorLabel: string): UIElement | null {
+  const scored = elements
+    .map((el) => ({ el, s: scoreTapMatch(el, anchorLabel) }))
+    .filter((x) => x.s >= 0)
+    .sort((a, b) => a.s - b.s);
+  return scored[0]?.el ?? null;
+}
+
+/**
+ * Resolve which element a `tap` should act on.
+ *
+ * Scores every element textually (with the clickable nudge the tap path uses),
+ * then — when a `proximity` qualifier is present — restricts to clickable
+ * candidates (so stray text that merely contains the word can't win on distance)
+ * and ranks them spatially against the resolved anchor. Returns `{ el: null,
+ * reason }` when nothing qualifies so the caller can retry / hard-fail.
+ */
+export function resolveTapTarget(
+  elements: UIElement[],
+  label: string,
+  proximity?: Proximity
+): { el: UIElement | null; reason?: string } {
+  const wantsClickable = trailingRoleWord(label) != null;
+  const scored = elements
+    .map((el) => ({ el, s: scoreTapMatch(el, label) }))
+    .filter((x) => x.s >= 0)
+    .map((x) => ({ ...x, eff: x.s + (wantsClickable && !x.el.clickable ? 0.5 : 0) }))
+    .sort((a, b) => {
+      if (a.eff !== b.eff) return a.eff - b.eff;
+      if (a.el.clickable !== b.el.clickable) return a.el.clickable ? -1 : 1;
+      return 0;
+    });
+
+  if (scored.length === 0) return { el: null, reason: `no element matches "${label}"` };
+  if (!proximity) return { el: scored[0].el };
+
+  const anchorEl = resolveAnchorElement(elements, proximity.anchor);
+  if (!anchorEl) return { el: null, reason: `anchor "${proximity.anchor}" not found` };
+
+  // A spatial pick ranks purely by distance, so it must not consider stray text
+  // that merely contains the word (e.g. a help paragraph mentioning "login
+  // button") — those can sit closer to the anchor than the real control. Prefer
+  // clickable candidates whenever any exist before ranking by position.
+  const candidateEls = scored.map((x) => x.el);
+  const clickable = candidateEls.filter((e) => e.clickable);
+  const pool = clickable.length > 0 ? clickable : candidateEls;
+  const ranked = rankBySpatial(pool, anchorEl, proximity.relation);
+  if (ranked.length === 0) {
+    return { el: null, reason: `no "${label}" ${relationPhrase(proximity.relation)} the anchor` };
+  }
+  return { el: ranked[0] };
+}
+
+/**
+ * Resolve which editable field a `type` should write into.
+ *
+ * Tiers:
+ *   1. Direct  — `target` matches an editable element's own text/hint/id/aid.
+ *   2. Label   — `target` matches a non-editable label; the nearest editable wins
+ *                (covers the "Username" label sitting above its input).
+ *   3. Spatial — a `proximity` qualifier narrows the pool by relation to an anchor.
+ *
+ * Returns `{ el: null, reason }` when nothing qualifies — the caller hard-fails
+ * rather than silently typing into the first field on screen.
+ */
+export function resolveEditableForTarget(
+  elements: UIElement[],
+  target?: string,
+  proximity?: Proximity
+): { el: UIElement | null; reason?: string } {
+  const editables = elements.filter((e) => e.editable && e.enabled !== false);
+  if (editables.length === 0) return { el: null, reason: 'no editable field on screen' };
+
+  let candidates: UIElement[] = editables;
+  if (target) {
+    // 1. Direct match among editable fields.
+    candidates = editables
+      .map((el) => ({ el, s: scoreTapMatch(el, target) }))
+      .filter((x) => x.s >= 0)
+      .sort((a, b) => a.s - b.s)
+      .map((x) => x.el);
+    // 2. Otherwise treat target as a nearby label and find the closest input.
+    if (candidates.length === 0) {
+      const labelEl = resolveAnchorElement(elements, target);
+      if (labelEl) candidates = rankBySpatial(editables, labelEl, 'near');
+    }
+  }
+
+  // 3. Spatial qualifier narrows by relation to a named anchor.
+  if (proximity) {
+    const anchorEl = resolveAnchorElement(elements, proximity.anchor);
+    if (!anchorEl) return { el: null, reason: `anchor "${proximity.anchor}" not found on screen` };
+    const pool = candidates.length > 0 ? candidates : editables;
+    const ranked = rankBySpatial(pool, anchorEl, proximity.relation);
+    if (ranked.length === 0) {
+      return {
+        el: null,
+        reason: `no input field ${relationPhrase(proximity.relation)} "${proximity.anchor}"`,
+      };
+    }
+    return { el: ranked[0] };
+  }
+
+  if (candidates.length === 0) {
+    return { el: null, reason: `"${target}" did not match any input field` };
+  }
+  return { el: candidates[0] };
 }
 
 /**
@@ -573,7 +826,8 @@ async function tryTapByVision(mcp: MCPClient, label: string): Promise<ActionResu
 /** Returns: ActionResult on success, "no_match" if label not in DOM, null if matched but UUID failed */
 async function tryTapByLabelOnDom(
   mcp: MCPClient,
-  label: string
+  label: string,
+  proximity?: Proximity
 ): Promise<ActionResult | 'no_match' | null> {
   const cacheCtx = getActiveLocatorCache();
   const pageSource = cacheCtx
@@ -582,8 +836,11 @@ async function tryTapByLabelOnDom(
 
   // SDK locator cache fast-path: skip parse + score + multi-strategy probe when
   // we already know the (strategy, selector) that won for this label on this
-  // screen. On miss / stale, falls through to the existing path below.
-  const keyInfo = cacheCtx ? buildCacheKey(cacheCtx, pageSource, 'tap', label) : null;
+  // screen. On miss / stale, falls through to the existing path below. The cache
+  // label folds in the proximity qualifier so a plain "login" and a spatially
+  // qualified "login below password" never share a cached locator.
+  const cacheLabel = proximity ? `${label}|${proximity.relation}:${proximity.anchor}` : label;
+  const keyInfo = cacheCtx ? buildCacheKey(cacheCtx, pageSource, 'tap', cacheLabel) : null;
   if (cacheCtx && keyInfo) {
     const hit = await tryCachedLocator(cacheCtx, mcp, keyInfo, async (uuid) => {
       await mcp.callTool('appium_gesture', { action: 'tap', elementUUID: uuid });
@@ -596,22 +853,11 @@ async function tryTapByLabelOnDom(
   const elements =
     platform === 'android' ? parseAndroidPageSource(pageSource) : parseIOSPageSource(pageSource);
 
-  // When the user named a tappable role ("...button/link/tab"), an equally-good
-  // but non-clickable text match (e.g. a header title) must not out-rank the
-  // real control. Nudge non-clickable candidates back by half a score level so
-  // they still beat a clearly worse clickable match, but lose ties.
-  const wantsClickable = trailingRoleWord(label) != null;
-  const scored = elements
-    .map((el) => ({ el, s: scoreTapMatch(el, label) }))
-    .filter((x) => x.s >= 0)
-    .map((x) => ({ ...x, eff: x.s + (wantsClickable && !x.el.clickable ? 0.5 : 0) }))
-    .sort((a, b) => {
-      if (a.eff !== b.eff) return a.eff - b.eff;
-      if (a.el.clickable !== b.el.clickable) return a.el.clickable ? -1 : 1;
-      return 0;
-    });
-
-  const pick = scored[0]?.el;
+  // Score textually (with the clickable nudge) and, when a proximity qualifier is
+  // present, narrow to clickable candidates and rank spatially. Any miss (no text
+  // match, anchor not found, no spatial survivor) becomes 'no_match' so the
+  // caller's poll loop keeps waiting — the screen may still be rendering.
+  const pick = resolveTapTarget(elements, label, proximity).el;
   if (!pick) return 'no_match';
 
   const resolved = await findByIdStrategiesDetailed(
@@ -633,13 +879,18 @@ async function tryTapByLabelOnDom(
     });
     cacheCtx.dirty = true;
   }
-  return { success: true, message: `Tapped "${label}" at [${coords[0]}, ${coords[1]}]` };
+  const where = proximity ? ` (${relationPhrase(proximity.relation)} "${proximity.anchor}")` : '';
+  return {
+    success: true,
+    message: `Tapped "${label}"${where} at [${coords[0]}, ${coords[1]}]`,
+  };
 }
 
 async function tapByLabel(
   mcp: MCPClient,
   label: string,
-  poll: FlowTapPollOptions
+  poll: FlowTapPollOptions,
+  proximity?: Proximity
 ): Promise<ActionResult> {
   // ── Vision-first mode: skip DOM entirely ──
   // Poll the full budget so the element is implicitly waited for until it
@@ -665,11 +916,15 @@ async function tapByLabel(
   // On the FIRST no_match we try vision once: catches icon-only elements that
   // are already on screen (no text to match) without burning the whole wait
   // budget on DOM polls before falling over to vision.
+  // Vision locates by bare label and can't honor a spatial qualifier, so it's
+  // disabled when a proximity is set — falling back to it could tap the very
+  // element the qualifier was meant to exclude.
+  const visionOk = isVisionLocateEnabled() && !proximity;
   let triedVisionEarly = false;
   for (let attempt = 0; attempt < poll.maxAttempts; attempt++) {
-    const domTap = await tryTapByLabelOnDom(mcp, label);
+    const domTap = await tryTapByLabelOnDom(mcp, label, proximity);
     if (domTap && domTap !== 'no_match') return domTap;
-    if (domTap === 'no_match' && !triedVisionEarly && isVisionLocateEnabled()) {
+    if (domTap === 'no_match' && !triedVisionEarly && visionOk) {
       triedVisionEarly = true;
       const visionTap = await tryTapByVision(mcp, label);
       if (visionTap) return visionTap;
@@ -686,13 +941,18 @@ async function tapByLabel(
 
   // Last resort: one more vision attempt after the wait budget is exhausted
   // (the element may have only just rendered on the final DOM poll).
-  if (isVisionLocateEnabled()) {
+  if (visionOk) {
     ui.printAgentBullet(`"${label}" not found in page source, trying vision…`);
     const visionTap = await tryTapByVision(mcp, label);
     if (visionTap) return visionTap;
   }
 
-  return { success: false, message: `No matching element for "${label}"` };
+  return {
+    success: false,
+    message: proximity
+      ? `No "${label}" found ${relationPhrase(proximity.relation)} "${proximity.anchor}" on screen`
+      : `No matching element for "${label}"`,
+  };
 }
 
 /** Long-press an element by visual label. Uses vision locate if available, falls back to DOM. */
@@ -812,12 +1072,17 @@ async function flowTypeText(
   text: string,
   target?: string,
   deviceUdid?: string,
-  poll: FlowTapPollOptions = { maxAttempts: 10, intervalMs: 300 }
+  poll: FlowTapPollOptions = { maxAttempts: 10, intervalMs: 300 },
+  proximity?: Proximity
 ): Promise<ActionResult> {
-  if (appclawDebug) ui.printAgentBullet(`[type] text="${text}", target=${target ?? '(none)'}`);
+  if (appclawDebug)
+    ui.printAgentBullet(
+      `[type] text="${text}", target=${target ?? '(none)'}` +
+        (proximity ? `, proximity=${proximity.relation}:"${proximity.anchor}"` : '')
+    );
   // ── If a target field is specified, tap it first to focus (implicit wait) ──
   if (target) {
-    const tapResult = await tapByLabel(mcp, target, poll);
+    const tapResult = await tapByLabel(mcp, target, poll, proximity);
     // Vision mode: a literal label like "search box"/"textbox" usually won't match a field
     // that only shows a placeholder. Fall back to locating the input field by kind before
     // giving up, so `type "x" → search box` works the same as the no-target path.
@@ -868,9 +1133,12 @@ async function flowTypeText(
     : await getPageSource(mcp);
 
   // SDK locator cache fast-path. Cache key for `type` is keyed on the optional
-  // target label (or the implicit-input sentinel when none) so two distinct
-  // editable fields on the same screen don't collide.
-  const cacheLabel = target ?? '__implicit_input__';
+  // target label (or the implicit-input sentinel when none) plus any proximity
+  // qualifier, so two distinct editable fields on the same screen don't collide.
+  const baseCacheLabel = target ?? '__implicit_input__';
+  const cacheLabel = proximity
+    ? `${baseCacheLabel}|${proximity.relation}:${proximity.anchor}`
+    : baseCacheLabel;
   const keyInfo = cacheCtx ? buildCacheKey(cacheCtx, pageSource, 'type', cacheLabel) : null;
   if (cacheCtx && keyInfo) {
     const hit = await tryCachedLocator(cacheCtx, mcp, keyInfo, async (uuid) => {
@@ -895,9 +1163,23 @@ async function flowTypeText(
   const platform = detectPlatform(pageSource);
   const elements =
     platform === 'android' ? parseAndroidPageSource(pageSource) : parseIOSPageSource(pageSource);
-  const editable = elements.find((e) => e.editable && e.enabled !== false);
-  if (!editable) {
-    return { success: false, message: 'No editable field found for type' };
+
+  // With a named target (or a spatial qualifier), type into THAT field — not the
+  // first editable on screen. Without one, the implicit-input case keeps using
+  // the first editable field.
+  let editable: UIElement | null;
+  if (target || proximity) {
+    const r = resolveEditableForTarget(elements, target, proximity);
+    if (!r.el) {
+      const what = target ? `target "${target}"` : 'an input';
+      return { success: false, message: `Could not find ${what} to type into: ${r.reason}` };
+    }
+    editable = r.el;
+  } else {
+    editable = elements.find((e) => e.editable && e.enabled !== false) ?? null;
+    if (!editable) {
+      return { success: false, message: 'No editable field found for type' };
+    }
   }
   const resolved = await findByIdStrategiesDetailed(
     mcp,
@@ -1460,7 +1742,14 @@ export async function executeStep(
           message: 'open … app steps need the installed-apps list (internal: pass AppResolver)',
         };
       }
-      const pkg = resolveAppId(step.query, appResolver);
+      let pkg = resolveAppId(step.query, appResolver);
+      if (!pkg) {
+        // The app list is cached at session start, so an app installed mid-session
+        // won't be found. Re-fetch the device list once and retry before failing.
+        if (await appResolver.refresh()) {
+          pkg = resolveAppId(step.query, appResolver);
+        }
+      }
       if (!pkg) {
         return {
           success: false,
@@ -1477,17 +1766,66 @@ export async function executeStep(
         message: r.success ? `Launched ${step.query} (${pkg})` : r.message,
       };
     }
+    case 'closeApp': {
+      // Resolve which app to terminate: an explicit name → package, otherwise the
+      // app launched this session (locator-cache currentAppId) or the YAML appId.
+      let pkg: string | null = null;
+      if (step.query) {
+        if (!appResolver) {
+          return {
+            success: false,
+            message: 'close <app> steps need the installed-apps list (internal: pass AppResolver)',
+          };
+        }
+        pkg = resolveAppId(step.query, appResolver);
+        if (!pkg && (await appResolver.refresh())) {
+          pkg = resolveAppId(step.query, appResolver);
+        }
+        if (!pkg) {
+          return {
+            success: false,
+            message: `Could not resolve app name "${step.query}" to a package`,
+          };
+        }
+      } else {
+        // No name: close the current foreground app. Read it from the live page
+        // source (its package), falling back to session state — so this works even
+        // when the locator cache isn't active (playground / SDK).
+        const pageSource = await getPageSource(mcp).catch(() => '');
+        pkg =
+          extractAppIdFromDom(pageSource) ??
+          getActiveLocatorCache()?.currentAppId ??
+          meta.appId?.trim() ??
+          null;
+        if (!pkg) {
+          return {
+            success: false,
+            message:
+              'close app: could not determine the current app — name it (e.g. "close youtube") or set appId in the YAML header',
+          };
+        }
+      }
+      const r = await terminateApp(mcp, pkg);
+      if (r.success) {
+        const cacheCtx = getActiveLocatorCache();
+        if (cacheCtx && cacheCtx.currentAppId === pkg) cacheCtx.currentAppId = undefined;
+      }
+      return {
+        success: r.success,
+        message: r.success ? `Closed ${step.query ?? pkg} (${pkg})` : r.message,
+      };
+    }
     case 'wait':
       await sleep(Math.round(step.seconds * 1000));
       return { success: true, message: `Waited ${step.seconds}s` };
     case 'waitUntil':
       return waitUntilCondition(mcp, step.condition, step.text, step.timeoutSeconds, tapPoll);
     case 'tap':
-      return tapByLabel(mcp, step.label, tapPoll);
+      return tapByLabel(mcp, step.label, tapPoll, step.proximity);
     case 'longPress':
       return longPressByLabel(mcp, step.label, step.duration);
     case 'type':
-      return flowTypeText(mcp, step.text, step.target, deviceUdid, tapPoll);
+      return flowTypeText(mcp, step.text, step.target, deviceUdid, tapPoll, step.proximity);
     case 'enter':
       return pressEnterKey(mcp);
     case 'back':

--- a/src/flow/types.ts
+++ b/src/flow/types.ts
@@ -54,9 +54,24 @@ export interface ParsedSuite {
 /** Set when the step was parsed from a natural-language YAML string (shown in CLI). */
 type Verbatim = { verbatim?: string };
 
+/**
+ * Spatial selectors for disambiguating which matching element to act on, modeled
+ * on Taiko's proximity selectors. Applied via the `proximity` qualifier on
+ * element-bearing steps (tap/type). See `rankBySpatial` in run-yaml-flow.ts.
+ */
+export type ProximityRelation = 'above' | 'below' | 'toLeftOf' | 'toRightOf' | 'near' | 'within';
+
+/**
+ * Optional spatial qualifier: "<target> below <anchor>", "<target> near <anchor>".
+ * Both fields are set together — `relation` is the geometric relation and
+ * `anchor` is the natural-language label of the reference element.
+ */
+export type Proximity = { relation: ProximityRelation; anchor: string };
+
 export type FlowStep =
   | ({ kind: 'launchApp' } & Verbatim)
   | ({ kind: 'openApp'; query: string } & Verbatim)
+  | ({ kind: 'closeApp'; query?: string } & Verbatim)
   | ({ kind: 'wait'; seconds: number } & Verbatim)
   | ({
       kind: 'waitUntil';
@@ -64,9 +79,9 @@ export type FlowStep =
       text?: string;
       timeoutSeconds: number;
     } & Verbatim)
-  | ({ kind: 'tap'; label: string } & Verbatim)
+  | ({ kind: 'tap'; label: string; proximity?: Proximity } & Verbatim)
   | ({ kind: 'longPress'; label: string; duration?: number } & Verbatim)
-  | ({ kind: 'type'; text: string; target?: string } & Verbatim)
+  | ({ kind: 'type'; text: string; target?: string; proximity?: Proximity } & Verbatim)
   | ({ kind: 'enter' } & Verbatim)
   | ({ kind: 'back' } & Verbatim)
   | ({ kind: 'home' } & Verbatim)

--- a/src/mcp/activate-app.ts
+++ b/src/mcp/activate-app.ts
@@ -69,3 +69,16 @@ export async function activateAppWithFallback(
     message: t0.slice(0, 400) || `Failed to activate ${packageId}`,
   };
 }
+
+/** Terminate (close) an app by package/bundle id via appium-mcp. */
+export async function terminateApp(
+  mcp: MCPClient,
+  packageId: string
+): Promise<{ success: boolean; message: string }> {
+  const r = await mcp.callTool('appium_app_lifecycle', { action: 'terminate', id: packageId });
+  const t = extractText(r);
+  if (responseLooksLikeFailure(t)) {
+    return { success: false, message: t.slice(0, 400) || `Failed to close ${packageId}` };
+  }
+  return { success: true, message: t.slice(0, 240) || `Closed ${packageId}` };
+}

--- a/src/playground/index.ts
+++ b/src/playground/index.ts
@@ -786,7 +786,7 @@ function printHelp(): void {
   const examples: Array<{ category: string; lines: string[] }> = [
     {
       category: 'Apps',
-      lines: ['open YouTube', 'launch Settings app'],
+      lines: ['open YouTube', 'launch Settings app', 'close YouTube', 'close the app'],
     },
     {
       category: 'Tap & Navigate',
@@ -795,6 +795,15 @@ function printHelp(): void {
         'click Search button',
         'select English',
         'navigate to Settings screen',
+      ],
+    },
+    {
+      category: 'Proximity (disambiguate by position)',
+      lines: [
+        'tap the login button below the password field',
+        'tap the icon to the right of the title',
+        'click the checkbox next to Terms',
+        'type "pass" in the field below the email',
       ],
     },
     {

--- a/src/ui/step-printer.ts
+++ b/src/ui/step-printer.ts
@@ -23,6 +23,8 @@ export function stepAction(step: FlowStep): string {
       return 'launch';
     case 'openApp':
       return 'open';
+    case 'closeApp':
+      return 'close';
     case 'tap':
       return 'tap';
     case 'longPress':
@@ -63,6 +65,8 @@ export function stepTarget(step: FlowStep): string {
       return 'app';
     case 'openApp':
       return step.query;
+    case 'closeApp':
+      return step.query ?? 'current app';
     case 'tap':
       return `"${step.label}"`;
     case 'longPress':

--- a/tests/flow/natural-line.test.ts
+++ b/tests/flow/natural-line.test.ts
@@ -42,6 +42,37 @@ describe('natural-line: tap/click', () => {
     expectStep('tap the Login button', { kind: 'tap', label: 'Login button' }));
 });
 
+// ── Close/terminate app ─────────────────────────────────────────────
+
+describe('natural-line: close app', () => {
+  test('close app → closeApp (no query)', () => {
+    const r = tryParseNaturalFlowLine('close app');
+    expect(r?.kind).toBe('closeApp');
+    expect(r?.kind === 'closeApp' && r.query).toBeUndefined();
+  });
+  test('close the app → closeApp (no query)', () => {
+    const r = tryParseNaturalFlowLine('close the app');
+    expect(r?.kind === 'closeApp' && r.query).toBeUndefined();
+  });
+  test('close <name> app', () =>
+    expectStep('close youtube app', { kind: 'closeApp', query: 'youtube' }));
+  test('close the <name> app', () =>
+    expectStep('close the youtube app', { kind: 'closeApp', query: 'youtube' }));
+  test('terminate <name>', () =>
+    expectStep('terminate youtube', { kind: 'closeApp', query: 'youtube' }));
+  test('quit <name>', () => expectStep('quit settings', { kind: 'closeApp', query: 'settings' }));
+  test('kill the <name> app', () =>
+    expectStep('kill the chrome app', { kind: 'closeApp', query: 'chrome' }));
+  test('terminate the app → no query', () => {
+    const r = tryParseNaturalFlowLine('terminate the app');
+    expect(r?.kind === 'closeApp' && r.query).toBeUndefined();
+  });
+  test('"close the dialog" is NOT a closeApp (no app keyword)', () => {
+    const r = tryParseNaturalFlowLine('close the dialog');
+    expect(r?.kind === 'closeApp').toBe(false);
+  });
+});
+
 // ── Navigate ────────────────────────────────────────────────────────
 
 describe('natural-line: navigate', () => {
@@ -78,6 +109,84 @@ describe('natural-line: type', () => {
       expect(result!.text).toBe('appium 3.0');
       expect(result!.target).toBe('search bar');
     }
+  });
+});
+
+// ── Type: field-first "as/to/with" ──────────────────────────────────
+
+describe('natural-line: type field-first', () => {
+  const typed = (input: string) => {
+    const r = tryParseNaturalFlowLine(input);
+    expect(r?.kind).toBe('type');
+    return r as Extract<FlowStep, { kind: 'type' }>;
+  };
+  test('type the <field> as <value>', () => {
+    const r = typed('type the username as appclaw@gmail.com');
+    expect(r.target).toBe('username');
+    expect(r.text).toBe('appclaw@gmail.com');
+  });
+  test('set the <field> to <value>', () => {
+    const r = typed('set the quantity to 5');
+    expect(r.target).toBe('quantity');
+    expect(r.text).toBe('5');
+  });
+  test('fill the <field> with <value>', () => {
+    const r = typed('fill the email with test@x.com');
+    expect(r.target).toBe('email');
+    expect(r.text).toBe('test@x.com');
+  });
+  test('literal text without leading "the" is not split', () => {
+    const r = typed('type save as draft');
+    expect(r.text).toBe('save as draft');
+    expect(r.target).toBeUndefined();
+  });
+});
+
+// ── Proximity qualifiers (tap + type) ────────────────────────────────
+
+describe('natural-line: proximity', () => {
+  test('tap <target> below <anchor>', () => {
+    const r = tryParseNaturalFlowLine('click login button below password field');
+    expect(r?.kind).toBe('tap');
+    if (r?.kind === 'tap') {
+      expect(r.label).toBe('login button');
+      expect(r.proximity).toEqual({ relation: 'below', anchor: 'password field' });
+    }
+  });
+  test.each([
+    ['tap the title above the form', 'above'],
+    ['tap icon under the header', 'below'],
+    ['tap the arrow to the left of the title', 'toLeftOf'],
+    ['tap the icon right of the label', 'toRightOf'],
+    ['tap the checkbox next to Terms', 'near'],
+    ['tap the star beside the rating', 'near'],
+    ['tap the button inside the dialog', 'within'],
+    ['tap login within the form', 'within'],
+  ])('%s → %s', (input, relation) => {
+    const r = tryParseNaturalFlowLine(input);
+    expect(r?.kind === 'tap' && r.proximity?.relation).toBe(relation);
+  });
+  test('anchor strips leading "the"', () => {
+    const r = tryParseNaturalFlowLine('tap the arrow to the left of the title');
+    expect(r?.kind === 'tap' && r.proximity?.anchor).toBe('title');
+  });
+  test('type target carries proximity too', () => {
+    const r = tryParseNaturalFlowLine('enter hi in the field below the header');
+    expect(r?.kind).toBe('type');
+    if (r?.kind === 'type') {
+      expect(r.text).toBe('hi');
+      expect(r.target).toBe('field');
+      expect(r.proximity).toEqual({ relation: 'below', anchor: 'header' });
+    }
+  });
+  test('no false positive: plain tap', () => {
+    const r = tryParseNaturalFlowLine('tap Settings');
+    expect(r?.kind === 'tap' && r.proximity).toBeUndefined();
+  });
+  test('no false positive: relation word with no anchor stays literal', () => {
+    const r = tryParseNaturalFlowLine('tap show more below');
+    expect(r?.kind === 'tap' && r.label).toBe('show more below');
+    expect(r?.kind === 'tap' && r.proximity).toBeUndefined();
   });
 });
 

--- a/tests/flow/proximity.test.ts
+++ b/tests/flow/proximity.test.ts
@@ -1,0 +1,207 @@
+import { describe, test, expect } from 'vitest';
+import {
+  rankBySpatial,
+  resolveEditableForTarget,
+  resolveTapTarget,
+} from '../../src/flow/run-yaml-flow.js';
+import type { UIElement } from '../../src/perception/types.js';
+
+function el(
+  text: string,
+  center: [number, number],
+  size: [number, number],
+  over: Partial<UIElement> = {}
+): UIElement {
+  return {
+    id: '',
+    accessibilityId: '',
+    text,
+    type: '',
+    bounds: '',
+    center,
+    size,
+    clickable: false,
+    editable: false,
+    enabled: true,
+    checked: false,
+    focused: false,
+    selected: false,
+    scrollable: false,
+    longClickable: false,
+    hint: '',
+    action: 'tap',
+    parent: '',
+    depth: 0,
+    platform: 'android',
+    ...over,
+  };
+}
+
+// ── Login-screen layout (device-pixel coords, top-down) ──────────────
+const headerLogin = el('Login', [322, 470], [180, 80], { clickable: true });
+const usernameField = el('username', [430, 700], [760, 120], { editable: true });
+const passwordField = el('Password', [430, 880], [760, 120], { editable: true });
+const orangeLoginBtn = el('LOGIN', [430, 1200], [600, 130], { clickable: true });
+const navLogin = el('Login', [310, 2300], [120, 140], { clickable: true });
+const formCard = el('', [430, 900], [800, 1000]);
+const loginCandidates = [headerLogin, orangeLoginBtn, navLogin];
+
+describe('rankBySpatial: relations', () => {
+  test('below → nearest below first (orange button, not nav)', () => {
+    expect(rankBySpatial(loginCandidates, passwordField, 'below')).toEqual([
+      orangeLoginBtn,
+      navLogin,
+    ]);
+  });
+  test('above → header tab', () => {
+    expect(rankBySpatial(loginCandidates, passwordField, 'above')[0]).toBe(headerLogin);
+  });
+  test('near → closest by bbox distance, far excluded', () => {
+    const r = rankBySpatial([usernameField, orangeLoginBtn, navLogin], passwordField, 'near');
+    expect(r[0]).toBe(usernameField);
+    expect(r).not.toContain(navLogin);
+  });
+  test('within → contained element only', () => {
+    const r = rankBySpatial([orangeLoginBtn, navLogin], formCard, 'within');
+    expect(r).toContain(orangeLoginBtn);
+    expect(r).not.toContain(navLogin);
+  });
+  test('toLeftOf / toRightOf', () => {
+    const a = el('A', [200, 500], [100, 60]);
+    const b = el('B', [600, 500], [100, 60]);
+    expect(rankBySpatial([b], a, 'toRightOf')[0]).toBe(b);
+    expect(rankBySpatial([a], b, 'toLeftOf')[0]).toBe(a);
+    expect(rankBySpatial([b], a, 'toLeftOf')).toHaveLength(0); // wrong side
+  });
+});
+
+describe('rankBySpatial: invariants', () => {
+  test('anchor itself never returned', () => {
+    expect(rankBySpatial([passwordField, orangeLoginBtn], passwordField, 'below')).not.toContain(
+      passwordField
+    );
+  });
+  test('no qualifying candidate → empty', () => {
+    expect(rankBySpatial([orangeLoginBtn, navLogin], headerLogin, 'above')).toHaveLength(0);
+  });
+  test('disabled candidates dropped', () => {
+    const disabled = el('LOGIN', [430, 1200], [600, 130], { enabled: false });
+    expect(rankBySpatial([disabled], passwordField, 'below')).toHaveLength(0);
+  });
+  test('near expands to reach a moderately distant candidate', () => {
+    const anchor = el('a', [100, 100], [20, 20]);
+    const reachable = el('b', [100, 250], [20, 20]); // found only after a few expansions
+    expect(rankBySpatial([reachable], anchor, 'near')[0]).toBe(reachable);
+  });
+  test('near is bounded — does not match across the whole screen', () => {
+    const anchor = el('a', [100, 100], [20, 20]);
+    const tooFar = el('b', [100, 5000], [20, 20]);
+    expect(rankBySpatial([tooFar], anchor, 'near')).toHaveLength(0);
+  });
+});
+
+describe('resolveEditableForTarget', () => {
+  const emailInput = el('', [430, 700], [760, 120], { hint: 'Email', editable: true });
+  const pwdInput = el('', [430, 880], [760, 120], { hint: 'Password', editable: true });
+  const userLabel = el('Username', [120, 600], [200, 40]);
+  const elements = [userLabel, emailInput, pwdInput];
+
+  test('target picks THAT field, not the first editable (latent bug)', () => {
+    expect(resolveEditableForTarget(elements, 'password').el).toBe(pwdInput);
+    expect(resolveEditableForTarget(elements, 'email').el).toBe(emailInput);
+  });
+  test('label-only target → nearest editable', () => {
+    expect(resolveEditableForTarget(elements, 'username').el).toBe(emailInput);
+  });
+  test('no target → first editable', () => {
+    expect(resolveEditableForTarget(elements).el).toBe(emailInput);
+  });
+  test('explicit proximity narrows by anchor', () => {
+    expect(
+      resolveEditableForTarget(elements, undefined, { relation: 'below', anchor: 'username' }).el
+    ).toBe(emailInput);
+  });
+  test('unmatched target → null + reason', () => {
+    const r = resolveEditableForTarget(elements, 'zzz');
+    expect(r.el).toBeNull();
+    expect(r.reason).toBeTruthy();
+  });
+  test('no editable fields → null + reason', () => {
+    const r = resolveEditableForTarget([userLabel], 'username');
+    expect(r.el).toBeNull();
+    expect(r.reason).toMatch(/no editable/i);
+  });
+  test('proximity anchor missing → null + reason', () => {
+    const r = resolveEditableForTarget(elements, undefined, { relation: 'below', anchor: 'nope' });
+    expect(r.el).toBeNull();
+    expect(r.reason).toMatch(/not found/i);
+  });
+});
+
+// Faithful to the WDIO login screen page source (center/size in device px).
+// The help paragraph mentions "login button" and sits CLOSER to the password
+// field than the real submit button — the exact trap that mis-fired before.
+describe('resolveTapTarget: WDIO login screen', () => {
+  const headerToggle = el('button-login-container', [529, 739], [311, 140], {
+    accessibilityId: 'button-login-container',
+    clickable: true,
+  });
+  const passwordInput = el('Password', [789, 1412], [1093, 158], {
+    accessibilityId: 'input-password',
+    hint: 'Password',
+    editable: true,
+    clickable: true,
+  });
+  const biometricsHelp = el(
+    'When the device has Touch/FaceID enabled a biometrics button will be shown to test the login.',
+    [720, 1681],
+    [1300, 180]
+  ); // clickable: false — pure text
+  const orangeLogin = el('button-LOGIN', [721, 1971], [990, 150], {
+    accessibilityId: 'button-LOGIN',
+    clickable: true,
+  });
+  const navLogin = el('Login', [514, 2931], [160, 170], {
+    accessibilityId: 'Login',
+    clickable: true,
+  });
+  const screen = [headerToggle, passwordInput, biometricsHelp, orangeLogin, navLogin];
+
+  test('"login button near password field" → orange submit, not the help paragraph', () => {
+    const r = resolveTapTarget(screen, 'login button', {
+      relation: 'near',
+      anchor: 'password field',
+    });
+    expect(r.el).toBe(orangeLogin);
+  });
+  test('"login button below password field" → orange submit, not nav', () => {
+    const r = resolveTapTarget(screen, 'login button', {
+      relation: 'below',
+      anchor: 'password field',
+    });
+    expect(r.el).toBe(orangeLogin);
+  });
+  test('non-clickable help paragraph is never the spatial pick', () => {
+    const r = resolveTapTarget(screen, 'login button', {
+      relation: 'near',
+      anchor: 'password field',
+    });
+    expect(r.el).not.toBe(biometricsHelp);
+  });
+  test('anchor "password field" resolves and is not returned as the pick', () => {
+    const r = resolveTapTarget(screen, 'login button', {
+      relation: 'near',
+      anchor: 'password field',
+    });
+    expect(r.el).not.toBe(passwordInput);
+  });
+});
+
+describe('resolveEditableForTarget: iOS elements', () => {
+  // Parser fills the same fields cross-platform; resolver is platform-agnostic.
+  const f1 = el('', [400, 600], [700, 110], { hint: 'Email', editable: true, platform: 'ios' });
+  const f2 = el('', [400, 760], [700, 110], { hint: 'Password', editable: true, platform: 'ios' });
+  test('targets the password field on iOS too', () => {
+    expect(resolveEditableForTarget([f1, f2], 'password').el).toBe(f2);
+  });
+});


### PR DESCRIPTION
This pull request introduces significant improvements to the documentation and user guides, especially around "Proximity Selectors" and app management commands, and updates the landing page's typefaces and SDK dependencies. The main changes are grouped below.

---

**New Features and Documentation:**

* Added comprehensive documentation and UI sections for "Proximity Selectors" to both `landing/index.html` and `landing/usage.html`, explaining how to target UI elements by their spatial relationship to others. This includes new examples, a command reference, and a dedicated navigation link. [[1]](diffhunk://#diff-e96b748cf2f0f1f9095d43f2376aa8b671367d15278726144bcc04344fe619d3R2061-R2119) [[2]](diffhunk://#diff-e96b748cf2f0f1f9095d43f2376aa8b671367d15278726144bcc04344fe619d3R2432) [[3]](diffhunk://#diff-04ffc0e9bf3f5c73930bc9059c28eaaf68d8bcbd78b4fbc2164f1564ce41ab48R1325-R1327) [[4]](diffhunk://#diff-04ffc0e9bf3f5c73930bc9059c28eaaf68d8bcbd78b4fbc2164f1564ce41ab48R2006-R2086)
* Added a new "Open / Close App" section to the usage guide, with examples and clarifications on how app launching and termination commands work. Also added `closeApp` to the command reference table. [[1]](diffhunk://#diff-04ffc0e9bf3f5c73930bc9059c28eaaf68d8bcbd78b4fbc2164f1564ce41ab48R1923-R1966) [[2]](diffhunk://#diff-04ffc0e9bf3f5c73930bc9059c28eaaf68d8bcbd78b4fbc2164f1564ce41ab48R2382-R2386)

**UI and Content Updates:**

* Changed the display and body fonts on the landing and usage pages to use monospaced fonts (`Menlo`, `SF Mono`, `JetBrains Mono`), for improved consistency and readability. [[1]](diffhunk://#diff-e96b748cf2f0f1f9095d43f2376aa8b671367d15278726144bcc04344fe619d3L68-R68) [[2]](diffhunk://#diff-04ffc0e9bf3f5c73930bc9059c28eaaf68d8bcbd78b4fbc2164f1564ce41ab48L73-R75)
* Minor content and formatting improvements in the capabilities and options reference sections, including clarifications, paragraph breaks, and improved readability. [[1]](diffhunk://#diff-04ffc0e9bf3f5c73930bc9059c28eaaf68d8bcbd78b4fbc2164f1564ce41ab48L2452-R2593) [[2]](diffhunk://#diff-04ffc0e9bf3f5c73930bc9059c28eaaf68d8bcbd78b4fbc2164f1564ce41ab48L2596-R2728) [[3]](diffhunk://#diff-04ffc0e9bf3f5c73930bc9059c28eaaf68d8bcbd78b4fbc2164f1564ce41ab48L2611-R2752) [[4]](diffhunk://#diff-04ffc0e9bf3f5c73930bc9059c28eaaf68d8bcbd78b4fbc2164f1564ce41ab48L2637-R2771) [[5]](diffhunk://#diff-04ffc0e9bf3f5c73930bc9059c28eaaf68d8bcbd78b4fbc2164f1564ce41ab48L2671-R2819) [[6]](diffhunk://#diff-04ffc0e9bf3f5c73930bc9059c28eaaf68d8bcbd78b4fbc2164f1564ce41ab48L2701-R2836) [[7]](diffhunk://#diff-04ffc0e9bf3f5c73930bc9059c28eaaf68d8bcbd78b4fbc2164f1564ce41ab48L2711-R2846) [[8]](diffhunk://#diff-04ffc0e9bf3f5c73930bc9059c28eaaf68d8bcbd78b4fbc2164f1564ce41ab48L3699-R3835)

**Dependency Updates:**

* Updated `@ai-sdk/anthropic` and `@ai-sdk/openai` dependencies in `package.json` from `^1.0.0` to `^3.0.0`.

**Codebase Maintenance:**

* In `src/agent/app-resolver.ts`, stored the `MCPClient` instance in the `AppResolver` class to allow for re-fetching the device app list after initialization, improving robustness in app resolution.

---

These changes enhance the clarity and discoverability of advanced features, improve the user experience, and keep dependencies up to date.