### PR TITLE
fix: cloud execution

### DIFF
--- a/.github/workflows/runner-e2e-lambdatest.yml
+++ b/.github/workflows/runner-e2e-lambdatest.yml
@@ -48,8 +48,8 @@ jobs:
       # are inline in examples/runner/appclaw.config.ts under `lt:options` —
       # change device/OS by editing that file, not by adding secrets.
       CLOUD_PROVIDER: lambdatest
-      CLOUD_USERNAME: ${{ secrets.LT_USERNAME }}
-      CLOUD_ACCESS_KEY: ${{ secrets.LT_ACCESS_KEY }}
+      CLOUD_USERNAME: ${{ secrets.CLOUD_USERNAME }}
+      CLOUD_ACCESS_KEY: ${{ secrets.CLOUD_ACCESS_KEY }}
       CLOUD_BUILD_NAME: appclaw-runner-${{ github.run_id }}
       CLOUD_PROJECT_NAME: AppClaw Runner E2E
 
@@ -79,13 +79,13 @@ jobs:
           npm link appclaw
 
       # ── Sanity-check the cloud creds are wired ───────────────────────────
-      - name: Verify LambdaTest secrets
+      - name: Verify cloud secrets
         run: |
           missing=()
-          [ -n "${CLOUD_USERNAME}" ]   || missing+=("LT_USERNAME")
-          [ -n "${CLOUD_ACCESS_KEY}" ] || missing+=("LT_ACCESS_KEY")
+          [ -n "${CLOUD_USERNAME}" ]   || missing+=("CLOUD_USERNAME")
+          [ -n "${CLOUD_ACCESS_KEY}" ] || missing+=("CLOUD_ACCESS_KEY")
           if [ ${#missing[@]} -ne 0 ]; then
-            echo "::error title=Missing LambdaTest secrets::${missing[*]}"
+            echo "::error title=Missing cloud secrets::${missing[*]}"
             exit 1
           fi
 

--- a/.github/workflows/runner-e2e-lambdatest.yml
+++ b/.github/workflows/runner-e2e-lambdatest.yml
@@ -1,0 +1,105 @@
+name: Runner E2E (LambdaTest cloud)
+
+# End-to-end test of the runner against LambdaTest's real device cloud
+# (examples/runner/tests/lambdatest-cloud.spec.ts). No local emulator is
+# needed — the runner synthesizes a single-device pool from CLOUD_DEVICE_NAME
+# and the SDK routes the Appium session to LambdaTest via the local appium-mcp
+# node (CLOUD_PROVIDER=lambdatest → remoteServerUrl).
+#
+# Runs on demand and when the runner, the cloud path, or the spec/config changes.
+
+on:
+  workflow_dispatch:
+    inputs:
+      provider:
+        description: 'LLM provider'
+        required: false
+        default: 'gemini'
+      model:
+        description: 'LLM model ID (blank = provider default)'
+        required: false
+        default: ''
+  pull_request:
+    paths:
+      - 'src/runner/**'
+      - 'src/device/cloud.ts'
+      - 'src/device/session.ts'
+      - 'src/sdk/**'
+      - 'examples/runner/**'
+      - '.github/workflows/runner-e2e-lambdatest.yml'
+
+concurrency:
+  group: runner-e2e-lambdatest-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lambdatest:
+    name: Runner — LambdaTest cloud
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    env:
+      LLM_PROVIDER: ${{ github.event.inputs.provider || 'gemini' }}
+      LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+      LLM_MODEL: ${{ github.event.inputs.model }}
+
+      # ── LambdaTest routing ────────────────────────────────────────────────
+      # Only creds + provider live in env. The device, OS version, and app id
+      # are inline in examples/runner/appclaw.config.ts under `lt:options` —
+      # change device/OS by editing that file, not by adding secrets.
+      CLOUD_PROVIDER: lambdatest
+      CLOUD_USERNAME: ${{ secrets.LT_USERNAME }}
+      CLOUD_ACCESS_KEY: ${{ secrets.LT_ACCESS_KEY }}
+      CLOUD_BUILD_NAME: appclaw-runner-${{ github.run_id }}
+      CLOUD_PROJECT_NAME: AppClaw Runner E2E
+
+      PLATFORM: android
+      # Plain reporter (no TUI dashboard) for readable CI logs.
+      APPCLAW_TUI: 'off'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+
+      # ── Build the local AppClaw and expose it as a global `appclaw` ──────
+      - name: Build & link AppClaw
+        run: |
+          npm ci
+          npm run build
+          npm link
+
+      - name: Install example deps & link AppClaw
+        working-directory: examples/runner
+        run: |
+          npm install
+          npm link appclaw
+
+      # ── Sanity-check the cloud creds are wired ───────────────────────────
+      - name: Verify LambdaTest secrets
+        run: |
+          missing=()
+          [ -n "${CLOUD_USERNAME}" ]   || missing+=("LT_USERNAME")
+          [ -n "${CLOUD_ACCESS_KEY}" ] || missing+=("LT_ACCESS_KEY")
+          if [ ${#missing[@]} -ne 0 ]; then
+            echo "::error title=Missing LambdaTest secrets::${missing[*]}"
+            exit 1
+          fi
+
+      # ── Run the cloud spec ───────────────────────────────────────────────
+      # One worker: the synthetic pool has exactly one cloud device. Retries
+      # help absorb hub-side flakiness (queue waits, session startup timeouts).
+      - name: Run LambdaTest cloud spec
+        working-directory: examples/runner
+        run: appclaw test tests/lambdatest-cloud.spec.ts --workers 1 --retries 1 --reporter plain
+
+      - name: Upload runner report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: runner-report-lambdatest
+          path: examples/runner/.appclaw/runs/
+          if-no-files-found: ignore

--- a/README.md
+++ b/README.md
@@ -117,6 +117,53 @@ PLATFORM=ios DEVICE_TYPE=simulator appclaw "Open Settings"
 
 > **Tip:** If only one simulator is booted, it's auto-selected — no `--udid` needed.
 
+### Cloud devices
+
+Run against a remote Appium grid — BrowserStack, Sauce Labs, LambdaTest, or any
+self-hosted grid — instead of a local device. Set `CLOUD_PROVIDER` and the
+`CLOUD_*` creds; AppClaw builds the hub URL, skips local device discovery, and
+routes the session to the grid. `appclaw init` can prompt for these and write
+them to `.env.example`.
+
+```bash
+# .env — BrowserStack
+CLOUD_PROVIDER=browserstack
+CLOUD_USERNAME=your-user
+CLOUD_ACCESS_KEY=your-key
+CLOUD_DEVICE_NAME=Google Pixel 8
+CLOUD_OS_VERSION=14
+CLOUD_APP=bs://<hashed-app-id>        # optional; app to install
+
+# Sauce Labs (region defaults to us-west-1; override with CLOUD_REGION)
+CLOUD_PROVIDER=saucelabs
+CLOUD_USERNAME=your-user
+CLOUD_ACCESS_KEY=your-key
+CLOUD_DEVICE_NAME=iPhone 14
+CLOUD_OS_VERSION=16
+
+# Self-hosted grid — bring your own hub URL (auth may be embedded)
+CLOUD_PROVIDER=custom
+CLOUD_SERVER_URL=https://user:key@grid.internal:4444/wd/hub
+CLOUD_DEVICE_NAME=Pixel_7
+CLOUD_OS_VERSION=14
+```
+
+AppClaw sets only the essentials (`platformName`, `appium:automationName`,
+device, OS, app). **Provider-specific options** — `bstack:options`,
+`sauce:options`, `lt:options`, real-vs-emulator flags, video, network logs — go
+in a capabilities file passed via `--caps` (or `CAPABILITIES_FILE` / the SDK
+`capabilitiesFile` option), which is merged on top and wins:
+
+```json
+// caps.json  →  appclaw --flow login.yaml --caps caps.json
+{
+  "bstack:options": { "projectName": "AppClaw", "buildName": "smoke", "networkLogs": true }
+}
+```
+
+`CLOUD_BUILD_NAME` / `CLOUD_PROJECT_NAME` are convenience shortcuts mapped into
+the active provider's namespace, so common dashboard labels don't need a caps file.
+
 ### Agent mode (LLM-driven)
 
 ```bash
@@ -495,6 +542,17 @@ All configuration is via `.env`:
 | **Output**            |                    |                                                                                                                                                                          |
 | `EXPORT_DIR`          | `.appclaw/exports` | Default directory for `--export` and `/export *.test.ts`. Bare filenames land here; paths with a directory hint are used verbatim. Override per-run with `--export-dir`. |
 | `MCP_DEBUG`           | `0`                | Stream verbose `[appium-mcp]` subprocess logs and per-tool timing. SDK can override via `mcpDebug` option.                                                               |
+| **Cloud devices**     |                    | See [Cloud devices](#cloud-devices) below                                                                                                                                |
+| `CLOUD_PROVIDER`      | (local)            | `browserstack`, `saucelabs`, `lambdatest`, or `custom`. Empty = local device.                                                                                            |
+| `CLOUD_USERNAME`      | —                  | Cloud account username (not required for `custom` when auth is in `CLOUD_SERVER_URL`)                                                                                    |
+| `CLOUD_ACCESS_KEY`    | —                  | Cloud access key / token                                                                                                                                                 |
+| `CLOUD_DEVICE_NAME`   | —                  | Remote device name, e.g. `Samsung Galaxy S24`, `iPhone 14`                                                                                                               |
+| `CLOUD_OS_VERSION`    | —                  | Remote OS version, e.g. `14`, `16`                                                                                                                                       |
+| `CLOUD_APP`           | —                  | App to install (provider-specific: `bs://…`, `lt://…`, `storage:…`, or an HTTP URL). Passed as `appium:app`.                                                             |
+| `CLOUD_BUILD_NAME`    | —                  | Dashboard build label — mapped into the provider's options namespace                                                                                                     |
+| `CLOUD_PROJECT_NAME`  | —                  | Dashboard project label                                                                                                                                                  |
+| `CLOUD_REGION`        | `us-west-1`        | Data-center region for Sauce Labs (ignored by other providers)                                                                                                           |
+| `CLOUD_SERVER_URL`    | (built-in)         | Full hub URL. **Required** for `CLOUD_PROVIDER=custom`; optional override for known providers. May embed `user:key@` auth.                                               |
 
 ## How It Works
 

--- a/examples/runner/README.md
+++ b/examples/runner/README.md
@@ -61,7 +61,28 @@ npm run test:login                # one file
 `appclaw test` auto-discovers `appclaw.config.ts` in the working directory and
 runs the specs in `testDir`. You can also call the binary directly
 (`npx appclaw test ...`) with the same flags: `--workers`, `--retries`,
-`--grep`, `--shard 1/2`, etc.
+`--grep`, `--shard 1/2`, `--ignore <pattern>`, etc.
+
+### Excluding specs from a run
+
+Some specs shouldn't be part of every run — here `lambdatest-cloud.spec.ts`
+needs cloud credentials and a provider hub. Two ways to leave specs out:
+
+- **Config (`testIgnore`)** — patterns excluded at discovery. This example
+  ignores the cloud spec unless `CLOUD_PROVIDER` is set, so plain
+  `appclaw test` (local emulators) never picks it up while the cloud CI —
+  which sets `CLOUD_PROVIDER` — runs it as usual:
+
+  ```ts
+  testIgnore: isCloud ? [] : ['**/lambdatest-cloud.spec.ts'],
+  ```
+
+- **CLI (`--ignore`)** — one-off exclusions, repeatable, stacked on top of the
+  config's `testIgnore`:
+
+  ```bash
+  appclaw test --ignore lambdatest-cloud --ignore fixtures-demo
+  ```
 
 ### Live view
 

--- a/examples/runner/appclaw.config.ts
+++ b/examples/runner/appclaw.config.ts
@@ -5,7 +5,9 @@ export default defineConfig({
   testDir: 'tests',
   concurrency: 'auto',
   retries: 1,
-  node: { local: true }, // spawn a local appium-mcp SSE server url: 'http://localhost:8080'
+  node: {
+    url: "https://57c0-49-206-52-37.ngrok-free.app/sse"
+  }, // spawn a local appium-mcp SSE server url: 'http://localhost:8080'
 
   // ── AppClaw options (forwarded to every test's session) ──
   platform: 'android',

--- a/examples/runner/appclaw.config.ts
+++ b/examples/runner/appclaw.config.ts
@@ -24,10 +24,12 @@ function cloudOptionsCaps(): Record<string, unknown> {
           isRealMobile: true,
           deviceName: 'Pixel 4a',
           platformVersion: '12',
-          app: 'lt://APP10160431111775634745871487',
+          // App ids go stale when the upload expires or is deleted on the hub —
+          // re-upload and set CLOUD_APP to override without a code change.
+          app: process.env.CLOUD_APP ?? 'lt://APP10160371691782901740218341',
           build,
           project,
-          name: 'AppClaw Runner'
+          name: 'AppClaw Runner',
         },
       };
     case 'browserstack':
@@ -62,6 +64,11 @@ function cloudOptionsCaps(): Record<string, unknown> {
 export default defineConfig({
   video: true,
   testDir: 'tests',
+  // Cloud specs need a provider hub — leave them out of a local run's
+  // discovery (`appclaw test` with no CLOUD_PROVIDER set). The cloud CI sets
+  // CLOUD_PROVIDER, so there the spec is discovered as usual. One-off
+  // exclusions also work from the CLI: `appclaw test --ignore <pattern>`.
+  testIgnore: isCloud ? [] : ['**/lambdatest-cloud.spec.ts'],
   concurrency: 'auto',
   retries: 1,
   // Local appium-mcp SSE node either way. In cloud mode the local node still

--- a/examples/runner/appclaw.config.ts
+++ b/examples/runner/appclaw.config.ts
@@ -1,26 +1,97 @@
 import { defineConfig, TestContext } from 'appclaw/runner';
 
+// Cloud mode is picked purely by env: set CLOUD_PROVIDER (lambdatest, browserstack,
+// saucelabs, custom) and the corresponding CLOUD_USERNAME / CLOUD_ACCESS_KEY /
+// CLOUD_DEVICE_NAME / CLOUD_OS_VERSION / CLOUD_APP vars. Everything else in this
+// file stays the same for local vs cloud.
+const cloudProvider = process.env.CLOUD_PROVIDER?.trim();
+const isCloud = !!cloudProvider;
+
+/**
+ * Provider-specific caps for a cloud run. Everything the grid needs — device,
+ * OS version, app, and the dashboard-facing bits — lives right here, keyed by
+ * provider. Change the device or bump the OS version in this file, not in a
+ * separate JSON or a wall of env vars.
+ */
+function cloudOptionsCaps(): Record<string, unknown> {
+  const build = process.env.CLOUD_BUILD_NAME ?? 'AppClaw';
+  const project = process.env.CLOUD_PROJECT_NAME ?? 'AppClaw Runner';
+  switch (cloudProvider) {
+    case 'lambdatest':
+      return {
+        'lt:options': {
+          w3c: true,
+          isRealMobile: true,
+          deviceName: 'Samsung Galaxy S24',
+          platformVersion: '14',
+          app: 'lt://APP10160431111775634745871487',
+          build,
+          project,
+          name: 'AppClaw Runner',
+          video: true,
+          network: false,
+        },
+      };
+    case 'browserstack':
+      return {
+        'bstack:options': {
+          deviceName: 'Samsung Galaxy S24',
+          osVersion: '14',
+          app: 'bs://<hashed-app-id>',
+          buildName: build,
+          projectName: project,
+          sessionName: 'AppClaw Runner',
+          debug: true,
+        },
+      };
+    case 'saucelabs':
+      return {
+        'sauce:options': {
+          deviceName: 'Samsung Galaxy S24',
+          platformVersion: '14',
+          app: 'storage:filename=app.apk',
+          build,
+          name: 'AppClaw Runner',
+        },
+      };
+    default:
+      // 'custom' or an unknown provider — no namespace to inject. Users can still
+      // pass grid-specific caps via CAPABILITIES_FILE / APPCLAW_CAPS.
+      return {};
+  }
+}
+
 export default defineConfig({
   video: true,
   testDir: 'tests',
   concurrency: 'auto',
   retries: 1,
-  node: {
-    local: true,
-  }, // spawn a local appium-mcp SSE server url: 'http://localhost:8080'
+  // Local appium-mcp SSE node either way. In cloud mode the local node still
+  // handles the WebDriver client — it forwards the session to the provider hub
+  // via `remoteServerUrl` (built from CLOUD_PROVIDER + CLOUD_* env).
+  node: { local: true },
 
   // ── AppClaw options (forwarded to every test's session) ──
-  platform: 'android',
+  // Platform: PLATFORM env wins, else Android by default.
+  platform: (process.env.PLATFORM as 'android' | 'ios') ?? 'android',
   provider: process.env.LLM_PROVIDER as any,
   apiKey: process.env.LLM_API_KEY,
   model: process.env.LLM_MODEL,
-  capabilitiesFile: process.env.APPCLAW_CAPS ?? './tests/caps.json', // resolved relative to this config file (CI overrides via APPCLAW_CAPS)
+
+  // Caps: cloud inlines the provider-options namespace; local reads caps.json.
+  // APPCLAW_CAPS (env or CI) overrides the local file — set it in cloud too
+  // when you want a per-stage file to stack on top of the inline baseline.
+  ...(isCloud
+    ? { capabilities: cloudOptionsCaps() }
+    : { capabilitiesFile: process.env.APPCLAW_CAPS ?? './tests/caps.json' }),
+
   // any other AppClawOptions also work here, e.g.:
-  // agentMode: 'vision', maxSteps: 40, waitTimeout: 15000, video: true,
+  // agentMode: 'vision', maxSteps: 40, waitTimeout: 15000,
 
   // ── run-scoped (once per run, in the control plane) ──
   globalSetup: async ({ pool }) => {
-    console.log(`[globalSetup] pool has ${pool.length} device(s)`);
+    const where = isCloud ? `cloud · ${cloudProvider}` : 'local';
+    console.log(`[globalSetup] ${where} · pool has ${pool.length} device(s)`);
     return { startedAt: Date.now(), seededUser: 'admin' }; // injected into every test as ctx.state
   },
   globalTeardown: async ({ state }) => {

--- a/examples/runner/appclaw.config.ts
+++ b/examples/runner/appclaw.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   concurrency: 'auto',
   retries: 1,
   node: {
-    url: "https://57c0-49-206-52-37.ngrok-free.app/sse"
+    url: 'https://57c0-49-206-52-37.ngrok-free.app/sse',
   }, // spawn a local appium-mcp SSE server url: 'http://localhost:8080'
 
   // ── AppClaw options (forwarded to every test's session) ──

--- a/examples/runner/appclaw.config.ts
+++ b/examples/runner/appclaw.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   concurrency: 'auto',
   retries: 1,
   node: {
-    url: 'https://57c0-49-206-52-37.ngrok-free.app/sse',
+    local: true,
   }, // spawn a local appium-mcp SSE server url: 'http://localhost:8080'
 
   // ── AppClaw options (forwarded to every test's session) ──

--- a/examples/runner/appclaw.config.ts
+++ b/examples/runner/appclaw.config.ts
@@ -22,14 +22,12 @@ function cloudOptionsCaps(): Record<string, unknown> {
         'lt:options': {
           w3c: true,
           isRealMobile: true,
-          deviceName: 'Samsung Galaxy S24',
-          platformVersion: '14',
+          deviceName: 'Pixel 4a',
+          platformVersion: '12',
           app: 'lt://APP10160431111775634745871487',
           build,
           project,
-          name: 'AppClaw Runner',
-          video: true,
-          network: false,
+          name: 'AppClaw Runner'
         },
       };
     case 'browserstack':

--- a/examples/runner/lt-caps.json
+++ b/examples/runner/lt-caps.json
@@ -1,0 +1,12 @@
+{
+  "lt:options": {
+    "w3c": true,
+    "platformName": "android",
+    "deviceName": "Realme GT2 Pro",
+    "platformVersion": "12",
+    "app": "lt://APP10160371691782901740218341",
+    "build": "Appclaw",
+    "name": "AppclawIntro",
+    "isRealMobile": true
+  }
+}

--- a/examples/runner/package.json
+++ b/examples/runner/package.json
@@ -11,7 +11,7 @@
     "test:ci": "appclaw test --env-file ../../.env --workers 2 --retries 1 --shard 1/1"
   },
   "devDependencies": {
-    "appclaw": "^1.8.0",
+    "appclaw": "^1.9.1",
     "tsx": "^4.21.0"
   }
 }

--- a/examples/runner/tests/caps.json
+++ b/examples/runner/tests/caps.json
@@ -1,7 +1,8 @@
 {
   "android": {
-    "appium:app": "/Users/saikrishna/Documents/git/appium-demo/VodQA.apk",
+    "appium:app": "https://github.com/AppiumTestDistribution/appium-demo/raw/refs/heads/main/VodQA.apk",
     "appium:automationName": "UiAutomator2",
-    "appium:autoGrantPermissions": true
+    "appium:autoGrantPermissions": true,
+    "appium:mjpegServerPort": 0
   }
 }

--- a/examples/runner/tests/lambdatest-cloud.spec.ts
+++ b/examples/runner/tests/lambdatest-cloud.spec.ts
@@ -1,0 +1,54 @@
+/**
+ * LambdaTest cloud e2e — SDK on a remote device.
+ *
+ * Runs the same natural-language SDK API (`app.run` / `app.verify`) as the
+ * local specs, but against a LambdaTest-uploaded VodQA build. The whole
+ * stack — provider hub, WDA/Appium, appium-mcp routing — is exercised end
+ * to end. Specs stay platform- and provider-agnostic; the wiring lives in
+ * `.env` and `lt-caps.json`.
+ *
+ * How to run
+ * ----------
+ *   # From examples/runner — creds + provider come from .env:
+ *   CLOUD_PROVIDER=lambdatest
+ *   CLOUD_USERNAME=your_username
+ *   CLOUD_ACCESS_KEY=your_access_key
+ *
+ *   npx appclaw test tests/lambdatest-cloud.spec.ts --env-file ../../.env
+ *
+ * Device / OS version / app id live inline in `appclaw.config.ts` under
+ * `lt:options` — no separate `lt-caps.json` needed. Point `capabilitiesFile`
+ * at a JSON file only when you need per-stage overrides on top of the
+ * inline baseline.
+ *
+ * Note: the runner still discovers a device pool via the local appium-mcp
+ * SSE node — cloud-aware pool discovery is not wired yet. Keep one Android
+ * emulator/device connected so the runner has something to hand out; in
+ * cloud mode the SDK ignores that udid and drives the LambdaTest device
+ * pinned by `CLOUD_DEVICE_NAME` + `CLOUD_OS_VERSION`.
+ */
+
+import { afterAll, beforeAll, describe } from 'appclaw/runner';
+import { test } from './fixtures.js';
+import { tapLogin } from './steps.js';
+
+describe('LambdaTest cloud · VodQA', () => {
+  beforeAll(async () => {
+    console.log('[cloud] suite starting — hub: mobile-hub.lambdatest.com');
+  });
+  afterAll(async () => {
+    console.log('[cloud] suite finished');
+  });
+
+  test('login screen reaches the demo list', async ({ app, device }) => {
+    console.log(`[cloud] running on ${device.name} (${device.platform})`);
+    await tapLogin(app);
+    await app.verify('the demo list is visible');
+  });
+
+  test('slider drags to reveal two green dots', async ({ loggedInApp }) => {
+    await loggedInApp.run('Click on slider');
+    await loggedInApp.run('Drag the slider fully to the right');
+    await loggedInApp.verify('two green dots are visible');
+  });
+});

--- a/landing/public/usage.html
+++ b/landing/public/usage.html
@@ -2944,8 +2944,8 @@
           <p>
             Run AppClaw on real iOS and Android devices in the cloud — no local device or emulator
             required. AppClaw ships built-in support for
-            <a href="https://www.lambdatest.com/" target="_blank">TestMuAI (formerly LambdaTest)</a>,
-            <a href="https://saucelabs.com/" target="_blank">Sauce Labs</a>, and
+            <a href="https://www.lambdatest.com/" target="_blank">TestMuAI (formerly LambdaTest)</a
+            >, <a href="https://saucelabs.com/" target="_blank">Sauce Labs</a>, and
             <a href="https://www.browserstack.com/" target="_blank">BrowserStack</a>, plus a
             <code>custom</code> mode that points at any Appium-compatible hub (self-hosted grids,
             device farms, Selenium Grid).
@@ -2956,8 +2956,8 @@
             <code>CLOUD_PROVIDER</code>, then supply credentials, target device, and app through the
             same <code>CLOUD_*</code> variables. Provider-specific dashboard options
             (<code>bstack:options</code>, <code>sauce:options</code>, <code>lt:options</code>) go
-            through <a href="#custom-capabilities">CAPABILITIES_FILE</a> — AppClaw doesn't wrap
-            them individually.
+            through <a href="#custom-capabilities">CAPABILITIES_FILE</a> — AppClaw doesn't wrap them
+            individually.
           </p>
 
           <h3>Quick reference</h3>
@@ -2972,7 +2972,10 @@
             </thead>
             <tbody>
               <tr>
-                <td>TestMuAI <span style="color: var(--muted); font-size: 0.9em;">(formerly LambdaTest)</span></td>
+                <td>
+                  TestMuAI
+                  <span style="color: var(--muted); font-size: 0.9em">(formerly LambdaTest)</span>
+                </td>
                 <td><code>lambdatest</code></td>
                 <td><code>mobile-hub.lambdatest.com/wd/hub</code></td>
                 <td><code>lt:options</code></td>
@@ -2998,7 +3001,12 @@
             </tbody>
           </table>
 
-          <h3 id="cloud-testmuai">TestMuAI <span style="color: var(--muted); font-weight: normal; font-size: 0.85em;">(formerly LambdaTest)</span></h3>
+          <h3 id="cloud-testmuai">
+            TestMuAI
+            <span style="color: var(--muted); font-weight: normal; font-size: 0.85em"
+              >(formerly LambdaTest)</span
+            >
+          </h3>
           <p>
             Example <code>.env</code> for the TestMuAI hub. Sauce Labs and BrowserStack use the same
             <code>CLOUD_*</code> variables — swap <code>CLOUD_PROVIDER</code> to
@@ -3063,10 +3071,10 @@ CLOUD_APP=https://storage.example.com/builds/app.apk</pre>
           <div class="callout callout-tip">
             <div class="callout-title">Overriding a known provider's hub</div>
             <p>
-              For BrowserStack / Sauce / LambdaTest you can override the built-in hub URL by
-              setting <code>CLOUD_SERVER_URL</code> — useful for private endpoints, regional
-              overrides, or Sauce datacenters not covered by <code>CLOUD_REGION</code>. Credentials
-              are still injected from <code>CLOUD_USERNAME</code> and <code>CLOUD_ACCESS_KEY</code>
+              For BrowserStack / Sauce / LambdaTest you can override the built-in hub URL by setting
+              <code>CLOUD_SERVER_URL</code> — useful for private endpoints, regional overrides, or
+              Sauce datacenters not covered by <code>CLOUD_REGION</code>. Credentials are still
+              injected from <code>CLOUD_USERNAME</code> and <code>CLOUD_ACCESS_KEY</code>
               unless the URL already carries basic auth.
             </p>
           </div>
@@ -3075,9 +3083,10 @@ CLOUD_APP=https://storage.example.com/builds/app.apk</pre>
           <p>
             AppClaw maps <code>CLOUD_BUILD_NAME</code> and <code>CLOUD_PROJECT_NAME</code> into the
             active provider's options namespace as a convenience (for BrowserStack it aliases both
-            <code>buildName</code>/<code>projectName</code> and <code>build</code>/<code>project</code>).
-            Everything else — video recording, network logs, tunneling, geo-location, project
-            capacity — goes through a <a href="#custom-capabilities">capabilities file</a>:
+            <code>buildName</code>/<code>projectName</code> and
+            <code>build</code>/<code>project</code>). Everything else — video recording, network
+            logs, tunneling, geo-location, project capacity — goes through a
+            <a href="#custom-capabilities">capabilities file</a>:
           </p>
 
           <div class="code-block">
@@ -3195,9 +3204,10 @@ appclaw --flow flows/checkout.yaml</pre>
                 <td>CLOUD_APP</td>
                 <td>No</td>
                 <td>
-                  App identifier — <code>bs://…</code> (BrowserStack), <code>storage:filename=…</code>
-                  or <code>https://…</code> (Sauce), <code>lt://APP…</code> (LambdaTest), or any URL
-                  the custom grid understands. Sent as <code>appium:app</code>.
+                  App identifier — <code>bs://…</code> (BrowserStack),
+                  <code>storage:filename=…</code> or <code>https://…</code> (Sauce),
+                  <code>lt://APP…</code> (LambdaTest), or any URL the custom grid understands. Sent
+                  as <code>appium:app</code>.
                 </td>
               </tr>
               <tr>
@@ -3229,9 +3239,10 @@ appclaw --flow flows/checkout.yaml</pre>
               </tr>
             </tbody>
           </table>
-          <p style="font-size: 0.9em; margin-top: 0.5em;">
+          <p style="font-size: 0.9em; margin-top: 0.5em">
             <sup>1</sup> Not strictly required for <code>custom</code> when the credentials are
-            embedded in <code>CLOUD_SERVER_URL</code> (<code>https://user:key@host/wd/hub</code>).<br />
+            embedded in
+            <code>CLOUD_SERVER_URL</code> (<code>https://user:key@host/wd/hub</code>).<br />
             <sup>2</sup> Required for <code>CLOUD_PROVIDER=custom</code>; optional otherwise.
           </p>
 

--- a/landing/public/usage.html
+++ b/landing/public/usage.html
@@ -1426,7 +1426,7 @@
 
         <div class="sidebar-group">
           <button class="sidebar-heading" aria-expanded="false">
-            LambdaTest Cloud
+            Cloud Providers
             <svg
               class="sidebar-chevron"
               viewBox="0 0 24 24"
@@ -1438,7 +1438,10 @@
             </svg>
           </button>
           <ul>
-            <li><a href="#lambdatest">Overview</a></li>
+            <li><a href="#cloud">Overview</a></li>
+            <li><a href="#cloud-testmuai">TestMuAI</a></li>
+            <li><a href="#cloud-custom">Custom / self-hosted</a></li>
+            <li><a href="#cloud-env-vars">Environment variables</a></li>
           </ul>
         </div>
 
@@ -2786,6 +2789,13 @@
               </tr>
             </tbody>
           </table>
+
+          <h3>Cloud Providers</h3>
+          <p>
+            Set <code>CLOUD_PROVIDER=browserstack | saucelabs | lambdatest | custom</code> to route
+            sessions through a remote hub instead of a local device. Full variable reference:
+            <a href="#cloud-env-vars">Cloud Providers → Environment variables</a>.
+          </p>
         </section>
 
         <!-- ============================================ -->
@@ -2918,54 +2928,184 @@
               errors at session creation.
             </li>
             <li>
-              <strong>LambdaTest:</strong> capabilities from this file are merged into the
-              LambdaTest session too, so cloud runs share the same configuration as local.
+              <strong>Cloud runs:</strong> capabilities from this file are merged into the remote
+              session too, including provider-specific namespaces like <code>bstack:options</code>,
+              <code>sauce:options</code>, or <code>lt:options</code>.
             </li>
           </ul>
         </section>
 
         <!-- ============================================ -->
-        <!-- LAMBDATEST                                   -->
+        <!-- CLOUD PROVIDERS                              -->
         <!-- ============================================ -->
 
-        <section id="lambdatest" class="reveal">
-          <h2>LambdaTest Cloud</h2>
+        <section id="cloud" class="reveal">
+          <h2>Cloud Providers</h2>
           <p>
-            Run AppClaw tests on real iOS and Android devices in the cloud — no local device or
-            emulator required. AppClaw integrates with
-            <a href="https://www.lambdatest.com/" target="_blank">LambdaTest</a>'s real device cloud
-            via its Appium-compatible hub.
+            Run AppClaw on real iOS and Android devices in the cloud — no local device or emulator
+            required. AppClaw ships built-in support for
+            <a href="https://www.lambdatest.com/" target="_blank">TestMuAI (formerly LambdaTest)</a>,
+            <a href="https://saucelabs.com/" target="_blank">Sauce Labs</a>, and
+            <a href="https://www.browserstack.com/" target="_blank">BrowserStack</a>, plus a
+            <code>custom</code> mode that points at any Appium-compatible hub (self-hosted grids,
+            device farms, Selenium Grid).
           </p>
 
-          <h3>Setup</h3>
-          <p>Add your LambdaTest credentials and target device to <code>.env</code>:</p>
+          <p>
+            Configuration is generic across providers: pick one via
+            <code>CLOUD_PROVIDER</code>, then supply credentials, target device, and app through the
+            same <code>CLOUD_*</code> variables. Provider-specific dashboard options
+            (<code>bstack:options</code>, <code>sauce:options</code>, <code>lt:options</code>) go
+            through <a href="#custom-capabilities">CAPABILITIES_FILE</a> — AppClaw doesn't wrap
+            them individually.
+          </p>
+
+          <h3>Quick reference</h3>
+          <table class="cmd-table">
+            <thead>
+              <tr>
+                <th>Provider</th>
+                <th>CLOUD_PROVIDER value</th>
+                <th>Default hub</th>
+                <th>Options namespace</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>TestMuAI <span style="color: var(--muted); font-size: 0.9em;">(formerly LambdaTest)</span></td>
+                <td><code>lambdatest</code></td>
+                <td><code>mobile-hub.lambdatest.com/wd/hub</code></td>
+                <td><code>lt:options</code></td>
+              </tr>
+              <tr>
+                <td>Sauce Labs</td>
+                <td><code>saucelabs</code></td>
+                <td><code>ondemand.{CLOUD_REGION}.saucelabs.com/wd/hub</code></td>
+                <td><code>sauce:options</code></td>
+              </tr>
+              <tr>
+                <td>BrowserStack</td>
+                <td><code>browserstack</code></td>
+                <td><code>hub-cloud.browserstack.com/wd/hub</code></td>
+                <td><code>bstack:options</code></td>
+              </tr>
+              <tr>
+                <td>Custom / self-hosted</td>
+                <td><code>custom</code></td>
+                <td>Supplied via <code>CLOUD_SERVER_URL</code></td>
+                <td>Whatever your grid reads</td>
+              </tr>
+            </tbody>
+          </table>
+
+          <h3 id="cloud-testmuai">TestMuAI <span style="color: var(--muted); font-weight: normal; font-size: 0.85em;">(formerly LambdaTest)</span></h3>
+          <p>
+            Example <code>.env</code> for the TestMuAI hub. Sauce Labs and BrowserStack use the same
+            <code>CLOUD_*</code> variables — swap <code>CLOUD_PROVIDER</code> to
+            <code>saucelabs</code> or <code>browserstack</code>, plug in that provider's credentials
+            and app identifier, and add <code>CLOUD_REGION</code> for Sauce if you're not on
+            <code>us-west-1</code>.
+          </p>
 
           <div class="code-block">
             <div class="code-block-header">
               <div class="code-block-dots"><span></span><span></span><span></span></div>
               <span class="code-block-label">.env</span>
             </div>
-            <pre><span class="c"># Enable LambdaTest cloud</span>
+            <pre><span class="c"># Enable TestMuAI (formerly LambdaTest)</span>
 CLOUD_PROVIDER=lambdatest
 
-<span class="c"># LambdaTest credentials (from app.lambdatest.com → Profile → Access Key)</span>
-LAMBDATEST_USERNAME=your_username
-LAMBDATEST_ACCESS_KEY=your_access_key
+<span class="c"># Credentials (app.lambdatest.com → Profile → Access Key)</span>
+CLOUD_USERNAME=your_username
+CLOUD_ACCESS_KEY=your_access_key
 
 <span class="c"># Target device</span>
-LAMBDATEST_DEVICE_NAME=iPhone 14
-LAMBDATEST_OS_VERSION=16
 PLATFORM=ios
+CLOUD_DEVICE_NAME=iPhone 14
+CLOUD_OS_VERSION=16
 
-<span class="c"># Your app (upload via LambdaTest portal, copy the lt:// ID)</span>
-LAMBDATEST_APP=lt://APP10xxxxxxxxxxxxxxxx
+<span class="c"># Your app (upload via portal, copy the lt:// ID)</span>
+CLOUD_APP=lt://APP10xxxxxxxxxxxxxxxx
 
-<span class="c"># LLM for AI-powered automation</span>
-LLM_PROVIDER=gemini
-LLM_API_KEY=your_gemini_api_key</pre>
+<span class="c"># Optional dashboard labels (mapped into lt:options.build/project)</span>
+CLOUD_BUILD_NAME=nightly-1234
+CLOUD_PROJECT_NAME=Checkout Suite</pre>
           </div>
 
-          <h3>CLI Usage</h3>
+          <h3 id="cloud-custom">Custom / self-hosted grid</h3>
+          <p>
+            Use <code>CLOUD_PROVIDER=custom</code> to point at any Appium-compatible hub — a
+            self-hosted Selenium Grid node, an internal device farm, an
+            <a href="https://appium.github.io/appium/" target="_blank">Appium</a> server running on
+            another machine, or a third-party provider not listed above. AppClaw sends W3C caps
+            verbatim; it doesn't inject a provider-specific options namespace.
+          </p>
+
+          <div class="code-block">
+            <div class="code-block-header">
+              <div class="code-block-dots"><span></span><span></span><span></span></div>
+              <span class="code-block-label">.env</span>
+            </div>
+            <pre><span class="c"># Custom grid — you supply the whole hub URL</span>
+CLOUD_PROVIDER=custom
+CLOUD_SERVER_URL=https://appium.example.com/wd/hub
+
+<span class="c"># Auth: either embed in the URL (https://user:key@host/wd/hub) OR set separately</span>
+CLOUD_USERNAME=your_username
+CLOUD_ACCESS_KEY=your_access_key
+
+PLATFORM=android
+CLOUD_DEVICE_NAME=Pixel 8
+CLOUD_OS_VERSION=14
+CLOUD_APP=https://storage.example.com/builds/app.apk</pre>
+          </div>
+
+          <div class="callout callout-tip">
+            <div class="callout-title">Overriding a known provider's hub</div>
+            <p>
+              For BrowserStack / Sauce / LambdaTest you can override the built-in hub URL by
+              setting <code>CLOUD_SERVER_URL</code> — useful for private endpoints, regional
+              overrides, or Sauce datacenters not covered by <code>CLOUD_REGION</code>. Credentials
+              are still injected from <code>CLOUD_USERNAME</code> and <code>CLOUD_ACCESS_KEY</code>
+              unless the URL already carries basic auth.
+            </p>
+          </div>
+
+          <h3>Provider-specific options (bstack / sauce / lt)</h3>
+          <p>
+            AppClaw maps <code>CLOUD_BUILD_NAME</code> and <code>CLOUD_PROJECT_NAME</code> into the
+            active provider's options namespace as a convenience (for BrowserStack it aliases both
+            <code>buildName</code>/<code>projectName</code> and <code>build</code>/<code>project</code>).
+            Everything else — video recording, network logs, tunneling, geo-location, project
+            capacity — goes through a <a href="#custom-capabilities">capabilities file</a>:
+          </p>
+
+          <div class="code-block">
+            <div class="code-block-header">
+              <div class="code-block-dots"><span></span><span></span><span></span></div>
+              <span class="code-block-label">caps.json</span>
+            </div>
+            <pre>{
+  <span class="s">"lt:options"</span>: {
+    <span class="s">"video"</span>: true,
+    <span class="s">"network"</span>: true,
+    <span class="s">"deviceOrientation"</span>: <span class="s">"PORTRAIT"</span>,
+    <span class="s">"idleTimeout"</span>: 300
+  }
+}</pre>
+          </div>
+
+          <p>Load it via CLI or SDK the same way you do for local runs:</p>
+
+          <div class="code-block">
+            <div class="code-block-header">
+              <div class="code-block-dots"><span></span><span></span><span></span></div>
+              <span class="code-block-label">Terminal</span>
+            </div>
+            <pre>appclaw --caps ./caps.json --flow flows/checkout.yaml</pre>
+          </div>
+
+          <h3>CLI usage</h3>
           <p>Once <code>.env</code> is configured, run AppClaw exactly as you would locally:</p>
 
           <div class="code-block">
@@ -2980,10 +3120,10 @@ appclaw "Open the app and navigate to the checkout screen"
 appclaw --flow flows/checkout.yaml</pre>
           </div>
 
-          <h3>SDK Usage</h3>
+          <h3>SDK usage</h3>
           <p>
-            No SDK changes needed — when <code>CLOUD_PROVIDER=lambdatest</code> is set in
-            <code>.env</code>, the SDK automatically routes the session through LambdaTest:
+            No SDK changes needed — the same <code>AppClaw</code> instance routes through the
+            configured cloud provider automatically:
           </p>
 
           <div class="code-block">
@@ -2993,11 +3133,11 @@ appclaw --flow flows/checkout.yaml</pre>
             </div>
             <pre><span class="k">import</span> <span class="p">{</span> AppClaw <span class="p">}</span> <span class="k">from</span> <span class="s">'appclaw'</span><span class="p">;</span>
 
-<span class="c">// CLOUD_PROVIDER=lambdatest is read from .env automatically</span>
+<span class="c">// CLOUD_PROVIDER is read from .env automatically</span>
 <span class="k">const</span> app <span class="p">=</span> <span class="k">new</span> AppClaw<span class="p">({</span>
   provider<span class="p">:</span>    <span class="s">'gemini'</span><span class="p">,</span>
   apiKey<span class="p">:</span>      process<span class="p">.</span>env<span class="p">.</span>LLM_API_KEY<span class="p">,</span>
-  reportName<span class="p">:</span>  <span class="s">'Checkout — LambdaTest'</span><span class="p">,</span>
+  reportName<span class="p">:</span>  <span class="s">'Checkout — Cloud'</span><span class="p">,</span>
 <span class="p">});</span>
 
 <span class="k">await</span> app<span class="p">.</span>run<span class="p">(</span><span class="s">'open the app'</span><span class="p">);</span>
@@ -3007,7 +3147,7 @@ appclaw --flow flows/checkout.yaml</pre>
 <span class="k">await</span> app<span class="p">.</span>teardown<span class="p">();</span>  <span class="c">// report saved to .appclaw/runs/</span></pre>
           </div>
 
-          <h3>Environment Variables</h3>
+          <h3 id="cloud-env-vars">Environment variables</h3>
           <table class="cmd-table">
             <thead>
               <tr>
@@ -3020,62 +3160,87 @@ appclaw --flow flows/checkout.yaml</pre>
               <tr>
                 <td>CLOUD_PROVIDER</td>
                 <td>Yes</td>
-                <td>Set to <code>lambdatest</code> to enable cloud execution</td>
+                <td>
+                  <code>browserstack</code>, <code>saucelabs</code>, <code>lambdatest</code>, or
+                  <code>custom</code>. Empty (default) = local execution.
+                </td>
               </tr>
               <tr>
-                <td>LAMBDATEST_USERNAME</td>
+                <td>CLOUD_USERNAME</td>
+                <td>Yes<sup>1</sup></td>
+                <td>Cloud account username / user ID.</td>
+              </tr>
+              <tr>
+                <td>CLOUD_ACCESS_KEY</td>
+                <td>Yes<sup>1</sup></td>
+                <td>Cloud access key / token from the provider dashboard.</td>
+              </tr>
+              <tr>
+                <td>CLOUD_DEVICE_NAME</td>
                 <td>Yes</td>
-                <td>Your LambdaTest account username</td>
+                <td>
+                  Cloud device to target, e.g. <code>iPhone 15 Pro</code> or
+                  <code>Samsung Galaxy S24</code>. Sent as <code>appium:deviceName</code>.
+                </td>
               </tr>
               <tr>
-                <td>LAMBDATEST_ACCESS_KEY</td>
+                <td>CLOUD_OS_VERSION</td>
                 <td>Yes</td>
-                <td>Your LambdaTest access key (from Profile → Access Key)</td>
+                <td>
+                  OS version, e.g. <code>17</code> (iOS) or <code>14</code> (Android). Sent as
+                  <code>appium:platformVersion</code>.
+                </td>
               </tr>
               <tr>
-                <td>LAMBDATEST_DEVICE_NAME</td>
-                <td>Yes</td>
-                <td>Cloud device to use, e.g. <code>iPhone 14</code>, <code>Galaxy S23</code></td>
-              </tr>
-              <tr>
-                <td>LAMBDATEST_OS_VERSION</td>
-                <td>Yes</td>
-                <td>OS version, e.g. <code>16</code> (iOS) or <code>13</code> (Android)</td>
-              </tr>
-              <tr>
-                <td>LAMBDATEST_APP</td>
+                <td>CLOUD_APP</td>
                 <td>No</td>
-                <td>App ID from the LambdaTest portal (format: <code>lt://APP…</code>)</td>
+                <td>
+                  App identifier — <code>bs://…</code> (BrowserStack), <code>storage:filename=…</code>
+                  or <code>https://…</code> (Sauce), <code>lt://APP…</code> (LambdaTest), or any URL
+                  the custom grid understands. Sent as <code>appium:app</code>.
+                </td>
               </tr>
               <tr>
-                <td>LAMBDATEST_BUILD_NAME</td>
-                <td>No</td>
-                <td>Build label shown in the LambdaTest dashboard</td>
+                <td>CLOUD_SERVER_URL</td>
+                <td>Yes<sup>2</sup></td>
+                <td>
+                  Full Appium hub URL, e.g. <code>https://appium.example.com/wd/hub</code>. Required
+                  for <code>custom</code>; optional for known providers (overrides the built-in
+                  hub).
+                </td>
               </tr>
               <tr>
-                <td>LAMBDATEST_PROJECT_NAME</td>
+                <td>CLOUD_REGION</td>
                 <td>No</td>
-                <td>Project label shown in the LambdaTest dashboard</td>
+                <td>
+                  Sauce Labs datacenter region for the built-in hub URL. Default:
+                  <code>us-west-1</code>. Ignored by other providers.
+                </td>
               </tr>
               <tr>
-                <td>LAMBDATEST_VIDEO</td>
+                <td>CLOUD_BUILD_NAME</td>
                 <td>No</td>
-                <td>Record session video. Default: <code>true</code></td>
+                <td>Build label shown in the provider dashboard.</td>
               </tr>
               <tr>
-                <td>LAMBDATEST_NETWORK</td>
+                <td>CLOUD_PROJECT_NAME</td>
                 <td>No</td>
-                <td>Capture network logs. Default: <code>false</code></td>
+                <td>Project label shown in the provider dashboard.</td>
               </tr>
             </tbody>
           </table>
+          <p style="font-size: 0.9em; margin-top: 0.5em;">
+            <sup>1</sup> Not strictly required for <code>custom</code> when the credentials are
+            embedded in <code>CLOUD_SERVER_URL</code> (<code>https://user:key@host/wd/hub</code>).<br />
+            <sup>2</sup> Required for <code>CLOUD_PROVIDER=custom</code>; optional otherwise.
+          </p>
 
           <div class="callout callout-tip">
             <div class="callout-title">No code changes required</div>
             <p>
               Switching between local and cloud execution is purely config — set
-              <code>CLOUD_PROVIDER=lambdatest</code> in your CI environment and remove it for local
-              runs. Your YAML flows and SDK tests stay identical.
+              <code>CLOUD_PROVIDER</code> in your CI environment and unset it (or leave it empty)
+              for local runs. Your YAML flows and SDK tests stay identical.
             </p>
           </div>
         </section>

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@modelcontextprotocol/sdk": "^1.22.0",
         "ai": "^6.0.72",
         "ai-sdk-ollama": "3.8.3",
-        "appium-mcp": "1.85.8",
+        "appium-mcp": "^1.87.0",
         "boxen": "^8.0.1",
         "chalk": "^5.6.2",
         "cli-spinners": "^3.4.0",
@@ -434,6 +434,8 @@
     "node_modules/@appium/mcp-documentation": {
       "version": "1.0.4",
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@appium/support": "^7.0.2",
         "@langchain/classic": "^1.0.10",
@@ -446,6 +448,8 @@
     "node_modules/@appium/mcp-documentation/node_modules/@langchain/classic": {
       "version": "1.0.34",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@langchain/openai": "1.4.7",
         "@langchain/textsplitters": "1.0.1",
@@ -483,6 +487,8 @@
     "node_modules/@appium/mcp-documentation/node_modules/zod": {
       "version": "4.4.3",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -643,9 +649,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -661,9 +664,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -681,9 +681,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -699,9 +696,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -719,9 +713,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -738,9 +729,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -756,9 +744,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -782,9 +767,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -806,9 +788,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -832,9 +811,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -857,9 +833,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -881,9 +854,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1183,7 +1153,9 @@
     },
     "node_modules/@cfworker/json-schema": {
       "version": "4.1.1",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
@@ -1217,7 +1189,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.1",
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1903,6 +1877,8 @@
     "node_modules/@huggingface/jinja": {
       "version": "0.2.2",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1957,6 +1933,41 @@
         "@img/sharp-libvips-darwin-x64": "1.0.4"
       }
     },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.1.tgz",
+      "integrity": "sha512-MBSQXqNPThW9EcZ905H6N4sEdX5EwZEYzGx5EBq9ncDCGJALMiY1xPFJxNdzuB1iBjLOpIfxajM6YxdvwmQSLA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32/node_modules/@img/sharp-wasm32": {
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.1.tgz",
+      "integrity": "sha512-PCQUoQdZyE8tp3HpbevuihfUmgSP4qWI0FGEPWoeXqaS+cUrFfemabHQiebUmUmlUhCuNnQMxGrQ+CPqK4hnxg==",
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.0"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
       "version": "1.0.4",
       "cpu": [
@@ -1994,9 +2005,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2012,9 +2020,6 @@
       "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -2032,9 +2037,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2050,9 +2052,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -2070,9 +2069,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2088,9 +2084,6 @@
       "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -2108,9 +2101,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2127,9 +2117,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2145,9 +2132,6 @@
       "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2171,9 +2155,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2195,9 +2176,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2221,9 +2199,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2245,9 +2220,6 @@
       "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2271,9 +2243,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2296,9 +2265,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2320,9 +2286,6 @@
       "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2353,6 +2316,41 @@
       },
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.1.tgz",
+      "integrity": "sha512-xU2ml2bU2OPxYVvW2A6ae4M1g5QKyhKG06P4FAt+YEaFQQO0919Qx+XxIZEUuWTMoDViLpMws2/dQwoe/VcA6A==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32/node_modules/@img/sharp-wasm32": {
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.1.tgz",
+      "integrity": "sha512-PCQUoQdZyE8tp3HpbevuihfUmgSP4qWI0FGEPWoeXqaS+cUrFfemabHQiebUmUmlUhCuNnQMxGrQ+CPqK4hnxg==",
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.0"
+      },
+      "engines": {
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
@@ -2481,6 +2479,8 @@
     "node_modules/@langchain/core": {
       "version": "1.1.49",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
         "@standard-schema/spec": "^1.1.0",
@@ -2497,6 +2497,8 @@
     "node_modules/@langchain/openai": {
       "version": "1.4.7",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "js-tiktoken": "^1.0.12",
         "openai": "^6.37.0",
@@ -2512,6 +2514,8 @@
     "node_modules/@langchain/textsplitters": {
       "version": "1.0.1",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "js-tiktoken": "^1.0.12"
       },
@@ -3320,7 +3324,9 @@
     },
     "node_modules/@protobufjs/inquire": {
       "version": "1.1.1",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
@@ -3540,9 +3546,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3560,9 +3563,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3580,9 +3580,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3600,9 +3597,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3620,9 +3614,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3640,9 +3631,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4476,7 +4464,9 @@
     },
     "node_modules/@types/long": {
       "version": "4.0.2",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/node": {
       "version": "25.5.0",
@@ -4809,6 +4799,8 @@
     "node_modules/@xenova/transformers": {
       "version": "2.17.2",
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@huggingface/jinja": "^0.2.2",
         "onnxruntime-web": "1.14.0",
@@ -4822,6 +4814,8 @@
       "version": "0.32.6",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "color": "^4.2.3",
         "detect-libc": "^2.0.2",
@@ -5329,9 +5323,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -5347,9 +5338,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -5367,9 +5355,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -5385,9 +5370,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -5405,9 +5387,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -5424,9 +5403,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -5442,9 +5418,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -5468,9 +5441,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5492,9 +5462,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -5518,9 +5485,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5543,9 +5507,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5567,9 +5528,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -5896,17 +5854,17 @@
       }
     },
     "node_modules/appium-mcp": {
-      "version": "1.85.8",
+      "version": "1.87.0",
+      "resolved": "https://registry.npmjs.org/appium-mcp/-/appium-mcp-1.87.0.tgz",
+      "integrity": "sha512-51fkbkyVhAvs9hYwG7Be6goezs+QzY3N8WKRs1BAxG+kPBgdk4F4aByWjG1OdBmYligtQ/xfi2tKDvlMI4S5WA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@appium/mcp-documentation": "^1.0.1",
         "@appium/support": "^7.0.2",
         "@modelcontextprotocol/sdk": "^1.22.0",
-        "@xenova/transformers": "^2.17.2",
         "@xmldom/xmldom": "^0.9.8",
         "appium-adb": "^15.0.0",
         "appium-ios-device": "^3.1.0",
-        "appium-uiautomator2-driver": "^7.0.0",
+        "appium-uiautomator2-driver": "^8.0.0",
         "appium-webdriveragent": "^12.1.1",
         "appium-xcuitest-driver": "^11.0.0",
         "applesign": "^5.0.0",
@@ -5925,6 +5883,14 @@
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",
         "@opentelemetry/sdk-node": "^0.219.0"
+      },
+      "peerDependencies": {
+        "@appium/mcp-documentation": "^1.0.1"
+      },
+      "peerDependenciesMeta": {
+        "@appium/mcp-documentation": {
+          "optional": true
+        }
       }
     },
     "node_modules/appium-mcp/node_modules/@opentelemetry/api": {
@@ -6141,18 +6107,19 @@
       }
     },
     "node_modules/appium-uiautomator2-driver": {
-      "version": "7.1.2",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/appium-uiautomator2-driver/-/appium-uiautomator2-driver-8.0.1.tgz",
+      "integrity": "sha512-NCTEk3Ou13MoGsPE8hE613EjvEuxrqorx19uBDwvBkcS2GkHhvnhLkJmUR/GeSPI3TO0epDdZMpYhroeHS+bKw==",
+      "hasShrinkwrap": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "appium-adb": "^14.0.0",
-        "appium-android-driver": "^13.1.1",
-        "appium-uiautomator2-server": "^9.11.1",
+        "@appium/css-locator-to-native": "^1.0.1",
+        "appium-adb": "^15.0.0",
+        "appium-android-driver": "^13.2.3",
+        "appium-uiautomator2-server": "^10.2.1",
         "asyncbox": "^6.0.1",
-        "axios": "^1.13.5",
-        "bluebird": "^3.5.1",
-        "css-selector-parser": "^3.0.0",
-        "io.appium.settings": "^7.0.1",
-        "lodash": "^4.17.4",
+        "axios": "^1.16.0",
+        "io.appium.settings": "^7.1.3",
         "portscanner": "^2.2.0",
         "teen_process": "^4.0.4"
       },
@@ -6165,27 +6132,26 @@
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/@appium/base-driver": {
-      "version": "10.3.0",
+      "version": "10.7.1",
+      "resolved": "https://registry.npmjs.org/@appium/base-driver/-/base-driver-10.7.1.tgz",
+      "integrity": "sha512-DE6TcCBvoL5N+5zjbwhyVvnfzTvvu1ZFLULjK8MZuPQPklLc8nRpYIgKIqvsGDUp2QH29Gs0SQDqO9XebOX1Jw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@appium/support": "7.1.0",
-        "@appium/types": "1.3.0",
-        "@colors/colors": "1.6.0",
+        "@appium/support": "7.2.5",
+        "@appium/types": "1.5.1",
         "async-lock": "1.4.1",
-        "asyncbox": "6.1.0",
-        "axios": "1.15.0",
-        "bluebird": "3.7.2",
+        "asyncbox": "6.3.0",
+        "axios": "1.18.0",
         "body-parser": "2.2.2",
         "express": "5.2.1",
         "fastest-levenshtein": "1.0.16",
         "http-status-codes": "2.3.0",
-        "lodash": "4.18.1",
-        "lru-cache": "11.3.3",
+        "lru-cache": "11.5.1",
         "method-override": "3.0.0",
-        "morgan": "1.10.1",
+        "morgan": "1.11.0",
         "path-to-regexp": "8.4.2",
         "serve-favicon": "2.5.1",
-        "type-fest": "5.5.0"
+        "type-fest": "5.7.0"
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
@@ -6195,14 +6161,91 @@
         "spdy": "4.0.2"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/@appium/base-driver/node_modules/asyncbox": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/asyncbox/-/asyncbox-6.3.0.tgz",
+      "integrity": "sha512-7IFpnQDltd5rYQjhIJIpyismJtdWmw/pOABZKJfv2WVo0a6iYh2ZzUuCJJclae5mBtK0H/EychxXg91GB7rGdQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "p-limit": "^7.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
+        "npm": ">=10"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/@appium/base-driver/node_modules/axios": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+      "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/@appium/css-locator-to-native": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@appium/css-locator-to-native/-/css-locator-to-native-1.0.1.tgz",
+      "integrity": "sha512-FIKjakA2E1WB6xneBlXYgUcsDqO/dwD4zXJxGE5DwkOUwvGXZ8HdLEvvQruoPRD4C2mYmn+/r89BZcXU5QMZPw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "css-selector-parser": "^3.3.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
+        "npm": ">=10"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/@appium/docutils": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@appium/docutils/-/docutils-2.5.1.tgz",
+      "integrity": "sha512-P2Kveb4I68KGC6gAY0TRTVgvqBaZW3WqpnHgK0iiN+lLhaxBoRrqoaGJR95oPb93sgkZQT59ZexdZ5KXf8wFtA==",
+      "extraneous": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@appium/support": "7.2.5",
+        "consola": "3.4.2",
+        "diff": "9.0.0",
+        "lilconfig": "3.1.3",
+        "normalize-package-data": "8.0.0",
+        "teen_process": "4.1.3",
+        "type-fest": "5.7.0",
+        "yaml": "2.9.0",
+        "yargs": "18.0.0",
+        "yargs-parser": "22.0.0"
+      },
+      "bin": {
+        "appium-docs": "bin/appium-docs.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
+        "npm": ">=10"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/@appium/docutils/node_modules/teen_process": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/teen_process/-/teen_process-4.1.3.tgz",
+      "integrity": "sha512-8W7Xp7WtJ5ZXjv0iHMsCgPPKzUt6ACfG/rDWX0tMIlMJaYcTYsPw3ZQQ9+hG7YsY+gm+DUATiyah3AraJ9JYpg==",
+      "extraneous": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "shell-quote": "^1.8.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
+        "npm": ">=10"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/@appium/logger": {
-      "version": "2.0.6",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@appium/logger/-/logger-2.0.9.tgz",
+      "integrity": "sha512-3rNqtyxTygrDkxEMA2UB35EQfzxlnGCkIJLdIRDLKhVfbHgFw8XEnPnYuvMKvzG8zVeBUoh76dxKVHyIezPsIQ==",
       "license": "ISC",
       "dependencies": {
-        "console-control-strings": "1.1.0",
-        "lodash": "4.18.1",
-        "lru-cache": "11.3.3",
-        "set-blocking": "2.0.0"
+        "lru-cache": "11.5.1"
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
@@ -6210,7 +6253,9 @@
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/@appium/schema": {
-      "version": "1.1.0",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@appium/schema/-/schema-1.2.1.tgz",
+      "integrity": "sha512-+XmwihFeW10Q0UI/WdLsMTfnC2d2ec0ceGRdhRcfBuo5cClfm/E7VCJH2PE64KE0A17ZlsZf63FRkKfNHw9PKw==",
       "license": "Apache-2.0",
       "dependencies": {
         "json-schema": "0.4.0"
@@ -6221,57 +6266,159 @@
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/@appium/support": {
-      "version": "7.1.0",
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/@appium/support/-/support-7.2.5.tgz",
+      "integrity": "sha512-+sk7HdWYD5EMcSVtiMK09aA960suBJY/8d+r5v8j9vHw47R4ukLrM2lShpIpFFCTTfz5ZTCjCtvqNwwM8EqyMg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@appium/logger": "2.0.6",
-        "@appium/tsconfig": "1.1.2",
-        "@appium/types": "1.3.0",
-        "@colors/colors": "1.6.0",
-        "archiver": "7.0.1",
-        "asyncbox": "6.1.0",
-        "axios": "1.15.0",
-        "base64-stream": "1.0.0",
+        "@appium/logger": "2.0.9",
+        "@appium/types": "1.5.1",
+        "archiver": "8.0.0",
+        "asyncbox": "6.3.0",
+        "axios": "1.18.0",
         "bluebird": "3.7.2",
         "bplist-creator": "0.1.1",
         "bplist-parser": "0.3.2",
-        "form-data": "4.0.5",
-        "get-stream": "9.0.1",
+        "form-data": "4.0.6",
         "glob": "13.0.6",
         "jsftp": "2.1.3",
         "klaw": "4.1.0",
         "lockfile": "1.0.4",
-        "lodash": "4.18.1",
-        "log-symbols": "7.0.1",
-        "ncp": "2.0.0",
-        "package-directory": "8.2.0",
-        "plist": "3.1.0",
+        "normalize-package-data": "8.0.0",
+        "plist": "4.0.0",
         "pluralize": "8.0.0",
-        "read-pkg": "10.1.0",
-        "resolve-from": "5.0.0",
         "sanitize-filename": "1.6.4",
-        "semver": "7.7.4",
-        "shell-quote": "1.8.3",
-        "supports-color": "10.2.2",
-        "teen_process": "4.1.0",
-        "type-fest": "5.5.0",
-        "uuid": "13.0.0",
+        "semver": "7.8.4",
+        "shell-quote": "1.8.4",
+        "teen_process": "4.1.3",
+        "type-fest": "5.7.0",
+        "uuid": "14.0.0",
         "which": "6.0.1",
-        "yauzl": "3.3.0"
+        "yauzl": "3.4.0"
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
         "npm": ">=10"
       },
       "optionalDependencies": {
-        "sharp": "0.34.5"
+        "sharp": "0.35.1"
       }
     },
-    "node_modules/appium-uiautomator2-driver/node_modules/@appium/tsconfig": {
-      "version": "1.1.2",
+    "node_modules/appium-uiautomator2-driver/node_modules/@appium/support/node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.0.tgz",
+      "integrity": "sha512-y9RNUYDe2A1UAdhLyfeOodGRszQdaEoe4nfOpp/sNVPl2CWIcUyFaDoCh4vPLPxu19803j2naLqZup2WxDXCLA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/@appium/support/node_modules/@img/sharp-linux-x64": {
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.1.tgz",
+      "integrity": "sha512-NbJD4mWdeyrNQKluO/tR/wBDOelcowSVGNBWxI0e3ZtlXc6F/UOVKDj1MLD4zl3oHTuvKW3s+MA9N54YTldAYw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.3.0"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/@appium/support/node_modules/asyncbox": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/asyncbox/-/asyncbox-6.3.0.tgz",
+      "integrity": "sha512-7IFpnQDltd5rYQjhIJIpyismJtdWmw/pOABZKJfv2WVo0a6iYh2ZzUuCJJclae5mBtK0H/EychxXg91GB7rGdQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@tsconfig/node20": "20.1.9"
+        "p-limit": "^7.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
+        "npm": ">=10"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/@appium/support/node_modules/axios": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+      "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/@appium/support/node_modules/sharp": {
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.1.tgz",
+      "integrity": "sha512-lW979AMi+ESidzMv/Lnv+F9bknzLyxLqFI05Sm433vOeRcltgxQmXpnfOOFIAlKtwXU/ksupm2srQoFCkR214g==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/colour": "^1.1.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.8.4"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.35.1",
+        "@img/sharp-darwin-x64": "0.35.1",
+        "@img/sharp-freebsd-wasm32": "0.35.1",
+        "@img/sharp-libvips-darwin-arm64": "1.3.0",
+        "@img/sharp-libvips-darwin-x64": "1.3.0",
+        "@img/sharp-libvips-linux-arm": "1.3.0",
+        "@img/sharp-libvips-linux-arm64": "1.3.0",
+        "@img/sharp-libvips-linux-ppc64": "1.3.0",
+        "@img/sharp-libvips-linux-riscv64": "1.3.0",
+        "@img/sharp-libvips-linux-s390x": "1.3.0",
+        "@img/sharp-libvips-linux-x64": "1.3.0",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.0",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.0",
+        "@img/sharp-linux-arm": "0.35.1",
+        "@img/sharp-linux-arm64": "0.35.1",
+        "@img/sharp-linux-ppc64": "0.35.1",
+        "@img/sharp-linux-riscv64": "0.35.1",
+        "@img/sharp-linux-s390x": "0.35.1",
+        "@img/sharp-linux-x64": "0.35.1",
+        "@img/sharp-linuxmusl-arm64": "0.35.1",
+        "@img/sharp-linuxmusl-x64": "0.35.1",
+        "@img/sharp-webcontainers-wasm32": "0.35.1",
+        "@img/sharp-win32-arm64": "0.35.1",
+        "@img/sharp-win32-ia32": "0.35.1",
+        "@img/sharp-win32-x64": "0.35.1"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/@appium/support/node_modules/teen_process": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/teen_process/-/teen_process-4.1.3.tgz",
+      "integrity": "sha512-8W7Xp7WtJ5ZXjv0iHMsCgPPKzUt6ACfG/rDWX0tMIlMJaYcTYsPw3ZQQ9+hG7YsY+gm+DUATiyah3AraJ9JYpg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "shell-quote": "^1.8.1"
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
@@ -6279,40 +6426,26 @@
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/@appium/types": {
-      "version": "1.3.0",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@appium/types/-/types-1.5.1.tgz",
+      "integrity": "sha512-cQkbSh6AwEGlowfKBxVngtBc5fkqAPmg4WdjGZ2txa81lpfuNTLX50VWM8Nxf3hiCgRMsRVfBWdU9x38OJqDrQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@appium/logger": "2.0.6",
-        "@appium/schema": "1.1.0",
-        "@appium/tsconfig": "1.1.2",
-        "type-fest": "5.5.0"
+        "@appium/schema": "1.2.1",
+        "type-fest": "5.7.0"
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
         "npm": ">=10"
-      }
-    },
-    "node_modules/appium-uiautomator2-driver/node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.1.1"
       },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/appium-uiautomator2-driver/node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
+      "peerDependencies": {
+        "@appium/logger": "^2.0.0"
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/@colors/colors": {
       "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
       "license": "MIT",
       "engines": {
         "node": ">=0.1.90"
@@ -6320,6 +6453,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/@img/colour": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -6327,7 +6462,9 @@
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.1.tgz",
+      "integrity": "sha512-T15JRWOubQ3f5+GxnWeIvo47u5qV0M9HBgJhT+f2gE1e9e6OhR6K73Re52Hm80qWcu1DNb3GweKmpr/MnuP2Ow==",
       "cpu": [
         "arm64"
       ],
@@ -6337,19 +6474,19 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+        "@img/sharp-libvips-darwin-arm64": "1.3.0"
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.1.tgz",
+      "integrity": "sha512-t1CPD0cr7XCHjwUj6tQ5MC0pCi866I+gUW6zbUX4aFPnKd1DFBtk0M+gWcjX8VeEzgfCNiSiNTVFZ6b7kvdbnQ==",
       "cpu": [
         "x64"
       ],
@@ -6359,17 +6496,19 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
+        "@img/sharp-libvips-darwin-x64": "1.3.0"
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.0.tgz",
+      "integrity": "sha512-EKbmBKtyTH+GPFDRw2TgK2oV6hyxxlJVIar4hoTYSNmIwipgMFdxPQqR392GmfdsPGWga0mCFN1cCKjRb9cljw==",
       "cpu": [
         "arm64"
       ],
@@ -6383,9 +6522,9 @@
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.0.tgz",
+      "integrity": "sha512-Pl2OmOvrJ42adUllESxBsG54PfXLo1OYg9i3c5/5Ln/qJ0gZuTM9YMhQJPIbXqwidLRc/c2zuHt4RsrymmNv7A==",
       "cpu": [
         "x64"
       ],
@@ -6399,14 +6538,11 @@
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.0.tgz",
+      "integrity": "sha512-A8UpHoUDW4DwnXoV6+q3C1s7QLRAHtPDEjWuNZjwHMyoCNZnm0GeNN8ls9f/bsEYTRQRW96C/n34XJQHJ2fT7A==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -6418,14 +6554,43 @@
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.0.tgz",
+      "integrity": "sha512-C0SqjoFKnszqa44EQ7xoaT48nnO0lOyXEULfXMWi8krrjOPGYkeK30Okzla6ATbBYsyZ0ySinK0FVkpv3DwzfQ==",
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.0.tgz",
+      "integrity": "sha512-WOpkVxAjFd369iaIzEgNRreFD+gWdUMIGD5zplhNKNeqS6mm5dac3q2AFyCBmzYoAdouzZvRBgxy4z8QHZb4/A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.0.tgz",
+      "integrity": "sha512-DRWw0mOHusrCCuw2rqP87oLg6PGlkomVDFqw2hIwsSfwWpu4k3XLcBPaKKl6ct/GtL/cwNkgwjV/tc0Mqht3VA==",
+      "cpu": [
+        "riscv64"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -6437,33 +6602,11 @@
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.0.tgz",
+      "integrity": "sha512-9APy+nFWhHS+kzLgWZfLcyrUd7YqnAQVa4BPOo4xkoHpdoktOAPG4cEr9+Jpl0TtqfVmcMJimNL5qNTyyOHZNA==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/appium-uiautomator2-driver/node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
-      "cpu": [
-        "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -6475,14 +6618,11 @@
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.0.tgz",
+      "integrity": "sha512-cC1wkC0Mlucd0KSiGrLkJnB/ZqPvZCntc/Lk7ZnYO5ZSbF2euNek4Xvxafojq+wN1q/W0eprdpUIjUr/EV2PBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -6494,14 +6634,11 @@
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.0.tgz",
+      "integrity": "sha512-LiYMhUZicB1QG//+RvmYZpXJO8fYRENfp+MZUCnG9aw+AKvGAy9gPaCnuwsPcBFs8EV66M0NNxj9VHcNklE8zw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -6513,39 +6650,33 @@
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.1.tgz",
+      "integrity": "sha512-jygmR02PpCYypt7xB7nst1vqjZp/BpRA/Kf9nK7qRponJ/KrLPaZWEG4G15z1d2FZ6XqI+T0350ha3RSnKx24A==",
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
+        "@img/sharp-libvips-linux-arm": "1.3.0"
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.1.tgz",
+      "integrity": "sha512-ErCRyGU7LeoaFBZ0xW8hhLlXzhAg80sc4vxePB86qvtEvW1jEhhmbiNBP4oEzZfPMnu6HwHXfzD2W2kBU+RnCw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -6553,99 +6684,109 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
+        "@img/sharp-libvips-linux-arm64": "1.3.0"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.1.tgz",
+      "integrity": "sha512-LUWZ2+r2UoLCd8j0RLCwQ4gL6w47+Y7igxtVnPIDXOOEjV86LpBkAHq5VpJeg+GHbw0KN/JWlPJOdZjyZnFqFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.3.0"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.1.tgz",
+      "integrity": "sha512-i7x6J3mwF4JgT0sM4V4WlAWdJ0bucPtA9rzO1bTji1n5qgBq/W5nn87RvOQPleuuxahNoLdTngByD8/vDDLArw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.3.0"
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.1.tgz",
+      "integrity": "sha512-0zSaTUjTF0kIWTSYxD4EG/nvCU4jez53+3RdURtoY3HvbXtIQ98W90JnrGz/oLRFuEnfIy9+7xeq883euc0ZWw==",
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.4"
-      }
-    },
-    "node_modules/appium-uiautomator2-driver/node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
-      "cpu": [
-        "x64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
+        "@img/sharp-libvips-linux-s390x": "1.3.0"
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.1.tgz",
+      "integrity": "sha512-VoW2sQCWI+0YIKQEmWJ8vzaQjTg9wIyfkFpvEfAS2h43X6iHu7GTk1hhOgB4IpSzCHe8UwQZIcx7b81VTaOrJA==",
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.0"
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.1.tgz",
+      "integrity": "sha512-LjBoSd/c5JU0/K5MwzDMlgsSRP2bPn98JQGFFQAOLQ0bU/1z4ekxUdSKY9BmlwSh/cA+OrvpgsWqfZyYfVHBRw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -6653,38 +6794,38 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.0"
       }
     },
-    "node_modules/appium-uiautomator2-driver/node_modules/@img/sharp-wasm32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+    "node_modules/appium-uiautomator2-driver/node_modules/@img/sharp-win32-arm64": {
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.1.tgz",
+      "integrity": "sha512-IkmHwuFhYpd3bTsN5SAahjwhiAcyXPooBt8vEUgxY3T0IP70sSJ0nU1xiPzZY8AH/OB1XpV3j8aZSVSOSfTbdA==",
       "cpu": [
-        "wasm32"
+        "arm64"
       ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
-      "dependencies": {
-        "@emnapi/runtime": "^1.7.0"
-      },
+      "os": [
+        "win32"
+      ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.1.tgz",
+      "integrity": "sha512-wQahqCi9MD8Yxzg4gVM4fNrZxh+r6vD55PyIg+WJPaM5ZRUyF35iQpwJCuma3r6viU9/8Pxlc+XHV+woVa6nCQ==",
       "cpu": [
         "ia32"
       ],
@@ -6694,16 +6835,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": "^20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.1.tgz",
+      "integrity": "sha512-WzBtkYtZHATLPe8XRharxZXxQ9cdLrQWHiwxt+BJ5rBsisQrKeeV86ErxPSVhcG6xCEuNhs0SqLpWr7XDa2k6w==",
       "cpu": [
         "x64"
       ],
@@ -6713,106 +6854,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
-    "node_modules/appium-uiautomator2-driver/node_modules/@isaacs/cliui": {
-      "version": "8.0.2",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^5.1.2",
-        "string-width-cjs": "npm:string-width@^4.2.0",
-        "strip-ansi": "^7.0.1",
-        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-        "wrap-ansi": "^8.1.0",
-        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/appium-uiautomator2-driver/node_modules/@isaacs/cliui/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/appium-uiautomator2-driver/node_modules/@isaacs/cliui/node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "license": "MIT"
-    },
-    "node_modules/appium-uiautomator2-driver/node_modules/@isaacs/cliui/node_modules/string-width": {
-      "version": "5.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/appium-uiautomator2-driver/node_modules/@isaacs/cliui/node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/appium-uiautomator2-driver/node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/appium-uiautomator2-driver/node_modules/@pkgjs/parseargs": {
-      "version": "0.11.0",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/appium-uiautomator2-driver/node_modules/@sec-ant/readable-stream": {
-      "version": "0.4.1",
-      "license": "MIT"
-    },
-    "node_modules/appium-uiautomator2-driver/node_modules/@tsconfig/node20": {
-      "version": "20.1.9",
-      "license": "MIT"
-    },
-    "node_modules/appium-uiautomator2-driver/node_modules/@types/normalize-package-data": {
-      "version": "2.4.4",
-      "license": "MIT"
-    },
     "node_modules/appium-uiautomator2-driver/node_modules/@xmldom/xmldom": {
-      "version": "0.9.9",
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.6"
@@ -6820,6 +6871,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/abort-controller": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
       "license": "MIT",
       "dependencies": {
         "event-target-shim": "^5.0.0"
@@ -6830,6 +6883,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/accepts": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
       "license": "MIT",
       "dependencies": {
         "mime-types": "^3.0.0",
@@ -6839,8 +6894,23 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/ansi-regex": {
       "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "extraneous": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -6851,6 +6921,9 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/ansi-styles": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -6863,15 +6936,15 @@
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/appium-adb": {
-      "version": "14.3.1",
+      "version": "15.0.6",
+      "resolved": "https://registry.npmjs.org/appium-adb/-/appium-adb-15.0.6.tgz",
+      "integrity": "sha512-BNHG7at55Tyivd/IIXg5jIljmubAz4n3SrWxQqD5Xer7VIO56hM27FkB0uT56iWofqUR8KWAcKaK6grslCGlzA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@appium/support": "^7.0.0-rc.1",
+        "@appium/support": "^7.2.2",
         "async-lock": "^1.0.0",
         "asyncbox": "^6.0.1",
-        "bluebird": "^3.4.7",
         "ini": "^6.0.0",
-        "lodash": "^4.0.0",
         "lru-cache": "^11.1.0",
         "semver": "^7.0.0",
         "teen_process": "^4.0.4"
@@ -6882,17 +6955,18 @@
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/appium-android-driver": {
-      "version": "13.1.1",
+      "version": "13.2.9",
+      "resolved": "https://registry.npmjs.org/appium-android-driver/-/appium-android-driver-13.2.9.tgz",
+      "integrity": "sha512-s61RR6/96sUUrgjcJhrGsZKpY2ma6lgaxpblTefdQFRn4GDzepsPCcGCFemRk8YaMiVb5Y2BtYsmOHkb56ifzQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@appium/support": "^7.0.0-rc.1",
+        "@appium/support": "^7.2.2",
         "@colors/colors": "^1.6.0",
-        "appium-adb": "^14.3.0",
-        "appium-chromedriver": "^8.2.25",
+        "appium-adb": "^15.0.0",
+        "appium-chromedriver": "^8.4.4",
         "asyncbox": "^6.1.0",
-        "axios": "^1.x",
-        "bluebird": "^3.4.7",
-        "io.appium.settings": "^7.0.4",
+        "axios": "^1.16.0",
+        "io.appium.settings": "^7.1.3",
         "lodash": "^4.17.4",
         "lru-cache": "^11.1.0",
         "moment": "^2.24.0",
@@ -6911,18 +6985,18 @@
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/appium-chromedriver": {
-      "version": "8.2.25",
+      "version": "8.4.14",
+      "resolved": "https://registry.npmjs.org/appium-chromedriver/-/appium-chromedriver-8.4.14.tgz",
+      "integrity": "sha512-17zQa+j1bv7LfYsvz2mDIBgMs9OeqsHp9lKSJeZ5NMVteIs3gTujaZTci0lNvPHqsXTmXYSGGdXdHiCEM3axAg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@appium/base-driver": "^10.0.0-rc.2",
-        "@appium/support": "^7.0.0-rc.1",
+        "@appium/support": "^7.2.2",
         "@xmldom/xmldom": "^0.x",
-        "appium-adb": "^14.0.0",
+        "appium-adb": "^15.0.0",
         "asyncbox": "^6.0.1",
-        "axios": "^1.6.5",
-        "bluebird": "^3.5.1",
+        "axios": "^1.16.0",
         "compare-versions": "^6.0.0",
-        "lodash": "^4.17.4",
         "semver": "^7.0.0",
         "teen_process": "^4.0.4",
         "xpath": "^0.x"
@@ -6933,7 +7007,9 @@
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/appium-uiautomator2-server": {
-      "version": "9.11.1",
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/appium-uiautomator2-server/-/appium-uiautomator2-server-10.2.4.tgz",
+      "integrity": "sha512-Y3DjrIR68lWhCiNmJy2q940hsBXHaNfrbIib0/W2tFwpoRlDnhCQ/i3wp60v5eS8m6I4+1NCAVHYYIAYSRic4A==",
       "license": "Apache-2.0",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
@@ -6941,103 +7017,48 @@
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/archiver": {
-      "version": "7.0.1",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-8.0.0.tgz",
+      "integrity": "sha512-fV1orZfsnPn9BaSByR/qE67rJCLJEy2Ox5bq7nJh+jquWaNh6Sfec75kJ2T6PtdGUbPQlrVoSVCEOa5SdiTQ1g==",
       "license": "MIT",
       "dependencies": {
-        "archiver-utils": "^5.0.2",
         "async": "^3.2.4",
         "buffer-crc32": "^1.0.0",
-        "readable-stream": "^4.0.0",
-        "readdir-glob": "^1.1.2",
-        "tar-stream": "^3.0.0",
-        "zip-stream": "^6.0.1"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/appium-uiautomator2-driver/node_modules/archiver-utils": {
-      "version": "5.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "glob": "^10.0.0",
-        "graceful-fs": "^4.2.0",
-        "is-stream": "^2.0.1",
+        "is-stream": "^4.0.0",
         "lazystream": "^1.0.0",
-        "lodash": "^4.17.15",
         "normalize-path": "^3.0.0",
-        "readable-stream": "^4.0.0"
+        "readable-stream": "^4.0.0",
+        "readdir-glob": "^3.0.0",
+        "tar-stream": "^3.0.0",
+        "zip-stream": "^7.0.2"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">=18"
       }
     },
-    "node_modules/appium-uiautomator2-driver/node_modules/archiver-utils/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/appium-uiautomator2-driver/node_modules/archiver-utils/node_modules/glob": {
-      "version": "10.5.0",
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/appium-uiautomator2-driver/node_modules/archiver-utils/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "license": "ISC"
-    },
-    "node_modules/appium-uiautomator2-driver/node_modules/archiver-utils/node_modules/minimatch": {
-      "version": "9.0.9",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/appium-uiautomator2-driver/node_modules/archiver-utils/node_modules/path-scurry": {
-      "version": "1.11.1",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
+    "node_modules/appium-uiautomator2-driver/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "extraneous": true,
+      "license": "Python-2.0"
     },
     "node_modules/appium-uiautomator2-driver/node_modules/async": {
       "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "license": "MIT"
     },
     "node_modules/appium-uiautomator2-driver/node_modules/async-lock": {
       "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.1.tgz",
+      "integrity": "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==",
       "license": "MIT"
     },
     "node_modules/appium-uiautomator2-driver/node_modules/asyncbox": {
-      "version": "6.1.0",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/asyncbox/-/asyncbox-6.3.1.tgz",
+      "integrity": "sha512-48aDXFweBUWkAjmE6fCobYZY+rq93OYerERLIaVYVDGZSRNFYYaI+sZEJyqUwzxDSlzOHF6ckUEqis/JmHkrMA==",
       "license": "Apache-2.0",
       "dependencies": {
         "p-limit": "^7.2.0"
@@ -7049,19 +7070,26 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/asynckit": {
       "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
     "node_modules/appium-uiautomator2-driver/node_modules/axios": {
-      "version": "1.15.0",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/b4a": {
-      "version": "1.8.0",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "react-native-b4a": "*"
@@ -7073,11 +7101,18 @@
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "license": "MIT"
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/bare-events": {
-      "version": "2.8.2",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "bare-abort-controller": "*"
@@ -7089,7 +7124,9 @@
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/bare-fs": {
-      "version": "4.7.0",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.2.tgz",
+      "integrity": "sha512-aTvMFUWkBmjzKtEQMDGGDNF8bkfpD5N1b/FCwt7A3wrU4t1o/e/85Wzkluh6JlODCjqVESYCkQCdTXqZ9G7VFg==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-events": "^2.5.4",
@@ -7111,23 +7148,30 @@
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/bare-os": {
-      "version": "3.8.7",
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.3.tgz",
+      "integrity": "sha512-fF4Q7QsyKVF5Rj0qvI8BgUNjqzC2JvQlpTaPLjVJVxYVUX5Zr9un+y3w1HmA4nNKdFmRBT8z/WmrjvXzXVerKQ==",
       "license": "Apache-2.0",
       "engines": {
         "bare": ">=1.14.0"
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/bare-path": {
-      "version": "3.0.0",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.1.tgz",
+      "integrity": "sha512-ghj2DSK/2e99a1anTVPCV4m4YIYtrbXhfM7V3D7XZLOTsybnYyaJloymGqssQc8l/or0UoDyRtNQkmkEF/ysgQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-os": "^3.0.1"
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/bare-stream": {
-      "version": "2.12.0",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
+      "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
       "license": "Apache-2.0",
       "dependencies": {
+        "b4a": "^1.8.1",
         "streamx": "^2.25.0",
         "teex": "^1.0.1"
       },
@@ -7149,7 +7193,9 @@
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/bare-url": {
-      "version": "2.4.0",
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.5.tgz",
+      "integrity": "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-path": "^3.0.0"
@@ -7157,6 +7203,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/base64-js": {
       "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
       "funding": [
         {
           "type": "github",
@@ -7173,12 +7221,10 @@
       ],
       "license": "MIT"
     },
-    "node_modules/appium-uiautomator2-driver/node_modules/base64-stream": {
-      "version": "1.0.0",
-      "license": "MIT"
-    },
     "node_modules/appium-uiautomator2-driver/node_modules/basic-auth": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "5.1.2"
@@ -7189,6 +7235,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/big-integer": {
       "version": "1.6.52",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
       "license": "Unlicense",
       "engines": {
         "node": ">=0.6"
@@ -7196,10 +7244,14 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/bluebird": {
       "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
       "license": "MIT"
     },
     "node_modules/appium-uiautomator2-driver/node_modules/body-parser": {
       "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
@@ -7222,6 +7274,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/bplist-creator": {
       "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.1.1.tgz",
+      "integrity": "sha512-Ese7052fdWrxp/vqSJkydgx/1MdBnNOCV2XVfbmdGWD2H6EYza+Q4pyYSuVSnCUD22hfI/BFI4jHaC3NLXLlJQ==",
       "license": "MIT",
       "dependencies": {
         "stream-buffers": "2.2.x"
@@ -7229,6 +7283,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/bplist-parser": {
       "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.3.2.tgz",
+      "integrity": "sha512-apC2+fspHGI3mMKj+dGevkGo/tCqVB8jMb6i+OX+E29p0Iposz07fABkRIfVUPNd5A5VbuOz1bZbnmkKLYF+wQ==",
       "license": "MIT",
       "dependencies": {
         "big-integer": "1.6.x"
@@ -7237,8 +7293,22 @@
         "node": ">= 5.10.0"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/brace-expansion": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/buffer-crc32": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
@@ -7246,6 +7316,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/bytes": {
       "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -7253,6 +7325,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -7264,6 +7338,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/call-bound": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -7276,8 +7352,84 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "extraneous": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/cliui/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "extraneous": true,
+      "license": "MIT"
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/cliui/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/cliui/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/color-convert": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -7288,10 +7440,15 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/color-name": {
       "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "extraneous": true,
       "license": "MIT"
     },
     "node_modules/appium-uiautomator2-driver/node_modules/combined-stream": {
       "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -7302,28 +7459,40 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/compare-versions": {
       "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
+      "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
       "license": "MIT"
     },
     "node_modules/appium-uiautomator2-driver/node_modules/compress-commons": {
-      "version": "6.0.2",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-7.0.1.tgz",
+      "integrity": "sha512-g0S8KAD8qf4+V//pr3BfB1aBnARLXNz2Gx+jmHU0LEriUuoQUOPOulVquHKTJ8+EAIIO7fhseNDr9wK5Q9FKBQ==",
       "license": "MIT",
       "dependencies": {
         "crc-32": "^1.2.0",
-        "crc32-stream": "^6.0.0",
-        "is-stream": "^2.0.1",
+        "crc32-stream": "^7.0.1",
+        "is-stream": "^4.0.0",
         "normalize-path": "^3.0.0",
         "readable-stream": "^4.0.0"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">=18"
       }
     },
-    "node_modules/appium-uiautomator2-driver/node_modules/console-control-strings": {
-      "version": "1.1.0",
-      "license": "ISC"
+    "node_modules/appium-uiautomator2-driver/node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/content-disposition": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -7335,6 +7504,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/content-type": {
       "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -7342,6 +7513,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/cookie": {
       "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -7349,6 +7522,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/cookie-signature": {
       "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
@@ -7356,10 +7531,14 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/core-util-is": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
     },
     "node_modules/appium-uiautomator2-driver/node_modules/crc-32": {
       "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
       "license": "Apache-2.0",
       "bin": {
         "crc32": "bin/crc32.njs"
@@ -7369,47 +7548,22 @@
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/crc32-stream": {
-      "version": "6.0.0",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-7.0.1.tgz",
+      "integrity": "sha512-IBWsY8xznyQrcHn8h4bC8/4ErNke5elzgG8GcqF4RFPw6aHkWWRc7Tgw6upjaTX/CT/yQgqYENkxYsTYN+hW2g==",
       "license": "MIT",
       "dependencies": {
         "crc-32": "^1.2.0",
         "readable-stream": "^4.0.0"
       },
       "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/appium-uiautomator2-driver/node_modules/cross-spawn": {
-      "version": "7.0.6",
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/appium-uiautomator2-driver/node_modules/cross-spawn/node_modules/isexe": {
-      "version": "2.0.0",
-      "license": "ISC"
-    },
-    "node_modules/appium-uiautomator2-driver/node_modules/cross-spawn/node_modules/which": {
-      "version": "2.0.2",
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
+        "node": ">=18"
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/css-selector-parser": {
       "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-3.3.0.tgz",
+      "integrity": "sha512-Y2asgMGFqJKF4fq4xHDSlFYIkeVfRsm69lQC1q9kbEsH5XtnINTMrweLkjYMeaUgiXBy/uvKeO/a1JHTNnmB2g==",
       "funding": [
         {
           "type": "github",
@@ -7424,6 +7578,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/debug": {
       "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -7439,6 +7595,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/delayed-stream": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -7446,6 +7604,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/depd": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -7453,6 +7613,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/detect-libc": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "license": "Apache-2.0",
       "optional": true,
       "engines": {
@@ -7461,11 +7623,25 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/detect-node": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
       "license": "MIT",
       "optional": true
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/diff": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
+      "extraneous": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/dunder-proto": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -7478,22 +7654,20 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/duplexer": {
       "version": "0.1.2",
-      "license": "MIT"
-    },
-    "node_modules/appium-uiautomator2-driver/node_modules/eastasianwidth": {
-      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
       "license": "MIT"
     },
     "node_modules/appium-uiautomator2-driver/node_modules/ee-first": {
       "version": "1.1.1",
-      "license": "MIT"
-    },
-    "node_modules/appium-uiautomator2-driver/node_modules/emoji-regex": {
-      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
     "node_modules/appium-uiautomator2-driver/node_modules/encodeurl": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -7501,6 +7675,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/es-define-property": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7508,13 +7684,17 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/es-errors": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/es-object-atoms": {
-      "version": "1.1.1",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -7525,6 +7705,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/es-set-tostringtag": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -7536,12 +7718,26 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/escape-html": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
     },
     "node_modules/appium-uiautomator2-driver/node_modules/etag": {
       "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -7549,6 +7745,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/event-target-shim": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -7556,6 +7754,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/events": {
       "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
@@ -7563,6 +7763,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/events-universal": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-events": "^2.7.0"
@@ -7570,6 +7772,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/express": {
       "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
       "dependencies": {
         "accepts": "^2.0.0",
@@ -7611,10 +7815,14 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/fast-fifo": {
       "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "license": "MIT"
     },
     "node_modules/appium-uiautomator2-driver/node_modules/fastest-levenshtein": {
       "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+      "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
       "license": "MIT",
       "engines": {
         "node": ">= 4.9.1"
@@ -7622,6 +7830,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/finalhandler": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -7639,18 +7849,10 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/appium-uiautomator2-driver/node_modules/find-up-simple": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/appium-uiautomator2-driver/node_modules/follow-redirects": {
-      "version": "1.15.11",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -7667,39 +7869,17 @@
         }
       }
     },
-    "node_modules/appium-uiautomator2-driver/node_modules/foreground-child": {
-      "version": "3.3.1",
-      "license": "ISC",
-      "dependencies": {
-        "cross-spawn": "^7.0.6",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/appium-uiautomator2-driver/node_modules/foreground-child/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/appium-uiautomator2-driver/node_modules/form-data": {
-      "version": "4.0.5",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -7707,6 +7887,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/form-data/node_modules/mime-db": {
       "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -7714,6 +7896,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/form-data/node_modules/mime-types": {
       "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -7724,6 +7908,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/forwarded": {
       "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -7731,6 +7917,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/fresh": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -7738,6 +7926,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/ftp-response-parser": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ftp-response-parser/-/ftp-response-parser-1.0.1.tgz",
+      "integrity": "sha512-++Ahlo2hs/IC7UVQzjcSAfeUpCwTTzs4uvG5XfGnsinIFkWUYF4xWwPd5qZuK8MJrmUIxFMuHcfqaosCDjvIWw==",
       "dependencies": {
         "readable-stream": "^1.0.31"
       },
@@ -7747,10 +7937,14 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/ftp-response-parser/node_modules/isarray": {
       "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
       "license": "MIT"
     },
     "node_modules/appium-uiautomator2-driver/node_modules/ftp-response-parser/node_modules/readable-stream": {
       "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -7761,17 +7955,46 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/ftp-response-parser/node_modules/string_decoder": {
       "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
       "license": "MIT"
     },
     "node_modules/appium-uiautomator2-driver/node_modules/function-bind": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "extraneous": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/get-intrinsic": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -7794,6 +8017,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/get-proto": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -7803,32 +8028,10 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/appium-uiautomator2-driver/node_modules/get-stream": {
-      "version": "9.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "@sec-ant/readable-stream": "^0.4.1",
-        "is-stream": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/appium-uiautomator2-driver/node_modules/get-stream/node_modules/is-stream": {
-      "version": "4.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/appium-uiautomator2-driver/node_modules/glob": {
       "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "minimatch": "^10.2.2",
@@ -7842,38 +8045,10 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/appium-uiautomator2-driver/node_modules/glob/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/appium-uiautomator2-driver/node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/appium-uiautomator2-driver/node_modules/glob/node_modules/minimatch": {
-      "version": "10.2.5",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/appium-uiautomator2-driver/node_modules/gopd": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7882,17 +8057,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/appium-uiautomator2-driver/node_modules/graceful-fs": {
-      "version": "4.2.11",
-      "license": "ISC"
-    },
     "node_modules/appium-uiautomator2-driver/node_modules/handle-thing": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
+      "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
       "license": "MIT",
       "optional": true
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/has-symbols": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7903,6 +8088,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/has-tostringtag": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -7915,7 +8102,9 @@
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/hasown": {
-      "version": "2.0.2",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -7925,7 +8114,9 @@
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/hosted-git-info": {
-      "version": "9.0.2",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+      "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
       "license": "ISC",
       "dependencies": {
         "lru-cache": "^11.1.0"
@@ -7936,6 +8127,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/hpack.js": {
       "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
+      "integrity": "sha512-zJxVehUdMGIKsRaNt7apO2Gqp0BdqW5yaiGHXXmbpvxgBYVZnAql+BJb4RO5ad2MgpbZKn5G6nMnegrH1FcNYQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -7947,6 +8140,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/hpack.js/node_modules/readable-stream": {
       "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -7961,6 +8156,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/hpack.js/node_modules/string_decoder": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -7969,11 +8166,15 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/http-deceiver": {
       "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
+      "integrity": "sha512-LmpOGxTfbpgtGVxJrj5k7asXHCgNZp5nLfp+hWc8QQRqtb7fUy6kRY3BO1h9ddF6yIPYUARgxGOwB42DnxIaNw==",
       "license": "MIT",
       "optional": true
     },
     "node_modules/appium-uiautomator2-driver/node_modules/http-errors": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "license": "MIT",
       "dependencies": {
         "depd": "~2.0.0",
@@ -7992,10 +8193,27 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/http-status-codes": {
       "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.3.0.tgz",
+      "integrity": "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==",
       "license": "MIT"
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/iconv-lite": {
       "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -8010,6 +8228,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/ieee754": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
       "funding": [
         {
           "type": "github",
@@ -8026,28 +8246,29 @@
       ],
       "license": "BSD-3-Clause"
     },
-    "node_modules/appium-uiautomator2-driver/node_modules/index-to-position": {
-      "version": "1.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/appium-uiautomator2-driver/node_modules/inherits": {
       "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/ini": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
+      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/io.appium.settings": {
-      "version": "7.0.22",
+      "version": "7.1.9",
+      "resolved": "https://registry.npmjs.org/io.appium.settings/-/io.appium.settings-7.1.9.tgz",
+      "integrity": "sha512-+gonaCuZSXcpbT2HGYVf0x+6brrygik90LhEKTjhl5GthE18h7wU0JUk/GMoVDRpPHeAq/S/p9RyjmPdU3Hwyw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@appium/logger": "^2.0.0-rc.1",
         "asyncbox": "^6.0.1",
-        "bluebird": "^3.5.1",
-        "lodash": "^4.2.1",
         "semver": "^7.5.4",
         "teen_process": "^4.0.4"
       },
@@ -8058,20 +8279,17 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/ipaddr.js": {
       "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
       }
     },
-    "node_modules/appium-uiautomator2-driver/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/appium-uiautomator2-driver/node_modules/is-number-like": {
       "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/is-number-like/-/is-number-like-1.0.8.tgz",
+      "integrity": "sha512-6rZi3ezCyFcn5L71ywzz2bS5b2Igl1En3eTlZlvKjpz1n3IZLAYMbKYAIQgFmEu0GENg92ziU/faEOA/aixjbA==",
       "license": "ISC",
       "dependencies": {
         "lodash.isfinite": "^3.3.2"
@@ -8079,20 +8297,14 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/is-promise": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
     "node_modules/appium-uiautomator2-driver/node_modules/is-stream": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/appium-uiautomator2-driver/node_modules/is-unicode-supported": {
-      "version": "2.1.0",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -8103,34 +8315,23 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/isarray": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "license": "MIT"
     },
     "node_modules/appium-uiautomator2-driver/node_modules/isexe": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=20"
       }
     },
-    "node_modules/appium-uiautomator2-driver/node_modules/jackspeak": {
-      "version": "3.4.3",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
-    "node_modules/appium-uiautomator2-driver/node_modules/js-tokens": {
-      "version": "4.0.0",
-      "license": "MIT"
-    },
     "node_modules/appium-uiautomator2-driver/node_modules/jsftp": {
       "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/jsftp/-/jsftp-2.1.3.tgz",
+      "integrity": "sha512-r79EVB8jaNAZbq8hvanL8e8JGu2ZNr2bXdHC4ZdQhRImpSPpnWwm5DYVzQ5QxJmtGtKhNNuvqGgbNaFl604fEQ==",
       "license": "MIT",
       "dependencies": {
         "debug": "^3.1.0",
@@ -8146,6 +8347,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/jsftp/node_modules/debug": {
       "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
@@ -8153,10 +8356,14 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/json-schema": {
       "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/appium-uiautomator2-driver/node_modules/klaw": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-4.1.0.tgz",
+      "integrity": "sha512-1zGZ9MF9H22UnkpVeuaGKOjfA2t6WrfdrJmGjy16ykcjnKQDmHVX+KI477rpbGevz/5FD4MC3xf1oxylBgcaQw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.14.0"
@@ -8164,6 +8371,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/lazystream": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
       "license": "MIT",
       "dependencies": {
         "readable-stream": "^2.0.5"
@@ -8174,6 +8383,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/lazystream/node_modules/readable-stream": {
       "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -8187,13 +8398,30 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/lazystream/node_modules/string_decoder": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/lockfile": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.4.tgz",
+      "integrity": "sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==",
       "license": "ISC",
       "dependencies": {
         "signal-exit": "^3.0.2"
@@ -8201,28 +8429,20 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/lodash": {
       "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/appium-uiautomator2-driver/node_modules/lodash.isfinite": {
       "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz",
+      "integrity": "sha512-7FGG40uhC8Mm633uKW1r58aElFlBlxCrg9JfSi3P6aYiWmfiWF0PgMd86ZUsxE5GwWPdHoS2+48bwTh2VPkIQA==",
       "license": "MIT"
     },
-    "node_modules/appium-uiautomator2-driver/node_modules/log-symbols": {
-      "version": "7.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "is-unicode-supported": "^2.0.0",
-        "yoctocolors": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/appium-uiautomator2-driver/node_modules/lru-cache": {
-      "version": "11.3.3",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -8230,6 +8450,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/math-intrinsics": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8237,6 +8459,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/media-typer": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -8244,6 +8468,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/merge-descriptors": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -8254,6 +8480,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/method-override": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/method-override/-/method-override-3.0.0.tgz",
+      "integrity": "sha512-IJ2NNN/mSl9w3kzWB92rcdHpz+HjkxhDJWNDBqSlas+zQdP8wBiJzITPg08M/k2uVvMow7Sk41atndNtt/PHSA==",
       "license": "MIT",
       "dependencies": {
         "debug": "3.1.0",
@@ -8267,6 +8495,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/method-override/node_modules/debug": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -8274,10 +8504,14 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/method-override/node_modules/ms": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
     "node_modules/appium-uiautomator2-driver/node_modules/methods": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -8285,6 +8519,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/mime-db": {
       "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -8292,6 +8528,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/mime-types": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
       "dependencies": {
         "mime-db": "^1.54.0"
@@ -8304,13 +8542,42 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/minimalistic-assert": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
       "license": "ISC",
       "optional": true
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/minipass": {
       "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -8318,13 +8585,17 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/moment": {
       "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
       "license": "MIT",
       "engines": {
         "node": "*"
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/moment-timezone": {
-      "version": "0.6.1",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.6.2.tgz",
+      "integrity": "sha512-lDsQv8FoGdBUdf0+TjGsq2orxKuXdwFlQ6Zw6TX3xIcTwTfEpCLyKqvEauvCHJ8iu3KBV8+uPhlv70YsNGdUBQ==",
       "license": "MIT",
       "dependencies": {
         "moment": "^2.29.4"
@@ -8334,21 +8605,29 @@
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/morgan": {
-      "version": "1.10.1",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.11.0.tgz",
+      "integrity": "sha512-zSkVu3t18r39pw4ixfBKvfZi3y2UOqr7d4WYwcj3m8nXpEQK4rPO6GLzs/CExoRgmX3y9EjmmcXqv6jq0SK46g==",
       "license": "MIT",
       "dependencies": {
         "basic-auth": "~2.0.1",
         "debug": "2.6.9",
         "depd": "~2.0.0",
-        "on-finished": "~2.3.0",
+        "on-finished": "~2.4.1",
         "on-headers": "~1.1.0"
       },
       "engines": {
         "node": ">= 0.8.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/morgan/node_modules/debug": {
       "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -8356,31 +8635,20 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/morgan/node_modules/ms": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
-    },
-    "node_modules/appium-uiautomator2-driver/node_modules/morgan/node_modules/on-finished": {
-      "version": "2.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "ee-first": "1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/ms": {
       "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
-    },
-    "node_modules/appium-uiautomator2-driver/node_modules/ncp": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "bin": {
-        "ncp": "bin/ncp"
-      }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/negotiator": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -8388,6 +8656,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/normalize-package-data": {
       "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-8.0.0.tgz",
+      "integrity": "sha512-RWk+PI433eESQ7ounYxIp67CYuVsS1uYSonX3kA6ps/3LWfjVQa/ptEg6Y3T6uAMq1mWpX9PQ+qx+QaHpsc7gQ==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "hosted-git-info": "^9.0.0",
@@ -8400,6 +8670,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/normalize-path": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8407,6 +8679,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/object-inspect": {
       "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8417,11 +8691,15 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/obuf": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
+      "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
       "license": "MIT",
       "optional": true
     },
     "node_modules/appium-uiautomator2-driver/node_modules/on-finished": {
       "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
       "license": "MIT",
       "dependencies": {
         "ee-first": "1.1.1"
@@ -8432,6 +8710,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/on-headers": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -8439,13 +8719,33 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/once": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/p-limit": {
       "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.0.tgz",
+      "integrity": "sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw==",
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^1.2.1"
@@ -8457,70 +8757,27 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/appium-uiautomator2-driver/node_modules/package-directory": {
-      "version": "8.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "find-up-simple": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/appium-uiautomator2-driver/node_modules/package-json-from-dist": {
-      "version": "1.0.1",
-      "license": "BlueOak-1.0.0"
-    },
-    "node_modules/appium-uiautomator2-driver/node_modules/parse-json": {
-      "version": "8.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.26.2",
-        "index-to-position": "^1.1.0",
-        "type-fest": "^4.39.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/appium-uiautomator2-driver/node_modules/parse-json/node_modules/type-fest": {
-      "version": "4.41.0",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/appium-uiautomator2-driver/node_modules/parse-listing": {
       "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/parse-listing/-/parse-listing-1.1.3.tgz",
+      "integrity": "sha512-a1p1i+9Qyc8pJNwdrSvW1g5TPxRH0sywVi6OzVvYHRo6xwF9bDWBxtH0KkxeOOvhUE8vAMtiSfsYQFOuK901eA==",
       "engines": {
         "node": ">=0.6.21"
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/parseurl": {
       "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
     },
-    "node_modules/appium-uiautomator2-driver/node_modules/path-key": {
-      "version": "3.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/appium-uiautomator2-driver/node_modules/path-scurry": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^11.0.0",
@@ -8535,6 +8792,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/path-to-regexp": {
       "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -8543,33 +8802,27 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/pend": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "license": "MIT"
     },
-    "node_modules/appium-uiautomator2-driver/node_modules/picocolors": {
-      "version": "1.1.1",
-      "license": "ISC"
-    },
     "node_modules/appium-uiautomator2-driver/node_modules/plist": {
-      "version": "3.1.0",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-4.0.0.tgz",
+      "integrity": "sha512-4dOqNo0Y2NpfSf9q4+zr4bh7pzNWeckIam34Z0KYJhg8qtNNfh59VbD+Yna5SjwcxawVvLKx5w5FtuCijpEF4Q==",
       "license": "MIT",
       "dependencies": {
-        "@xmldom/xmldom": "^0.8.8",
-        "base64-js": "^1.5.1",
+        "@xmldom/xmldom": "^0.9.10",
         "xmlbuilder": "^15.1.1"
       },
       "engines": {
-        "node": ">=10.4.0"
-      }
-    },
-    "node_modules/appium-uiautomator2-driver/node_modules/plist/node_modules/@xmldom/xmldom": {
-      "version": "0.8.12",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
+        "node": ">=18"
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/pluralize": {
       "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -8577,6 +8830,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/portscanner": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/portscanner/-/portscanner-2.2.0.tgz",
+      "integrity": "sha512-IFroCz/59Lqa2uBvzK3bKDbDDIEaAY8XJ1jFxcLWTqosrsc32//P4VuSB2vZXoHiHqOmx8B5L5hnKOxL/7FlPw==",
       "license": "MIT",
       "dependencies": {
         "async": "^2.6.0",
@@ -8589,6 +8844,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/portscanner/node_modules/async": {
       "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.14"
@@ -8596,6 +8853,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/process": {
       "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6.0"
@@ -8603,10 +8862,14 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/process-nextick-args": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
     },
     "node_modules/appium-uiautomator2-driver/node_modules/proxy-addr": {
       "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
       "license": "MIT",
       "dependencies": {
         "forwarded": "0.2.0",
@@ -8618,16 +8881,21 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/proxy-from-env": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
       "license": "MIT",
       "engines": {
         "node": ">=10"
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/qs": {
-      "version": "6.15.1",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -8637,14 +8905,22 @@
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/range-parser": {
-      "version": "1.2.1",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/raw-body": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -8656,25 +8932,10 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/appium-uiautomator2-driver/node_modules/read-pkg": {
-      "version": "10.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "@types/normalize-package-data": "^2.4.4",
-        "normalize-package-data": "^8.0.0",
-        "parse-json": "^8.3.0",
-        "type-fest": "^5.4.4",
-        "unicorn-magic": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/appium-uiautomator2-driver/node_modules/readable-stream": {
       "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
       "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",
@@ -8689,6 +8950,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/readable-stream/node_modules/buffer": {
       "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
       "funding": [
         {
           "type": "github",
@@ -8710,38 +8973,24 @@
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/readdir-glob": {
-      "version": "1.1.3",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-3.0.0.tgz",
+      "integrity": "sha512-AhNB2KgKeVJr16nK9LLZbJNWnYoT23ZrumNKFDebHBdkC8KHSqWo871JAUhoWC/RtjEVdqNMFpM6qrwRbaUqpw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "minimatch": "^5.1.0"
-      }
-    },
-    "node_modules/appium-uiautomator2-driver/node_modules/readdir-glob/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/appium-uiautomator2-driver/node_modules/readdir-glob/node_modules/minimatch": {
-      "version": "5.1.9",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "minimatch": "^10.2.2"
       },
       "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/appium-uiautomator2-driver/node_modules/resolve-from": {
-      "version": "5.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/yqnn"
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/router": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -8756,14 +9005,20 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/safe-buffer": {
       "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
     "node_modules/appium-uiautomator2-driver/node_modules/safer-buffer": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
     "node_modules/appium-uiautomator2-driver/node_modules/sanitize-filename": {
       "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.4.tgz",
+      "integrity": "sha512-9ZyI08PsvdQl2r/bBIGubpVdR3RR9sY6RDiWFPreA21C/EFlQhmgo20UZlNjZMMZNubusLhAQozkA0Od5J21Eg==",
       "license": "WTFPL OR ISC",
       "dependencies": {
         "truncate-utf8-bytes": "^1.0.0"
@@ -8771,11 +9026,15 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/select-hose": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
+      "integrity": "sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg==",
       "license": "MIT",
       "optional": true
     },
     "node_modules/appium-uiautomator2-driver/node_modules/semver": {
-      "version": "7.7.4",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -8786,6 +9045,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/send": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.3",
@@ -8810,6 +9071,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/serve-favicon": {
       "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.5.1.tgz",
+      "integrity": "sha512-JndLBslCLA/ebr7rS3d+/EKkzTsTi1jI2T9l+vHfAaGJ7A7NhtDpSZ0lx81HCNWnnE0yHncG+SSnVf9IMxOwXQ==",
       "license": "MIT",
       "dependencies": {
         "etag": "~1.8.1",
@@ -8824,6 +9087,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/serve-favicon/node_modules/fresh": {
       "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -8831,6 +9096,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/serve-favicon/node_modules/safe-buffer": {
       "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "funding": [
         {
           "type": "github",
@@ -8849,6 +9116,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/serve-static": {
       "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
       "license": "MIT",
       "dependencies": {
         "encodeurl": "^2.0.0",
@@ -8864,76 +9133,16 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/appium-uiautomator2-driver/node_modules/set-blocking": {
-      "version": "2.0.0",
-      "license": "ISC"
-    },
     "node_modules/appium-uiautomator2-driver/node_modules/setprototypeof": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
     },
-    "node_modules/appium-uiautomator2-driver/node_modules/sharp": {
-      "version": "0.34.5",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@img/colour": "^1.0.0",
-        "detect-libc": "^2.1.2",
-        "semver": "^7.7.3"
-      },
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.5",
-        "@img/sharp-darwin-x64": "0.34.5",
-        "@img/sharp-libvips-darwin-arm64": "1.2.4",
-        "@img/sharp-libvips-darwin-x64": "1.2.4",
-        "@img/sharp-libvips-linux-arm": "1.2.4",
-        "@img/sharp-libvips-linux-arm64": "1.2.4",
-        "@img/sharp-libvips-linux-ppc64": "1.2.4",
-        "@img/sharp-libvips-linux-riscv64": "1.2.4",
-        "@img/sharp-libvips-linux-s390x": "1.2.4",
-        "@img/sharp-libvips-linux-x64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-        "@img/sharp-linux-arm": "0.34.5",
-        "@img/sharp-linux-arm64": "0.34.5",
-        "@img/sharp-linux-ppc64": "0.34.5",
-        "@img/sharp-linux-riscv64": "0.34.5",
-        "@img/sharp-linux-s390x": "0.34.5",
-        "@img/sharp-linux-x64": "0.34.5",
-        "@img/sharp-linuxmusl-arm64": "0.34.5",
-        "@img/sharp-linuxmusl-x64": "0.34.5",
-        "@img/sharp-wasm32": "0.34.5",
-        "@img/sharp-win32-arm64": "0.34.5",
-        "@img/sharp-win32-ia32": "0.34.5",
-        "@img/sharp-win32-x64": "0.34.5"
-      }
-    },
-    "node_modules/appium-uiautomator2-driver/node_modules/shebang-command": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "shebang-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/appium-uiautomator2-driver/node_modules/shebang-regex": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/appium-uiautomator2-driver/node_modules/shell-quote": {
-      "version": "1.8.3",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8943,12 +9152,14 @@
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/side-channel": {
-      "version": "1.1.0",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -8961,6 +9172,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/side-channel-list": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -8975,6 +9188,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/side-channel-map": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -8991,6 +9206,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/side-channel-weakmap": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -9008,34 +9225,46 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/signal-exit": {
       "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
     },
     "node_modules/appium-uiautomator2-driver/node_modules/spdx-correct": {
       "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+      "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
       "license": "Apache-2.0",
       "dependencies": {
         "spdx-expression-parse": "^3.0.0",
         "spdx-license-ids": "^3.0.0"
       }
     },
-    "node_modules/appium-uiautomator2-driver/node_modules/spdx-exceptions": {
-      "version": "2.5.0",
-      "license": "CC-BY-3.0"
-    },
-    "node_modules/appium-uiautomator2-driver/node_modules/spdx-expression-parse": {
+    "node_modules/appium-uiautomator2-driver/node_modules/spdx-correct/node_modules/spdx-expression-parse": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
       "license": "MIT",
       "dependencies": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/spdx-exceptions": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+      "license": "CC-BY-3.0"
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/spdx-license-ids": {
       "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+      "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
       "license": "CC0-1.0"
     },
     "node_modules/appium-uiautomator2-driver/node_modules/spdy": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/spdy/-/spdy-4.0.2.tgz",
+      "integrity": "sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -9051,6 +9280,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/spdy-transport": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-3.0.0.tgz",
+      "integrity": "sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -9064,6 +9295,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/spdy-transport/node_modules/readable-stream": {
       "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -9077,6 +9310,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/statuses": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -9084,6 +9319,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/stream-buffers": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
+      "integrity": "sha512-uyQK/mx5QjHun80FLJTfaWE7JtwfRMKBLkMne6udYOmvH0CawotVa7TfgYHzAnpphn4+TweIx1QKMnRIbipmUg==",
       "license": "Unlicense",
       "engines": {
         "node": ">= 0.10.0"
@@ -9091,6 +9328,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/stream-combiner": {
       "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+      "integrity": "sha512-6yHMqgLYDzQDcAkL+tjJDC5nSNuNIx0vZtRZeiPh7Saef7VHX9H5Ijn9l2VIol2zaNYlYEX6KyuT/237A58qEQ==",
       "license": "MIT",
       "dependencies": {
         "duplexer": "~0.1.1",
@@ -9098,7 +9337,9 @@
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/streamx": {
-      "version": "2.25.0",
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
+      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
       "license": "MIT",
       "dependencies": {
         "events-universal": "^1.0.0",
@@ -9108,6 +9349,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/string_decoder": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -9115,6 +9358,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/string_decoder/node_modules/safe-buffer": {
       "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "funding": [
         {
           "type": "github",
@@ -9131,78 +9376,46 @@
       ],
       "license": "MIT"
     },
-    "node_modules/appium-uiautomator2-driver/node_modules/string-width": {
-      "version": "4.2.3",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/appium-uiautomator2-driver/node_modules/string-width-cjs": {
-      "name": "string-width",
-      "version": "4.2.3",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/appium-uiautomator2-driver/node_modules/strip-ansi": {
       "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/appium-uiautomator2-driver/node_modules/strip-ansi-cjs": {
-      "name": "strip-ansi",
-      "version": "6.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/appium-uiautomator2-driver/node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/strip-ansi/node_modules/ansi-regex": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "extraneous": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/supports-color": {
-      "version": "10.2.2",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "extraneous": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=18"
+      "dependencies": {
+        "has-flag": "^4.0.0"
       },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/tagged-tag": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -9212,7 +9425,9 @@
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/tar-stream": {
-      "version": "3.1.8",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
       "license": "MIT",
       "dependencies": {
         "b4a": "^1.6.4",
@@ -9222,10 +9437,11 @@
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/teen_process": {
-      "version": "4.1.0",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/teen_process/-/teen_process-4.1.7.tgz",
+      "integrity": "sha512-rWYaZsS8hjySi6lgrewZsOtELuya7W2xu2DEG16ibcDcH+iyqn4fyp8Y08IncBo/q8MdOibVyP9GViqzvA7nsw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "lodash": "^4.17.21",
         "shell-quote": "^1.8.1"
       },
       "engines": {
@@ -9235,6 +9451,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/teex": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
       "license": "MIT",
       "dependencies": {
         "streamx": "^2.12.5"
@@ -9242,6 +9460,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/text-decoder": {
       "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "b4a": "^1.6.4"
@@ -9249,10 +9469,14 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/through": {
       "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "license": "MIT"
     },
     "node_modules/appium-uiautomator2-driver/node_modules/toidentifier": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
@@ -9260,13 +9484,24 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/truncate-utf8-bytes": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==",
       "license": "WTFPL",
       "dependencies": {
         "utf8-byte-length": "^1.0.1"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "extraneous": true,
+      "license": "0BSD"
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/type-fest": {
-      "version": "5.5.0",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.7.0.tgz",
+      "integrity": "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==",
       "license": "(MIT OR CC0-1.0)",
       "dependencies": {
         "tagged-tag": "^1.0.0"
@@ -9279,29 +9514,40 @@
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/type-is": {
-      "version": "2.0.1",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/appium-uiautomator2-driver/node_modules/unicorn-magic": {
-      "version": "0.4.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
+        "node": ">= 18"
       },
       "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/appium-uiautomator2-driver/node_modules/unorm": {
       "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.6.0.tgz",
+      "integrity": "sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA==",
       "license": "MIT or GPL-2.0",
       "engines": {
         "node": ">= 0.4.0"
@@ -9309,6 +9555,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/unpipe": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -9316,14 +9564,20 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/utf8-byte-length": {
       "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
+      "integrity": "sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==",
       "license": "(WTFPL OR MIT)"
     },
     "node_modules/appium-uiautomator2-driver/node_modules/util-deprecate": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
     "node_modules/appium-uiautomator2-driver/node_modules/uuid": {
-      "version": "13.0.0",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -9335,14 +9589,28 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/validate-npm-package-license": {
       "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "license": "Apache-2.0",
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/validate-npm-package-license/node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/vary": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -9350,6 +9618,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/wbuf": {
       "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
+      "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -9358,6 +9628,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/which": {
       "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+      "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
       "license": "ISC",
       "dependencies": {
         "isexe": "^4.0.0"
@@ -9369,28 +9641,88 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/appium-uiautomator2-driver/node_modules/wrap-ansi-cjs": {
-      "name": "wrap-ansi",
-      "version": "7.0.0",
+    "node_modules/appium-uiautomator2-driver/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/appium-uiautomator2-driver/node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/wrap-ansi/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "extraneous": true,
+      "license": "MIT"
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/appium-uiautomator2-driver/node_modules/wrappy": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
     "node_modules/appium-uiautomator2-driver/node_modules/ws": {
-      "version": "8.20.0",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -9410,6 +9742,8 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/xmlbuilder": {
       "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
       "license": "MIT",
       "engines": {
         "node": ">=8.0"
@@ -9417,31 +9751,124 @@
     },
     "node_modules/appium-uiautomator2-driver/node_modules/xpath": {
       "version": "0.0.34",
+      "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.34.tgz",
+      "integrity": "sha512-FxF6+rkr1rNSQrhUNYrAFJpRXNzlDoMxeXN5qI84939ylEv3qqPFKa85Oxr6tDaJKqwW6KKyo2v26TSv3k6LeA==",
       "license": "MIT",
       "engines": {
         "node": ">=0.6.0"
       }
     },
-    "node_modules/appium-uiautomator2-driver/node_modules/yauzl": {
-      "version": "3.3.0",
+    "node_modules/appium-uiautomator2-driver/node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "extraneous": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "extraneous": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "extraneous": true,
       "license": "MIT",
       "dependencies": {
-        "buffer-crc32": "~0.2.3",
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "extraneous": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/yargs/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "extraneous": true,
+      "license": "MIT"
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/yargs/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/yargs/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/appium-uiautomator2-driver/node_modules/yauzl": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
+      "license": "MIT",
+      "dependencies": {
         "pend": "~1.2.0"
       },
       "engines": {
         "node": ">=12"
       }
     },
-    "node_modules/appium-uiautomator2-driver/node_modules/yauzl/node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/appium-uiautomator2-driver/node_modules/yocto-queue": {
       "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
       "license": "MIT",
       "engines": {
         "node": ">=12.20"
@@ -9450,26 +9877,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/appium-uiautomator2-driver/node_modules/yoctocolors": {
-      "version": "2.1.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/appium-uiautomator2-driver/node_modules/zip-stream": {
-      "version": "6.0.1",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-7.0.5.tgz",
+      "integrity": "sha512-dSvYKdvLsAHCDqPOhIwk/q5CvuWtTB3Dgpoe0uVEFjTzIOAmsQpprX25InCvrvJsirEbu1OHyy67n/kAj1Sw/w==",
       "license": "MIT",
       "dependencies": {
-        "archiver-utils": "^5.0.0",
-        "compress-commons": "^6.0.2",
+        "compress-commons": "^7.0.0",
+        "normalize-path": "^3.0.0",
         "readable-stream": "^4.0.0"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">=18"
       }
     },
     "node_modules/appium-webdriveragent": {
@@ -9838,9 +10257,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -9856,9 +10272,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -9876,9 +10289,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -9894,9 +10304,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -9914,9 +10321,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -9933,9 +10337,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -9951,9 +10352,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -9977,9 +10375,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -10001,9 +10396,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -10027,9 +10419,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -10052,9 +10441,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -10076,9 +10462,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -13829,6 +14212,7 @@
     "node_modules/bl": {
       "version": "4.1.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -13838,6 +14222,7 @@
     "node_modules/bl/node_modules/readable-stream": {
       "version": "3.6.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -13956,6 +14341,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -14084,7 +14470,9 @@
     },
     "node_modules/chownr": {
       "version": "1.1.4",
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true,
+      "peer": true
     },
     "node_modules/cjs-module-lexer": {
       "version": "2.2.0",
@@ -14757,6 +15145,8 @@
     "node_modules/decompress-response": {
       "version": "6.0.0",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "mimic-response": "^3.1.0"
       },
@@ -14773,6 +15163,7 @@
     },
     "node_modules/deep-extend": {
       "version": "0.6.0",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=4.0.0"
@@ -15437,7 +15828,9 @@
     },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/events": {
       "version": "3.3.0",
@@ -15508,6 +15901,8 @@
     "node_modules/expand-template": {
       "version": "2.0.3",
       "license": "(MIT OR WTFPL)",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -15866,7 +16261,9 @@
     },
     "node_modules/flatbuffers": {
       "version": "1.12.0",
-      "license": "SEE LICENSE IN LICENSE.txt"
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "peer": true
     },
     "node_modules/fn.name": {
       "version": "1.1.0",
@@ -16005,7 +16402,9 @@
     },
     "node_modules/fs-constants": {
       "version": "1.0.0",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/fs-extra": {
       "version": "11.3.4",
@@ -16265,7 +16664,9 @@
     },
     "node_modules/github-from-package": {
       "version": "0.0.0",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/glob": {
       "version": "13.0.6",
@@ -16352,7 +16753,9 @@
     },
     "node_modules/guid-typescript": {
       "version": "1.0.9",
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true,
+      "peer": true
     },
     "node_modules/handle-thing": {
       "version": "2.0.1",
@@ -16361,6 +16764,7 @@
     },
     "node_modules/handlebars": {
       "version": "4.7.9",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.5",
@@ -17197,6 +17601,8 @@
     "node_modules/js-tiktoken": {
       "version": "1.0.21",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "base64-js": "^1.5.1"
       }
@@ -17207,6 +17613,7 @@
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -17286,6 +17693,8 @@
     "node_modules/jsonpointer": {
       "version": "5.0.1",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -17441,6 +17850,8 @@
     "node_modules/langsmith": {
       "version": "0.7.10",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "p-queue": "6.6.2"
       },
@@ -17638,9 +18049,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -17662,9 +18070,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -17686,9 +18091,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -17710,9 +18112,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -17953,7 +18352,9 @@
     },
     "node_modules/long": {
       "version": "4.0.0",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -18202,6 +18603,8 @@
     "node_modules/mimic-response": {
       "version": "3.1.0",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -18254,7 +18657,9 @@
     },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/mocha": {
       "version": "9.2.2",
@@ -18528,6 +18933,8 @@
     "node_modules/mustache": {
       "version": "4.2.0",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "bin": {
         "mustache": "bin/mustache"
       }
@@ -18560,7 +18967,9 @@
     },
     "node_modules/napi-build-utils": {
       "version": "2.0.0",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/ncp": {
       "version": "2.0.0",
@@ -18578,6 +18987,7 @@
     },
     "node_modules/neo-async": {
       "version": "2.6.2",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/nerf-dart": {
@@ -18595,6 +19005,8 @@
     "node_modules/node-abi": {
       "version": "3.90.0",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -18604,7 +19016,9 @@
     },
     "node_modules/node-addon-api": {
       "version": "6.1.0",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",
@@ -21349,13 +21763,17 @@
     "node_modules/onnx-proto": {
       "version": "4.0.4",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "protobufjs": "^6.8.8"
       }
     },
     "node_modules/onnxruntime-common": {
       "version": "1.14.0",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/onnxruntime-node": {
       "version": "1.14.0",
@@ -21366,6 +21784,7 @@
         "darwin",
         "linux"
       ],
+      "peer": true,
       "dependencies": {
         "onnxruntime-common": "~1.14.0"
       }
@@ -21373,6 +21792,8 @@
     "node_modules/onnxruntime-web": {
       "version": "1.14.0",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "flatbuffers": "^1.12.0",
         "guid-typescript": "^1.0.9",
@@ -21385,6 +21806,8 @@
     "node_modules/openai": {
       "version": "6.43.0",
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "peerDependencies": {
         "ws": "^8.18.0",
         "zod": "^3.25 || ^4.0"
@@ -21400,7 +21823,9 @@
     },
     "node_modules/openapi-types": {
       "version": "12.1.3",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/ora": {
       "version": "5.4.1",
@@ -21562,6 +21987,8 @@
     "node_modules/p-finally": {
       "version": "1.0.0",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -21637,6 +22064,8 @@
     "node_modules/p-queue": {
       "version": "6.6.2",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "eventemitter3": "^4.0.4",
         "p-timeout": "^3.2.0"
@@ -21672,6 +22101,8 @@
     "node_modules/p-timeout": {
       "version": "3.2.0",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "p-finally": "^1.0.0"
       },
@@ -22039,7 +22470,9 @@
     },
     "node_modules/platform": {
       "version": "1.3.6",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/plist": {
       "version": "3.1.0",
@@ -22097,6 +22530,8 @@
     "node_modules/prebuild-install": {
       "version": "7.1.3",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.0",
         "expand-template": "^2.0.3",
@@ -22121,6 +22556,8 @@
     "node_modules/prebuild-install/node_modules/readable-stream": {
       "version": "3.6.2",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -22133,6 +22570,8 @@
     "node_modules/prebuild-install/node_modules/tar-fs": {
       "version": "2.1.4",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -22143,6 +22582,8 @@
     "node_modules/prebuild-install/node_modules/tar-stream": {
       "version": "2.2.0",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -22208,6 +22649,8 @@
       "version": "6.11.5",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -22331,6 +22774,7 @@
     },
     "node_modules/rc": {
       "version": "1.2.8",
+      "devOptional": true,
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
       "dependencies": {
         "deep-extend": "^0.6.0",
@@ -22344,10 +22788,12 @@
     },
     "node_modules/rc/node_modules/ini": {
       "version": "1.3.8",
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/rc/node_modules/strip-json-comments": {
       "version": "2.0.1",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -23450,7 +23896,9 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/simple-get": {
       "version": "4.0.1",
@@ -23469,6 +23917,8 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
@@ -23597,6 +24047,7 @@
     },
     "node_modules/source-map": {
       "version": "0.6.1",
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -24328,6 +24779,8 @@
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       },
@@ -24371,6 +24824,7 @@
     },
     "node_modules/uglify-js": {
       "version": "3.19.3",
+      "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
       "bin": {
@@ -24897,6 +25351,7 @@
     },
     "node_modules/wordwrap": {
       "version": "1.0.0",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/workerpool": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@modelcontextprotocol/sdk": "^1.22.0",
     "ai": "^6.0.72",
     "ai-sdk-ollama": "3.8.3",
-    "appium-mcp": "1.85.8",
+    "appium-mcp": "^1.87.0",
     "boxen": "^8.0.1",
     "chalk": "^5.6.2",
     "cli-spinners": "^3.4.0",

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -39,12 +39,23 @@ const theme = {
 type Platform = 'android' | 'ios';
 type Provider = 'anthropic' | 'openai' | 'gemini' | 'groq' | 'ollama';
 type AgentMode = 'dom' | 'vision';
+type CloudProvider = 'none' | 'browserstack' | 'saucelabs' | 'lambdatest' | 'custom';
+
+/** Cloud creds collected interactively (only when a provider other than 'none' is chosen). */
+interface CloudChoices {
+  provider: CloudProvider;
+  username: string;
+  accessKey: string;
+  deviceName: string;
+  osVersion: string;
+}
 
 interface InitChoices {
   dir: string;
   platform: Platform;
   provider: Provider;
   agentMode: AgentMode;
+  cloud: CloudChoices;
 }
 
 const PROVIDERS: { value: Provider; label: string }[] = [
@@ -207,6 +218,50 @@ const MODE_ITEMS: PickerItem<AgentMode>[] = [
   { value: 'dom', label: 'DOM', hint: 'fast, cheap — reads the UI tree' },
   { value: 'vision', label: 'Vision', hint: 'screenshot + AI — for canvas/games' },
 ];
+const CLOUD_ITEMS: PickerItem<CloudProvider>[] = [
+  { value: 'none', label: 'Local device', hint: 'emulator/simulator/USB — default' },
+  { value: 'browserstack', label: 'BrowserStack', hint: 'hub-cloud.browserstack.com' },
+  { value: 'saucelabs', label: 'Sauce Labs', hint: 'ondemand.<region>.saucelabs.com' },
+  { value: 'lambdatest', label: 'LambdaTest', hint: 'mobile-hub.lambdatest.com' },
+  { value: 'custom', label: 'Custom / self-hosted grid', hint: 'you provide the hub URL' },
+];
+
+/** Default: run on a local device, no cloud creds. */
+const NO_CLOUD: CloudChoices = {
+  provider: 'none',
+  username: '',
+  accessKey: '',
+  deviceName: '',
+  osVersion: '',
+};
+
+/**
+ * Collect cloud creds via the shared Prompter (works on both TTY and non-TTY).
+ * Returns NO_CLOUD when the user picks a local device. Access key is echoed as
+ * typed — readline has no masking here, so we note it rather than pretend.
+ */
+async function gatherCloud(p: Prompter, platform: Platform): Promise<CloudChoices> {
+  const provider = await p.choose<CloudProvider>(
+    'Run on a cloud device? (creds saved to .env.example — fill your .env)',
+    CLOUD_ITEMS,
+    'none'
+  );
+  if (provider === 'none') return NO_CLOUD;
+
+  const deviceHint = platform === 'ios' ? 'iPhone 14' : 'Samsung Galaxy S24';
+  const osHint = platform === 'ios' ? '16' : '14';
+  const username =
+    provider === 'custom'
+      ? await p.ask('Cloud username (blank if auth is in the hub URL)', '')
+      : await p.ask('Cloud username', '');
+  const accessKey =
+    provider === 'custom'
+      ? await p.ask('Cloud access key (blank if auth is in the hub URL)', '')
+      : await p.ask('Cloud access key', '');
+  const deviceName = await p.ask('Cloud device name', deviceHint);
+  const osVersion = await p.ask('Cloud OS version', osHint);
+  return { provider, username, accessKey, deviceName, osVersion };
+}
 
 async function gatherChoices(parsed: ParsedArgs): Promise<InitChoices> {
   if (parsed.yes) {
@@ -215,6 +270,7 @@ async function gatherChoices(parsed: ParsedArgs): Promise<InitChoices> {
       platform: parsed.platform ?? 'android',
       provider: parsed.provider ?? 'gemini',
       agentMode: 'dom',
+      cloud: NO_CLOUD,
     };
   }
 
@@ -238,7 +294,16 @@ async function gatherChoices(parsed: ParsedArgs): Promise<InitChoices> {
       prompt: 'Default agent mode? (↑/↓, Enter)',
       searchable: false,
     });
-    return { dir, platform, provider, agentMode };
+    // Cloud creds use the shared numbered Prompter (conditional follow-up prompts
+    // don't fit the single-shot arrow picker). It closes its own readline.
+    const p = new Prompter();
+    let cloud: CloudChoices;
+    try {
+      cloud = await gatherCloud(p, platform);
+    } finally {
+      p.close();
+    }
+    return { dir, platform, provider, agentMode, cloud };
   }
 
   // Non-TTY (piped / some IDE terminals) → one shared readline, numbered prompts.
@@ -252,7 +317,8 @@ async function gatherChoices(parsed: ParsedArgs): Promise<InitChoices> {
       parsed.provider ??
       (await p.choose<Provider>('Which LLM provider?', PROVIDER_ITEMS, 'gemini'));
     const agentMode = await p.choose<AgentMode>('Default agent mode?', MODE_ITEMS, 'dom');
-    return { dir, platform, provider, agentMode };
+    const cloud = await gatherCloud(p, platform);
+    return { dir, platform, provider, agentMode, cloud };
   } finally {
     p.close();
   }
@@ -314,13 +380,39 @@ AGENT_MODE=${c.agentMode}               # dom (fast) | vision (screenshot + AI)
 #MCP_DEBUG=false                        # verbose appium-mcp logs
 #LOCATOR_CACHE_ENABLED=off              # cache resolved DOM locators across runs
 
-# ── Cloud devices (LambdaTest) — uncomment to run on the cloud ─
-#CLOUD_PROVIDER=lambdatest
-#LAMBDATEST_USERNAME=
-#LAMBDATEST_ACCESS_KEY=
-#LAMBDATEST_DEVICE_NAME=Samsung Galaxy S24
-#LAMBDATEST_OS_VERSION=14
-#LAMBDATEST_APP=lt://APP...             # the app to install on the cloud device
+${cloudEnvBlock(c.cloud)}`;
+}
+
+/**
+ * Render the cloud-devices block. When the user picked a provider in `init`, the
+ * keys are active (with their entered values); otherwise the block is a commented
+ * reference. Provider-specific options (bstack:options / sauce:options / lt:options)
+ * are supplied via a --caps file, not env — see the note.
+ */
+function cloudEnvBlock(cloud: CloudChoices): string {
+  const on = cloud.provider !== 'none';
+  const c = (line: string) => (on ? line : `#${line}`);
+  const appExample: Record<Exclude<CloudProvider, 'none'>, string> = {
+    browserstack: 'bs://<hashed-app-id>',
+    saucelabs: 'storage:filename=app.apk',
+    lambdatest: 'lt://APP...',
+    custom: 'https://example.com/app.apk',
+  };
+  const provider: Exclude<CloudProvider, 'none'> =
+    cloud.provider === 'none' ? 'browserstack' : cloud.provider;
+  return `# ── Cloud devices — run on a remote Appium grid ──────────────
+#   Provider builds the hub URL + auth from the creds below. Provider-specific
+#   options (bstack:options / sauce:options / lt:options) go in a --caps JSON file.
+${c(`CLOUD_PROVIDER=${provider}`)}   # browserstack | saucelabs | lambdatest | custom
+${c(`CLOUD_USERNAME=${cloud.username}`)}
+${c(`CLOUD_ACCESS_KEY=${cloud.accessKey}`)}
+${c(`CLOUD_DEVICE_NAME=${cloud.deviceName || 'Samsung Galaxy S24'}`)}
+${c(`CLOUD_OS_VERSION=${cloud.osVersion || '14'}`)}
+#CLOUD_APP=${appExample[provider]}     # app to install on the cloud device (provider-specific format)
+#CLOUD_BUILD_NAME=                      # dashboard build label (→ provider's options namespace)
+#CLOUD_PROJECT_NAME=                    # dashboard project label
+#CLOUD_REGION=us-west-1                 # Sauce Labs data center (ignored by others)
+#CLOUD_SERVER_URL=                      # required for CLOUD_PROVIDER=custom; overrides the built-in hub for others
 `;
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -194,36 +194,55 @@ const envSchema = z.object({
   RUN_SUMMARY_EVERY_N_STEPS: z.coerce.number().default(8),
 
   // ── Cloud provider ──────────────────────────────────────────────────────────
+  // Generic remote-Appium cloud support. AppClaw builds the hub URL + auth from
+  // the CLOUD_* creds below and routes the session through appium-mcp's
+  // `remoteServerUrl` path. Provider-specific capability namespaces
+  // (bstack:options / sauce:options / lt:options) are supplied via
+  // CAPABILITIES_FILE (`--caps`) — AppClaw stays agnostic about them.
 
-  /** Cloud provider for remote device execution. Empty = local (default). */
-  CLOUD_PROVIDER: z.enum(['', 'lambdatest']).default(''),
+  /**
+   * Cloud provider for remote device execution. Empty = local (default).
+   * Known providers get a built-in hub URL; `custom` requires CLOUD_SERVER_URL.
+   */
+  CLOUD_PROVIDER: z.enum(['', 'browserstack', 'saucelabs', 'lambdatest', 'custom']).default(''),
 
-  /** LambdaTest account username (required when CLOUD_PROVIDER=lambdatest). */
-  LAMBDATEST_USERNAME: z.string().default(''),
+  /** Cloud account username (required when CLOUD_PROVIDER is set, except `custom` with auth-in-URL). */
+  CLOUD_USERNAME: z.string().default(''),
 
-  /** LambdaTest access key (required when CLOUD_PROVIDER=lambdatest). */
-  LAMBDATEST_ACCESS_KEY: z.string().default(''),
+  /** Cloud access key / token (required when CLOUD_PROVIDER is set, except `custom` with auth-in-URL). */
+  CLOUD_ACCESS_KEY: z.string().default(''),
 
-  /** Cloud device name, e.g. "iPhone 14" (required when CLOUD_PROVIDER=lambdatest). */
-  LAMBDATEST_DEVICE_NAME: z.string().default(''),
+  /** Cloud device name, e.g. "iPhone 14" or "Samsung Galaxy S24" (required when CLOUD_PROVIDER is set). */
+  CLOUD_DEVICE_NAME: z.string().default(''),
 
-  /** Cloud OS version, e.g. "16" (required when CLOUD_PROVIDER=lambdatest). */
-  LAMBDATEST_OS_VERSION: z.string().default(''),
+  /** Cloud OS version, e.g. "16" or "14" (required when CLOUD_PROVIDER is set). */
+  CLOUD_OS_VERSION: z.string().default(''),
 
-  /** LambdaTest build label shown in the dashboard. */
-  LAMBDATEST_BUILD_NAME: z.string().default(''),
+  /**
+   * App to install on the cloud device. Format is provider-specific:
+   * BrowserStack `bs://…`, LambdaTest `lt://…`, Sauce Labs `storage:…`,
+   * or an HTTP(S) URL for `custom`. Passed as `appium:app`.
+   */
+  CLOUD_APP: z.string().default(''),
 
-  /** LambdaTest project label shown in the dashboard. */
-  LAMBDATEST_PROJECT_NAME: z.string().default(''),
+  /**
+   * Full Appium hub URL. Required when CLOUD_PROVIDER=custom (e.g. a self-hosted
+   * grid). Optional override for known providers. May embed auth
+   * (https://user:key@host/wd/hub); otherwise CLOUD_USERNAME/CLOUD_ACCESS_KEY are injected.
+   */
+  CLOUD_SERVER_URL: z.string().default(''),
 
-  /** Record session video on LambdaTest. Default: true. */
-  LAMBDATEST_VIDEO: z.enum(['true', 'false']).default('true'),
+  /**
+   * Data-center region for providers that have regional hubs (Sauce Labs).
+   * Default us-west-1. Ignored by providers without regions.
+   */
+  CLOUD_REGION: z.string().default('us-west-1'),
 
-  /** Capture network logs on LambdaTest. Default: false. */
-  LAMBDATEST_NETWORK: z.enum(['true', 'false']).default('false'),
+  /** Build label shown in the provider dashboard. Mapped into the provider's option namespace. */
+  CLOUD_BUILD_NAME: z.string().default(''),
 
-  /** LambdaTest app ID (lt://APP...) — the app to install and test on the cloud device. */
-  LAMBDATEST_APP: z.string().default(''),
+  /** Project label shown in the provider dashboard. Mapped into the provider's option namespace. */
+  CLOUD_PROJECT_NAME: z.string().default(''),
 });
 
 export type AppClawConfig = z.infer<typeof envSchema>;
@@ -231,15 +250,21 @@ export type AppClawConfig = z.infer<typeof envSchema>;
 export function loadConfig(overrides?: Record<string, string | undefined>): AppClawConfig {
   const env = overrides ? { ...process.env, ...overrides } : process.env;
   const config = envSchema.parse(env);
-  if (config.CLOUD_PROVIDER === 'lambdatest') {
-    if (!config.LAMBDATEST_USERNAME || !config.LAMBDATEST_ACCESS_KEY) {
+  if (config.CLOUD_PROVIDER) {
+    // `custom` can carry auth in CLOUD_SERVER_URL, so creds aren't strictly
+    // required there — but it MUST provide the hub URL. Known providers need creds.
+    if (config.CLOUD_PROVIDER === 'custom') {
+      if (!config.CLOUD_SERVER_URL) {
+        throw new Error('CLOUD_SERVER_URL is required when CLOUD_PROVIDER=custom');
+      }
+    } else if (!config.CLOUD_USERNAME || !config.CLOUD_ACCESS_KEY) {
       throw new Error(
-        'LAMBDATEST_USERNAME and LAMBDATEST_ACCESS_KEY are required when CLOUD_PROVIDER=lambdatest'
+        `CLOUD_USERNAME and CLOUD_ACCESS_KEY are required when CLOUD_PROVIDER=${config.CLOUD_PROVIDER}`
       );
     }
-    if (!config.LAMBDATEST_DEVICE_NAME || !config.LAMBDATEST_OS_VERSION) {
+    if (!config.CLOUD_DEVICE_NAME || !config.CLOUD_OS_VERSION) {
       throw new Error(
-        'LAMBDATEST_DEVICE_NAME and LAMBDATEST_OS_VERSION are required when CLOUD_PROVIDER=lambdatest'
+        `CLOUD_DEVICE_NAME and CLOUD_OS_VERSION are required when CLOUD_PROVIDER=${config.CLOUD_PROVIDER}`
       );
     }
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -44,6 +44,12 @@ const envSchema = z.object({
   MCP_TRANSPORT: z.enum(['stdio', 'sse']).default('stdio'),
   MCP_HOST: z.string().default('localhost'),
   MCP_PORT: z.coerce.number().default(8080),
+  /**
+   * Full appium-mcp SSE URL. When set (transport 'sse') it takes precedence over
+   * MCP_HOST/MCP_PORT and preserves scheme + path — required for https tunnels
+   * (ngrok) and non-default ports. Empty string means "reconstruct from host:port".
+   */
+  MCP_URL: z.string().default(''),
 
   /**
    * Android UiAutomator2: appium:mjpegScreenshotUrl — MJPEG stream URL for faster screenshots.

--- a/src/config.ts
+++ b/src/config.ts
@@ -268,11 +268,12 @@ export function loadConfig(overrides?: Record<string, string | undefined>): AppC
         `CLOUD_USERNAME and CLOUD_ACCESS_KEY are required when CLOUD_PROVIDER=${config.CLOUD_PROVIDER}`
       );
     }
-    if (!config.CLOUD_DEVICE_NAME || !config.CLOUD_OS_VERSION) {
-      throw new Error(
-        `CLOUD_DEVICE_NAME and CLOUD_OS_VERSION are required when CLOUD_PROVIDER=${config.CLOUD_PROVIDER}`
-      );
-    }
+    // Note: device / OS / app can come from CLOUD_DEVICE_NAME / CLOUD_OS_VERSION
+    // / CLOUD_APP, or from inline `capabilities` (top-level appium:* or a
+    // provider namespace like lt:options). We don't hard-fail here — the grid
+    // itself returns a clear W3C error if the merged caps are missing platform
+    // or device selectors, and requiring env vars would defeat the point of
+    // "everything inline in appclaw.config.ts".
   }
   return config;
 }

--- a/src/device/cloud.ts
+++ b/src/device/cloud.ts
@@ -96,7 +96,8 @@ function injectAuth(rawUrl: string, config: AppClawConfig): string {
       `Invalid cloud hub URL "${rawUrl}". Provide a full http(s) URL, e.g. https://hub.example.com/wd/hub`
     );
   }
-  if (!url.username && config.CLOUD_USERNAME) url.username = encodeURIComponent(config.CLOUD_USERNAME);
+  if (!url.username && config.CLOUD_USERNAME)
+    url.username = encodeURIComponent(config.CLOUD_USERNAME);
   if (!url.password && config.CLOUD_ACCESS_KEY)
     url.password = encodeURIComponent(config.CLOUD_ACCESS_KEY);
   return url.toString();

--- a/src/device/cloud.ts
+++ b/src/device/cloud.ts
@@ -1,0 +1,153 @@
+/**
+ * Generic cloud-provider support.
+ *
+ * AppClaw drives Appium through appium-mcp. For a remote/cloud device we hand
+ * appium-mcp a `remoteServerUrl` (the provider's Appium hub) plus a flat set of
+ * W3C capabilities; appium-mcp forwards them verbatim to the grid (it injects
+ * NO defaults on the remote path — unlike the embedded local drivers). So this
+ * module is responsible for:
+ *
+ *   1. building the hub URL (with basic-auth embedded, which appium-mcp decodes),
+ *   2. supplying the caps the grid needs — including `platformName` and
+ *      `appium:automationName`, which the caller MUST provide for a remote session.
+ *
+ * Provider-specific capability *namespaces* (bstack:options / sauce:options /
+ * lt:options) are deliberately NOT modelled here. Users supply them via
+ * CAPABILITIES_FILE (`--caps`), which is merged on top of the caps below. The
+ * only convenience we map for the user are build/project labels (the most-used
+ * dashboard fields), placed into the active provider's namespace.
+ */
+
+import type { AppClawConfig } from '../config.js';
+import type { Platform } from '../index.js';
+
+export type CloudProvider = Exclude<AppClawConfig['CLOUD_PROVIDER'], ''>;
+
+/** Per-provider connection details. */
+interface ProviderSpec {
+  label: string;
+  /** Build the base hub URL (no auth) for this provider from config. */
+  hubHost: (config: AppClawConfig) => string;
+  /** The `xxx:options` capability namespace this provider reads dashboard/session opts from. */
+  optionsNamespace: string;
+}
+
+const PROVIDERS: Record<Exclude<CloudProvider, 'custom'>, ProviderSpec> = {
+  browserstack: {
+    label: 'BrowserStack',
+    hubHost: () => 'hub-cloud.browserstack.com/wd/hub',
+    optionsNamespace: 'bstack:options',
+  },
+  saucelabs: {
+    label: 'Sauce Labs',
+    // Sauce hubs are regional; default us-west-1, overridable via CLOUD_REGION.
+    hubHost: (c) => `ondemand.${c.CLOUD_REGION || 'us-west-1'}.saucelabs.com/wd/hub`,
+    optionsNamespace: 'sauce:options',
+  },
+  lambdatest: {
+    label: 'LambdaTest',
+    hubHost: () => 'mobile-hub.lambdatest.com/wd/hub',
+    optionsNamespace: 'lt:options',
+  },
+};
+
+/** True when a cloud/remote provider is configured (any non-empty CLOUD_PROVIDER). */
+export function isCloud(config: AppClawConfig): boolean {
+  return config.CLOUD_PROVIDER !== '';
+}
+
+/** Human-readable provider name for logs/messages. */
+export function cloudProviderLabel(config: AppClawConfig): string {
+  if (config.CLOUD_PROVIDER === 'custom' || config.CLOUD_PROVIDER === '') {
+    return config.CLOUD_PROVIDER === 'custom' ? 'Custom grid' : 'local';
+  }
+  return PROVIDERS[config.CLOUD_PROVIDER].label;
+}
+
+/**
+ * Build the full Appium hub URL for the configured provider, embedding basic
+ * auth (`https://user:key@host/wd/hub`) when the URL doesn't already carry it.
+ * appium-mcp parses this and passes user/key to the WebDriver client.
+ */
+export function buildCloudHubUrl(config: AppClawConfig): string {
+  const provider = config.CLOUD_PROVIDER;
+  if (provider === '') {
+    throw new Error('buildCloudHubUrl called without a CLOUD_PROVIDER');
+  }
+
+  // `custom` (self-hosted grid): user supplies the whole URL. Inject creds only
+  // if they gave them separately and didn't already embed auth in the URL.
+  if (provider === 'custom') {
+    return injectAuth(config.CLOUD_SERVER_URL, config);
+  }
+
+  // Known provider: allow CLOUD_SERVER_URL to override the built-in host.
+  const host = config.CLOUD_SERVER_URL || `https://${PROVIDERS[provider].hubHost(config)}`;
+  return injectAuth(host, config);
+}
+
+/** Embed `user:key@` into an http(s) URL if not already present. */
+function injectAuth(rawUrl: string, config: AppClawConfig): string {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    throw new Error(
+      `Invalid cloud hub URL "${rawUrl}". Provide a full http(s) URL, e.g. https://hub.example.com/wd/hub`
+    );
+  }
+  if (!url.username && config.CLOUD_USERNAME) url.username = encodeURIComponent(config.CLOUD_USERNAME);
+  if (!url.password && config.CLOUD_ACCESS_KEY)
+    url.password = encodeURIComponent(config.CLOUD_ACCESS_KEY);
+  return url.toString();
+}
+
+/** W3C platformName + default automationName per AppClaw platform. */
+function platformCaps(platform: Platform): Record<string, unknown> {
+  return platform === 'ios'
+    ? { platformName: 'iOS', 'appium:automationName': 'XCUITest' }
+    : { platformName: 'Android', 'appium:automationName': 'UiAutomator2' };
+}
+
+/**
+ * Build the capability object sent to the remote grid.
+ *
+ * Precedence (later wins): platform/automation defaults < device/os/app <
+ * build/project convenience labels < user-supplied fileCaps (CAPABILITIES_FILE).
+ * The caps file wins last so a user can override anything — including the
+ * automationName or the provider-options namespace — for their grid.
+ */
+export function buildCloudCapabilities(
+  config: AppClawConfig,
+  platform: Platform,
+  fileCaps: Record<string, unknown> = {}
+): Record<string, unknown> {
+  const caps: Record<string, unknown> = {
+    ...platformCaps(platform),
+    'appium:deviceName': config.CLOUD_DEVICE_NAME,
+    'appium:platformVersion': config.CLOUD_OS_VERSION,
+    ...(config.CLOUD_APP ? { 'appium:app': config.CLOUD_APP } : {}),
+  };
+
+  // Map build/project labels into the active provider's options namespace.
+  // `custom` has no known namespace, so these are only applied for known providers.
+  const provider = config.CLOUD_PROVIDER;
+  if (provider !== '' && provider !== 'custom') {
+    const ns = PROVIDERS[provider].optionsNamespace;
+    const options: Record<string, unknown> = {};
+    if (config.CLOUD_BUILD_NAME) options.build = config.CLOUD_BUILD_NAME;
+    if (config.CLOUD_PROJECT_NAME) options.project = config.CLOUD_PROJECT_NAME;
+    // BrowserStack uses camelCase (buildName/projectName); alias so both grids read it.
+    if (provider === 'browserstack') {
+      if (config.CLOUD_BUILD_NAME) options.buildName = config.CLOUD_BUILD_NAME;
+      if (config.CLOUD_PROJECT_NAME) options.projectName = config.CLOUD_PROJECT_NAME;
+    }
+    if (Object.keys(options).length > 0) {
+      // Merge into any namespace the user already set via fileCaps below.
+      caps[ns] = { ...options, ...((fileCaps[ns] as Record<string, unknown>) ?? {}) };
+    }
+  }
+
+  // User caps win last (including a fuller provider-options object).
+  return { ...caps, ...fileCaps };
+}

--- a/src/device/cloud.ts
+++ b/src/device/cloud.ts
@@ -117,18 +117,23 @@ function platformCaps(platform: Platform): Record<string, unknown> {
  * build/project convenience labels < user-supplied fileCaps (CAPABILITIES_FILE).
  * The caps file wins last so a user can override anything — including the
  * automationName or the provider-options namespace — for their grid.
+ *
+ * Device selectors (`appium:deviceName` / `appium:platformVersion` /
+ * `appium:app`) are injected ONLY when the CLOUD_* env vars are set. Callers
+ * who prefer to keep everything inline (e.g. `capabilities: { 'lt:options':
+ * { deviceName, platformVersion, app } }` in appclaw.config.ts) can omit the
+ * env vars entirely — the inline caps flow through fileCaps and reach the
+ * grid unchanged.
  */
 export function buildCloudCapabilities(
   config: AppClawConfig,
   platform: Platform,
   fileCaps: Record<string, unknown> = {}
 ): Record<string, unknown> {
-  const caps: Record<string, unknown> = {
-    ...platformCaps(platform),
-    'appium:deviceName': config.CLOUD_DEVICE_NAME,
-    'appium:platformVersion': config.CLOUD_OS_VERSION,
-    ...(config.CLOUD_APP ? { 'appium:app': config.CLOUD_APP } : {}),
-  };
+  const caps: Record<string, unknown> = { ...platformCaps(platform) };
+  if (config.CLOUD_DEVICE_NAME) caps['appium:deviceName'] = config.CLOUD_DEVICE_NAME;
+  if (config.CLOUD_OS_VERSION) caps['appium:platformVersion'] = config.CLOUD_OS_VERSION;
+  if (config.CLOUD_APP) caps['appium:app'] = config.CLOUD_APP;
 
   // Map build/project labels into the active provider's options namespace.
   // `custom` has no known namespace, so these are only applied for known providers.

--- a/src/device/device-picker.ts
+++ b/src/device/device-picker.ts
@@ -15,6 +15,7 @@ import type { Platform, DeviceType } from '../index.js';
 import { extractText } from '../mcp/tools.js';
 import { interactivePicker } from './interactive-picker.js';
 import type { PickerItem } from './interactive-picker.js';
+import { listIOSSimulators } from './ios-simulators.js';
 import * as ui from '../ui/terminal.js';
 
 export interface DeviceInfo {
@@ -54,36 +55,68 @@ export async function discoverAndSelectDevice(
     return { device: { name: udid, udid }, platform, deviceType };
   }
 
-  // Step 1: Call select_device to discover available devices
+  // Step 1: Discover available devices.
+  // For iOS simulators, ask simctl directly — appium-mcp's `select_device`
+  // response omits the iOS runtime version and text-parses inconsistently for
+  // unnamed sims. For everything else, use the MCP tool as before.
   ui.startSpinner(`Discovering ${platform} devices...`);
 
-  const selectPlatformArgs: Record<string, unknown> = { platform };
-  if (platform === 'ios' && deviceType) {
-    selectPlatformArgs.iosDeviceType = deviceType;
+  let devices: DeviceInfo[];
+  if (platform === 'ios' && deviceType === 'simulator') {
+    try {
+      const sims = await listIOSSimulators();
+      devices = sims.map((s) => ({
+        name: s.name,
+        udid: s.udid,
+        state: s.state,
+        platform: s.iosVersion,
+      }));
+    } catch (err: any) {
+      ui.stopSpinner();
+      ui.printSetupError(
+        `Failed to list iOS simulators: ${err?.message ?? err}`,
+        'Check that Xcode is installed and run: xcrun simctl list devices'
+      );
+      process.exit(1);
+    }
+    ui.stopSpinner();
+
+    if (devices.length === 0) {
+      ui.printSetupError(
+        'No iOS simulators found.',
+        'Open Simulator.app or run: xcrun simctl list devices'
+      );
+      process.exit(1);
+    }
+  } else {
+    const selectPlatformArgs: Record<string, unknown> = { platform };
+    if (platform === 'ios' && deviceType) {
+      selectPlatformArgs.iosDeviceType = deviceType;
+    }
+
+    const platformResult = await mcp.callTool('select_device', selectPlatformArgs);
+    const platformText = extractText(platformResult);
+    ui.stopSpinner();
+
+    // Check for errors
+    if (
+      platformText.toLowerCase().includes('no devices') ||
+      platformText.toLowerCase().includes('no simulators') ||
+      platformText.toLowerCase().includes('no ios devices')
+    ) {
+      const hint =
+        platform === 'android'
+          ? 'Connect a device/emulator: adb devices'
+          : deviceType === 'simulator'
+            ? 'Open Simulator.app or run: xcrun simctl list devices'
+            : 'Connect an iOS device via USB and trust this computer';
+      ui.printSetupError(`No ${platform} ${deviceType ?? ''} devices found.`, hint);
+      process.exit(1);
+    }
+
+    // Step 2: Parse device list from response
+    devices = parseDeviceList(platformText, platform);
   }
-
-  const platformResult = await mcp.callTool('select_device', selectPlatformArgs);
-  const platformText = extractText(platformResult);
-  ui.stopSpinner();
-
-  // Check for errors
-  if (
-    platformText.toLowerCase().includes('no devices') ||
-    platformText.toLowerCase().includes('no simulators') ||
-    platformText.toLowerCase().includes('no ios devices')
-  ) {
-    const hint =
-      platform === 'android'
-        ? 'Connect a device/emulator: adb devices'
-        : deviceType === 'simulator'
-          ? 'Open Simulator.app or run: xcrun simctl list devices'
-          : 'Connect an iOS device via USB and trust this computer';
-    ui.printSetupError(`No ${platform} ${deviceType ?? ''} devices found.`, hint);
-    process.exit(1);
-  }
-
-  // Step 2: Parse device list from response
-  let devices = parseDeviceList(platformText, platform);
 
   // Clean up the list: remove junk, deduplicate, sort
   devices = cleanAndSortDevices(devices);
@@ -303,24 +336,39 @@ export function parseDeviceList(text: string, _platform: Platform): DeviceInfo[]
 
 /** Interactive device picker using the shared searchable picker */
 async function promptDevicePicker(devices: DeviceInfo[]): Promise<DeviceInfo> {
+  // When every device has a parsed iOS version, render an aligned table:
+  //   iPhone 16 Pro Max          iOS 18.2   206754D6…
+  // Otherwise fall back to plain name + optional hint.
+  const allHaveIOSVersion = devices.every((d) => !!d.platform);
+  const nameWidth = allHaveIOSVersion
+    ? Math.min(32, Math.max(...devices.map((d) => d.name.length)))
+    : 0;
+  const versionWidth = allHaveIOSVersion
+    ? Math.max(...devices.map((d) => (d.platform ?? '').length))
+    : 0;
+
   const items: PickerItem<DeviceInfo>[] = devices.map((d) => {
     const tag = d.state?.toLowerCase() === 'booted' ? 'Booted' : undefined;
-    const hint =
-      d.state?.toLowerCase() !== 'booted' && d.platform
-        ? `iOS ${d.platform}`
-        : d.platform
-          ? `iOS ${d.platform}`
-          : undefined;
+
+    if (allHaveIOSVersion) {
+      const paddedName = d.name.padEnd(nameWidth).slice(0, nameWidth);
+      const paddedVersion = (d.platform ?? '').padEnd(versionWidth);
+      const shortUdid = d.udid.length > 8 ? `${d.udid.slice(0, 8)}…` : d.udid;
+      return {
+        label: `${paddedName}  iOS ${paddedVersion}  ${shortUdid}`,
+        value: d,
+        tag,
+      };
+    }
 
     return {
       label: d.name,
       value: d,
       tag,
-      hint,
+      hint: d.platform ? `iOS ${d.platform}` : undefined,
     };
   });
 
-  // Start selection on first booted device (if any)
   return interactivePicker(items, {
     prompt: 'Select device:',
     viewportSize: 12,

--- a/src/device/index.ts
+++ b/src/device/index.ts
@@ -113,19 +113,32 @@ export async function setupDevice(
   );
 
   // Step 3: iOS-specific setup
+  let simulatorHint: Record<string, unknown> = {};
   if (platform === 'ios' && deviceType === 'simulator') {
-    await setupSimulator(mcp, selection.device.udid);
+    const setup = await setupSimulator(mcp, selection.device.udid);
+    simulatorHint = setup.capabilitiesHint;
   } else if (platform === 'ios' && deviceType === 'real') {
     await checkRealDeviceWDA();
   }
 
   // Step 4: Create session
+  // Merge the WDA capabilities hint from prepare_ios_simulator into extraCaps.
+  // Precedence: hint < caller extraCaps (caller can still override).
+  // When the hint provides `appium:webDriverAgentUrl`, drop any conflicting
+  // `appium:wdaLocalPort` — the two are mutually exclusive per XCUITestDriver's
+  // contract (webDriverAgentUrl reuses a running WDA; wdaLocalPort tells it to
+  // launch a new one). Passing both makes XCUITest ignore the running WDA and
+  // fail on xcodebuild.
+  const mergedExtraCaps: Record<string, unknown> = { ...simulatorHint, ...args.extraCaps };
+  if (mergedExtraCaps['appium:webDriverAgentUrl']) {
+    delete mergedExtraCaps['appium:wdaLocalPort'];
+  }
   const session = await createPlatformSession(
     mcp,
     args.config,
     platform,
     deviceType,
-    args.extraCaps
+    mergedExtraCaps
   );
 
   return {

--- a/src/device/index.ts
+++ b/src/device/index.ts
@@ -20,6 +20,7 @@ import { discoverAndSelectDevice } from './device-picker.js';
 import { setupSimulator, checkRealDeviceWDA } from './ios-setup.js';
 import { createPlatformSession } from './session.js';
 import type { SessionResult } from './session.js';
+import { isCloud, cloudProviderLabel } from './cloud.js';
 
 export interface DeviceSetupArgs {
   cliPlatform: Platform | null;
@@ -76,13 +77,13 @@ export async function setupDevice(
   });
 
   // Cloud mode: skip local device discovery and iOS setup entirely
-  if (args.config.CLOUD_PROVIDER === 'lambdatest') {
+  if (isCloud(args.config)) {
     const session = await createPlatformSession(mcp, args.config, platform, deviceType);
     return {
       platform,
       deviceType,
-      deviceName: args.config.LAMBDATEST_DEVICE_NAME || 'LambdaTest Cloud',
-      deviceUdid: 'lambdatest-cloud',
+      deviceName: args.config.CLOUD_DEVICE_NAME || `${cloudProviderLabel(args.config)} Cloud`,
+      deviceUdid: 'cloud',
       session,
       sessionId: session.sessionId,
       scopedMcp: session.scopedMcp,

--- a/src/device/interactive-picker.ts
+++ b/src/device/interactive-picker.ts
@@ -10,6 +10,7 @@
 
 import readline from 'node:readline';
 import { Writable } from 'node:stream';
+import boxen from 'boxen';
 
 export interface PickerItem<T> {
   label: string;
@@ -64,8 +65,7 @@ export async function interactivePicker<T>(
     readline.emitKeypressEvents(process.stdin);
 
     const formatItem = (item: PickerItem<T>, selected: boolean): string => {
-      const arrow = selected ? '\x1B[36m>\x1B[0m ' : '  ';
-      const prefix = `  ${arrow}`;
+      const prefix = selected ? '\x1B[36m>\x1B[0m ' : '  ';
 
       let line = '';
       if (selected) {
@@ -107,52 +107,59 @@ export async function interactivePicker<T>(
       // Clear everything from cursor to end of screen
       process.stdout.write('\x1B[J');
 
-      let lineCount = 0;
+      // Build the inner content of the boxed frame.
+      const lines: string[] = [];
 
-      // Prompt line with inline search
+      // Search hint line inside the box.
       if (searchable && searchQuery) {
-        console.log(`  ? ${prompt} \x1B[33m${searchQuery}\x1B[90m|\x1B[0m`);
+        lines.push(`\x1B[33m${searchQuery}\x1B[90m|\x1B[0m`);
       } else if (searchable) {
-        console.log(`  ? ${prompt} \x1B[90m(type to filter)\x1B[0m`);
-      } else {
-        console.log(`  ? ${prompt}`);
+        lines.push(`\x1B[90m(type to filter)\x1B[0m`);
       }
-      lineCount++;
 
-      // Empty state
       if (filteredItems.length === 0) {
-        console.log(`    \x1B[90mNo matches found\x1B[0m`);
-        lineCount++;
-        lastRenderedLineCount = lineCount;
-        return;
+        lines.push(`\x1B[90mNo matches found\x1B[0m`);
+      } else {
+        // Adjust scroll to keep selection visible
+        const visibleCount = Math.min(maxVisible, filteredItems.length);
+        if (selectedIndex < scrollOffset) {
+          scrollOffset = selectedIndex;
+        } else if (selectedIndex >= scrollOffset + visibleCount) {
+          scrollOffset = selectedIndex - visibleCount + 1;
+        }
+
+        for (
+          let i = scrollOffset;
+          i < scrollOffset + visibleCount && i < filteredItems.length;
+          i++
+        ) {
+          lines.push(formatItem(filteredItems[i], i === selectedIndex));
+        }
+
+        if (filteredItems.length > maxVisible) {
+          const below = filteredItems.length - scrollOffset - visibleCount;
+          const above = scrollOffset;
+          const parts: string[] = [];
+          if (above > 0) parts.push(`${above} more above`);
+          if (below > 0) parts.push(`${below} more below`);
+          lines.push(`\x1B[90m${parts.join(' · ')}\x1B[0m`);
+        }
       }
 
-      // Adjust scroll to keep selection visible
-      const visibleCount = Math.min(maxVisible, filteredItems.length);
-      if (selectedIndex < scrollOffset) {
-        scrollOffset = selectedIndex;
-      } else if (selectedIndex >= scrollOffset + visibleCount) {
-        scrollOffset = selectedIndex - visibleCount + 1;
-      }
+      const boxed = boxen(lines.join('\n'), {
+        title: prompt,
+        titleAlignment: 'left',
+        padding: { top: 0, bottom: 0, left: 1, right: 1 },
+        margin: { left: 2, right: 0, top: 0, bottom: 0 },
+        borderStyle: 'round',
+        borderColor: '#FC8EAC',
+      });
 
-      // Render visible items
-      for (let i = scrollOffset; i < scrollOffset + visibleCount && i < filteredItems.length; i++) {
-        console.log(formatItem(filteredItems[i], i === selectedIndex));
-        lineCount++;
-      }
-
-      // Scroll indicator (only when list is truncated)
-      if (filteredItems.length > maxVisible) {
-        const below = filteredItems.length - scrollOffset - visibleCount;
-        const above = scrollOffset;
-        const parts: string[] = [];
-        if (above > 0) parts.push(`${above} more above`);
-        if (below > 0) parts.push(`${below} more below`);
-        console.log(`    \x1B[90m${parts.join(' · ')}\x1B[0m`);
-        lineCount++;
-      }
-
-      lastRenderedLineCount = lineCount;
+      process.stdout.write(`${boxed}\n`);
+      // Track how many terminal lines we just drew so the next render can
+      // rewind and overwrite them cleanly. boxed has N-1 internal newlines and
+      // the trailing `\n` we added advances the cursor a total of N lines.
+      lastRenderedLineCount = boxed.split('\n').length;
     };
 
     // Initial render

--- a/src/device/ios-setup.ts
+++ b/src/device/ios-setup.ts
@@ -11,11 +11,24 @@ import type { MCPClient } from '../mcp/types.js';
 import { extractText } from '../mcp/tools.js';
 import * as ui from '../ui/terminal.js';
 
+export interface SimulatorSetupResult {
+  /**
+   * Capabilities the caller MUST merge into appium_session_management create.
+   *
+   * Includes `appium:webDriverAgentUrl` pointing at the WDA that
+   * prepare_ios_simulator already installed and launched on a per-simulator
+   * port. Without this, XCUITestDriver ignores the running WDA, allocates a
+   * new wdaLocalPort, and tries to build+launch WDA via xcodebuild — which
+   * frequently fails (xcodebuild exit 65) and always races the prepared WDA.
+   */
+  capabilitiesHint: Record<string, unknown>;
+}
+
 /**
  * Full simulator setup: boot + WDA download + WDA install.
  * Uses the prepare_ios_simulator tool which handles all three steps in one call.
  */
-export async function setupSimulator(mcp: MCPClient, udid: string): Promise<void> {
+export async function setupSimulator(mcp: MCPClient, udid: string): Promise<SimulatorSetupResult> {
   ui.startSpinner('Preparing iOS simulator...');
   let result: any;
   try {
@@ -36,7 +49,7 @@ export async function setupSimulator(mcp: MCPClient, udid: string): Promise<void
 
   if (!result) {
     ui.printSetupOk('iOS simulator prepared');
-    return;
+    return { capabilitiesHint: {} };
   }
 
   // Boot step
@@ -77,6 +90,12 @@ export async function setupSimulator(mcp: MCPClient, udid: string): Promise<void
   } else if (result.wda_install?.status === 'skipped') {
     ui.printSetupOk('WebDriverAgent already installed');
   }
+
+  const hint =
+    result.capabilitiesHint && typeof result.capabilitiesHint === 'object'
+      ? (result.capabilitiesHint as Record<string, unknown>)
+      : {};
+  return { capabilitiesHint: hint };
 }
 
 /**

--- a/src/device/ios-simulators.ts
+++ b/src/device/ios-simulators.ts
@@ -1,0 +1,66 @@
+/**
+ * Direct iOS simulator discovery via `xcrun simctl list devices --json`.
+ *
+ * Bypasses appium-mcp's `select_device` text response because that response
+ * strips the iOS runtime version and text-parses inconsistently for
+ * unnamed / blank-named simulators (surfacing as bare UDIDs in the picker).
+ * `select_device` is still called downstream to lock in the choice.
+ */
+
+import { exec as execCallback } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const exec = promisify(execCallback);
+
+export interface IOSSimulatorInfo {
+  name: string;
+  udid: string;
+  state: string;
+  /** iOS runtime version, e.g. "18.2" */
+  iosVersion: string;
+}
+
+export async function listIOSSimulators(): Promise<IOSSimulatorInfo[]> {
+  const { stdout } = await exec('xcrun simctl list devices available --json', {
+    maxBuffer: 16 * 1024 * 1024,
+  });
+  const data = JSON.parse(stdout);
+  const devicesByRuntime = (data?.devices ?? {}) as Record<string, unknown>;
+
+  const result: IOSSimulatorInfo[] = [];
+  for (const [runtimeKey, deviceList] of Object.entries(devicesByRuntime)) {
+    if (!Array.isArray(deviceList)) continue;
+    const iosVersion = parseIOSRuntime(runtimeKey);
+    if (!iosVersion) continue; // skip watchOS / tvOS / visionOS runtimes
+    for (const dev of deviceList as Array<Record<string, unknown>>) {
+      if (dev.isAvailable === false) continue;
+      const name = typeof dev.name === 'string' ? dev.name : '';
+      const udid = typeof dev.udid === 'string' ? dev.udid : '';
+      if (!udid) continue;
+      result.push({
+        name: name || udid,
+        udid,
+        state: typeof dev.state === 'string' ? dev.state : 'Shutdown',
+        iosVersion,
+      });
+    }
+  }
+  return result;
+}
+
+/**
+ * Parse the iOS version out of a simctl runtime key.
+ * Newer format: "com.apple.CoreSimulator.SimRuntime.iOS-18-2"
+ * Older format: "iOS 18.2"
+ * Returns null for non-iOS runtimes (watchOS, tvOS, visionOS).
+ */
+function parseIOSRuntime(key: string): string | null {
+  const dashed = key.match(/SimRuntime\.iOS-(\d+)-(\d+)(?:-(\d+))?$/);
+  if (dashed) {
+    const [, maj, min, patch] = dashed;
+    return patch ? `${maj}.${min}.${patch}` : `${maj}.${min}`;
+  }
+  const spaced = key.match(/^iOS (\d+\.\d+(?:\.\d+)?)$/);
+  if (spaced) return spaced[1];
+  return null;
+}

--- a/src/device/session.ts
+++ b/src/device/session.ts
@@ -36,31 +36,45 @@ export interface SessionResult {
  *   Used for parallel runs to assign unique ports:
  *   - Android: `appium:systemPort`, `appium:mjpegServerPort`
  *   - iOS: `appium:wdaLocalPort`
+ * @param inlineCaps - Author-supplied capabilities from the SDK options object
+ *   (e.g. `new AppClaw({ capabilities: { 'lt:options': { ... } } })`).
+ *   Sits between config defaults and CAPABILITIES_FILE in precedence — a
+ *   file override still wins so environments can tweak per stage/CI.
  */
 export async function createPlatformSession(
   mcp: MCPClient,
   config: AppClawConfig,
   platform: Platform,
   _deviceType?: DeviceType,
-  extraCaps?: Record<string, unknown>
+  extraCaps?: Record<string, unknown>,
+  inlineCaps?: Record<string, unknown>
 ): Promise<SessionResult> {
   // User-supplied capabilities from CAPABILITIES_FILE (if any). Loaded once and
   // merged into whichever session path runs below.
   const fileCaps = loadCapabilitiesFile(config, platform);
+  const inlineCapsForPlatform = inlineCaps
+    ? normalizeCapabilitiesForPlatform(inlineCaps, platform, 'capabilities')
+    : {};
 
   if (isCloud(config)) {
-    return createCloudSession(mcp, config, platform, fileCaps);
+    return createCloudSession(mcp, config, platform, { ...inlineCapsForPlatform, ...fileCaps });
   }
 
   ui.startSpinner('Creating Appium session...');
 
   const args: Record<string, unknown> = { platform };
 
-  // Capability precedence (later wins): config defaults < CAPABILITIES_FILE <
-  // extraCaps. extraCaps (parallel ports, pinned udid) must win last so concurrent
-  // workers don't collide and device pinning holds even if the file sets the same key.
+  // Capability precedence (later wins): config defaults < inline capabilities <
+  // CAPABILITIES_FILE < extraCaps. extraCaps (parallel ports, pinned udid) must win
+  // last so concurrent workers don't collide and device pinning holds even if the
+  // file sets the same key.
   if (platform === 'android') {
-    const caps = { ...buildAndroidCapabilities(config), ...fileCaps, ...extraCaps };
+    const caps = {
+      ...buildAndroidCapabilities(config),
+      ...inlineCapsForPlatform,
+      ...fileCaps,
+      ...extraCaps,
+    };
     if (Object.keys(caps).length > 0) {
       args.capabilities = JSON.stringify(caps);
     }
@@ -69,6 +83,7 @@ export async function createPlatformSession(
     // Merge config-level APP_PATH with the caps file and extraCaps (per-flow app: overrides .env).
     const iosCaps = {
       ...(config.APP_PATH ? { 'appium:app': config.APP_PATH } : {}),
+      ...inlineCapsForPlatform,
       ...fileCaps,
       ...extraCaps,
     };

--- a/src/device/session.ts
+++ b/src/device/session.ts
@@ -17,6 +17,7 @@ import {
   getIOSScreenSizeFromModel,
 } from '../vision/ios-device-map.js';
 import { SessionScopedMCPClient } from '../mcp/session-client.js';
+import { isCloud, buildCloudHubUrl, buildCloudCapabilities, cloudProviderLabel } from './cloud.js';
 import * as ui from '../ui/terminal.js';
 
 export interface SessionResult {
@@ -47,8 +48,8 @@ export async function createPlatformSession(
   // merged into whichever session path runs below.
   const fileCaps = loadCapabilitiesFile(config, platform);
 
-  if (config.CLOUD_PROVIDER === 'lambdatest') {
-    return createLambdaTestSession(mcp, config, platform, fileCaps);
+  if (isCloud(config)) {
+    return createCloudSession(mcp, config, platform, fileCaps);
   }
 
   ui.startSpinner('Creating Appium session...');
@@ -227,33 +228,22 @@ function buildAndroidCapabilities(config: AppClawConfig): Record<string, unknown
   return caps;
 }
 
-/** Create a remote Appium session on LambdaTest cloud. */
-async function createLambdaTestSession(
+/**
+ * Create a remote Appium session on any cloud provider (BrowserStack, Sauce
+ * Labs, LambdaTest, or a self-hosted grid). The hub URL and capabilities are
+ * built generically in ./cloud.ts; appium-mcp forwards them to the grid.
+ */
+async function createCloudSession(
   mcp: MCPClient,
   config: AppClawConfig,
   platform: Platform,
   fileCaps: Record<string, unknown> = {}
 ): Promise<SessionResult> {
-  ui.startSpinner('Creating LambdaTest cloud session...');
+  const providerLabel = cloudProviderLabel(config);
+  ui.startSpinner(`Creating ${providerLabel} cloud session...`);
 
-  const hubUrl = `https://${config.LAMBDATEST_USERNAME}:${config.LAMBDATEST_ACCESS_KEY}@mobile-hub.lambdatest.com/wd/hub`;
-
-  const ltOptions: Record<string, unknown> = {
-    video: config.LAMBDATEST_VIDEO === 'true',
-    network: config.LAMBDATEST_NETWORK === 'true',
-    isRealMobile: true,
-  };
-  if (config.LAMBDATEST_BUILD_NAME) ltOptions.build = config.LAMBDATEST_BUILD_NAME;
-  if (config.LAMBDATEST_PROJECT_NAME) ltOptions.project = config.LAMBDATEST_PROJECT_NAME;
-  if (config.LAMBDATEST_APP) ltOptions.app = config.LAMBDATEST_APP;
-
-  const capabilities: Record<string, unknown> = {
-    'appium:deviceName': config.LAMBDATEST_DEVICE_NAME,
-    'appium:platformVersion': config.LAMBDATEST_OS_VERSION,
-    'lt:options': ltOptions,
-    // User-supplied caps win over the cloud defaults above (their explicit choice).
-    ...fileCaps,
-  };
+  const hubUrl = buildCloudHubUrl(config);
+  const capabilities = buildCloudCapabilities(config, platform, fileCaps);
 
   const args: Record<string, unknown> = {
     platform,
@@ -274,7 +264,7 @@ async function createLambdaTestSession(
 
     ui.stopSpinner();
     ui.printSetupOk(
-      `LambdaTest session created — ${config.LAMBDATEST_DEVICE_NAME} (iOS ${config.LAMBDATEST_OS_VERSION})`
+      `${providerLabel} session created — ${config.CLOUD_DEVICE_NAME} (${platform === 'ios' ? 'iOS' : 'Android'} ${config.CLOUD_OS_VERSION})`
     );
 
     const sessionIdMatch = resultText.match(/session created successfully with ID:\s*(\S+)/i);
@@ -289,8 +279,8 @@ async function createLambdaTestSession(
     ui.stopSpinner();
     const msg = err instanceof Error ? err.message : String(err);
     ui.printSetupError(
-      `Failed to create LambdaTest session: ${msg}`,
-      'Check LAMBDATEST_USERNAME, LAMBDATEST_ACCESS_KEY, LAMBDATEST_DEVICE_NAME, and LAMBDATEST_OS_VERSION'
+      `Failed to create ${providerLabel} session: ${msg}`,
+      'Check CLOUD_USERNAME, CLOUD_ACCESS_KEY, CLOUD_DEVICE_NAME, and CLOUD_OS_VERSION (or CLOUD_SERVER_URL for a custom grid)'
     );
     throw err;
   }

--- a/src/flow/parallel-runner.ts
+++ b/src/flow/parallel-runner.ts
@@ -27,6 +27,7 @@ import { extractText } from '../mcp/tools.js';
 import { parseDeviceList } from '../device/device-picker.js';
 import { setupDevice } from '../device/index.js';
 import type { DeviceSetupArgs } from '../device/index.js';
+import { isCloud as isCloudConfig, cloudProviderLabel } from '../device/cloud.js';
 import { AppResolver } from '../agent/app-resolver.js';
 import { runYamlFlow } from './run-yaml-flow.js';
 import type { RunYamlFlowOptions, RunYamlFlowResult } from './run-yaml-flow.js';
@@ -145,7 +146,7 @@ async function runWorkerJob(
   platform: Platform
 ): Promise<WorkerFlowResult> {
   const label = chalk.cyan(`[worker:${workerIndex + 1}]`);
-  const isCloud = baseSetupArgs.config.CLOUD_PROVIDER === 'lambdatest';
+  const isCloud = isCloudConfig(baseSetupArgs.config);
 
   // setupDevice creates the Appium session and returns a session-scoped MCP
   // wrapper (scopedMcp). All subsequent tool calls go through scopedMcp so
@@ -154,7 +155,7 @@ async function runWorkerJob(
   // correct device regardless of appium-mcp's global select_device state.
   // Without this, concurrent workers race on the shared activeDevice global
   // in appium-mcp and both end up targeting the same physical device.
-  // Cloud mode: skip local port allocation — LambdaTest allocates sessions dynamically.
+  // Cloud mode: skip local port allocation — the grid allocates sessions dynamically.
   const {
     caps: workerCaps,
     mjpegUrl,
@@ -350,16 +351,16 @@ export async function runFlowOnDevices(
   const sharedMcp = await acquireSharedMCPClient(mcpConfig);
 
   try {
-    const isCloud = config.CLOUD_PROVIDER === 'lambdatest';
+    const isCloud = isCloudConfig(config);
     let selected: DiscoveredDevice[];
 
     if (isCloud) {
       ui.printInfo(
-        `Using LambdaTest cloud — ${parallelCount} parallel session(s) on ${config.LAMBDATEST_DEVICE_NAME}`
+        `Using ${cloudProviderLabel(config)} cloud — ${parallelCount} parallel session(s) on ${config.CLOUD_DEVICE_NAME}`
       );
       selected = Array.from({ length: parallelCount }, (_, i) => ({
-        name: `${config.LAMBDATEST_DEVICE_NAME} [${i + 1}]`,
-        udid: `lambdatest-cloud-${i + 1}`,
+        name: `${config.CLOUD_DEVICE_NAME} [${i + 1}]`,
+        udid: `cloud-${i + 1}`,
       }));
     } else {
       ui.printInfo(`Discovering ${platform} devices for ${parallelCount} parallel workers...`);
@@ -449,16 +450,16 @@ export async function runSuite(
   try {
     ui.printInfo(`Suite: ${suite.flows.length} flows, ${parallelCount} worker(s) on ${platform}`);
 
-    const isCloud = config.CLOUD_PROVIDER === 'lambdatest';
+    const isCloud = isCloudConfig(config);
     let selected: DiscoveredDevice[];
 
     if (isCloud) {
       ui.printInfo(
-        `Using LambdaTest cloud — ${parallelCount} parallel session(s) on ${config.LAMBDATEST_DEVICE_NAME}`
+        `Using ${cloudProviderLabel(config)} cloud — ${parallelCount} parallel session(s) on ${config.CLOUD_DEVICE_NAME}`
       );
       selected = Array.from({ length: parallelCount }, (_, i) => ({
-        name: `${config.LAMBDATEST_DEVICE_NAME} [${i + 1}]`,
-        udid: `lambdatest-cloud-${i + 1}`,
+        name: `${config.CLOUD_DEVICE_NAME} [${i + 1}]`,
+        udid: `cloud-${i + 1}`,
       }));
     } else {
       const devices = await discoverDevices(sharedMcp, platform, deviceType);

--- a/src/index.ts
+++ b/src/index.ts
@@ -497,6 +497,7 @@ async function main() {
       transport: config.MCP_TRANSPORT,
       host: config.MCP_HOST,
       port: config.MCP_PORT,
+      url: config.MCP_URL || undefined,
     });
     const mcp = mcpClient;
 
@@ -573,6 +574,7 @@ async function main() {
           transport: config.MCP_TRANSPORT,
           host: config.MCP_HOST,
           port: config.MCP_PORT,
+          url: config.MCP_URL || undefined,
         });
         ui.stopSpinner();
         ui.printSetupOk('Connected to appium-mcp');
@@ -774,6 +776,7 @@ async function main() {
       transport: config.MCP_TRANSPORT,
       host: config.MCP_HOST,
       port: config.MCP_PORT,
+      url: config.MCP_URL || undefined,
     });
     const mcp = mcpClient;
 
@@ -956,6 +959,7 @@ async function main() {
     transport: config.MCP_TRANSPORT,
     host: config.MCP_HOST,
     port: config.MCP_PORT,
+    url: config.MCP_URL || undefined,
   });
 
   const mcp = mcpClient;

--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -144,7 +144,10 @@ async function connectClient(config: MCPConfig): Promise<Client> {
       throw err;
     }
   } else {
-    const url = new URL(`http://${config.host}:${config.port}/sse`);
+    // Prefer the full URL when provided so the original scheme (https for
+    // ngrok/cloud tunnels) and path survive; fall back to the host:port form
+    // for a co-located node.
+    const url = new URL(config.url ?? `http://${config.host}:${config.port}/sse`);
     const transport = new SSEClientTransport(url);
     await client.connect(transport);
   }
@@ -192,7 +195,9 @@ export async function createMCPClient(config: MCPConfig): Promise<MCPClient> {
 
 /** Config key for deduplication */
 function configKey(config: MCPConfig): string {
-  return `${config.transport}:${config.host}:${config.port}`;
+  return config.url
+    ? `${config.transport}:${config.url}`
+    : `${config.transport}:${config.host}:${config.port}`;
 }
 
 interface SharedEntry {

--- a/src/mcp/tool-converter.ts
+++ b/src/mcp/tool-converter.ts
@@ -50,6 +50,11 @@ export const EXCLUDED_MCP_TOOLS = new Set([
   // Documentation/skills tools — not relevant to device control
   'appium_documentation_query',
   'appium_skills',
+  // Perception owns screenshot capture — the LLM sees screenshots via the
+  // prompt image part, so exposing this tool just invites redundant calls
+  // (and the tool's own description tells the model to leave returnRawBase64
+  // false, which breaks on remote MCP servers).
+  'appium_screenshot',
 ]);
 
 /** Additional tools to exclude in vision mode — DOM-based tools that distract the agent */

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -69,25 +69,11 @@ export async function getPageSource(client: MCPClient): Promise<string> {
 /** Take a screenshot and return base64 image data, or null if unavailable */
 export async function screenshot(client: MCPClient, elementUUID?: string): Promise<string | null> {
   const result = await client.callTool('appium_screenshot', {
+    returnRawBase64: true,
     ...(elementUUID && { elementUUID }),
   });
   for (const content of result.content) {
     if (content.type === 'image') return content.data;
-  }
-  const text = extractText(result);
-  if (text.startsWith('iVBOR') || text.startsWith('/9j/')) {
-    return text;
-  }
-  if (text.includes('screenshot') && text.includes('/')) {
-    try {
-      const pathMatch = text.match(/:\s*(.+\.png)/);
-      if (pathMatch) {
-        const { readFileSync } = await import('fs');
-        return readFileSync(pathMatch[1]).toString('base64');
-      }
-    } catch {
-      // File read failed
-    }
   }
   return null;
 }

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -16,6 +16,12 @@ export interface MCPConfig {
   transport: 'stdio' | 'sse';
   host: string;
   port: number;
+  /**
+   * Full SSE endpoint URL (scheme + host + port + path). When set it is used
+   * verbatim instead of reconstructing `http://host:port/sse` — required for
+   * https tunnels (ngrok) and any non-default port or path.
+   */
+  url?: string;
 }
 
 /** Wrapper around MCP client for typed access */

--- a/src/playground/index.ts
+++ b/src/playground/index.ts
@@ -922,6 +922,7 @@ async function connectToDevice(): Promise<boolean> {
       transport: config.MCP_TRANSPORT,
       host: config.MCP_HOST,
       port: config.MCP_PORT,
+      url: config.MCP_URL || undefined,
     });
     state.mcp = mcpClient;
     ui.stopSpinner();

--- a/src/runner/cli.ts
+++ b/src/runner/cli.ts
@@ -69,6 +69,9 @@ function parseArgs(argv: string[]): ParsedArgs {
       case '--grep':
         overrides.grep = next();
         break;
+      case '--ignore':
+        (overrides.testIgnore ??= []).push(next());
+        break;
       case '--grep-invert':
         overrides.grepInvert = next();
         break;
@@ -144,6 +147,7 @@ Options:
   --timeout <ms>          per-test timeout
   --grep <regex>          run only tests whose title matches
   --grep-invert <regex>   skip tests whose title matches
+  --ignore <pattern>      exclude spec files (repeatable; adds to testIgnore)
   --shard <x/n>           run shard x of n
   --reporter <name>       reporter (list, html, plain)
   --platform <p>          android | ios
@@ -209,8 +213,11 @@ export async function runCli(argv: string[]): Promise<number> {
     config.testFilter
   );
   if (specs.length === 0) {
+    const hint = config.testIgnore.length
+      ? ` (testIgnore/--ignore excludes: ${config.testIgnore.join(', ')})`
+      : '';
     // eslint-disable-next-line no-console
-    console.error(`No spec files found under "${config.testDir}".`);
+    console.error(`No spec files found under "${config.testDir}"${hint}.`);
     return 1;
   }
 

--- a/src/runner/config.ts
+++ b/src/runner/config.ts
@@ -107,7 +107,10 @@ export function resolveConfig(fileConfig: RunnerConfig, cli: CliOverrides = {}):
   return {
     testDir: testDir ?? DEFAULTS.testDir,
     testMatch: asArray(testMatch) ?? DEFAULTS.testMatch,
-    testIgnore: asArray(testIgnore) ?? DEFAULTS.testIgnore,
+    // `--ignore` stacks on top of the config's testIgnore (both apply) rather
+    // than replacing it — excluding more from the CLI shouldn't un-exclude
+    // what the config already filters out.
+    testIgnore: [...(asArray(testIgnore) ?? DEFAULTS.testIgnore), ...(cli.testIgnore ?? [])],
     testFilter: cli.testFilter ?? [],
 
     platform,

--- a/src/runner/node-local.ts
+++ b/src/runner/node-local.ts
@@ -60,6 +60,12 @@ function resolveAppiumMcp(): { command: string; args: string[] } {
 export interface SSENode {
   host: string;
   port: number;
+  /**
+   * Full SSE endpoint URL for an externally-owned node (e.g. an https ngrok
+   * tunnel). Undefined for a locally-spawned node, which is always
+   * `http://host:port/sse` and reconstructed from host+port.
+   */
+  url?: string;
   stop(): Promise<void>;
   /**
    * The most recent appium-mcp server log lines (stdout+stderr), newest last.

--- a/src/runner/pool.ts
+++ b/src/runner/pool.ts
@@ -22,6 +22,7 @@ export async function discoverPool(node: SSENode, platform: Platform): Promise<D
     transport: 'sse',
     host: node.host,
     port: node.port,
+    url: node.url,
   });
   try {
     const result = await mcp.callTool('select_device', { platform });

--- a/src/runner/runner.ts
+++ b/src/runner/runner.ts
@@ -65,6 +65,8 @@ export class Runner<State = unknown> {
   /** Address of the SSE node every leased session connects to (set in run()). */
   private nodeHost = '127.0.0.1';
   private nodePort = 0;
+  /** Full SSE URL when connecting to an external node; undefined for a local one. */
+  private nodeUrl?: string;
   /** Live view (TUI) or line output (plain) — chosen per run in run(). */
   private reporter: RunnerReporter = new PlainReporter();
   /** Suite identity for this run — tags every test's manifest + the report. */
@@ -88,6 +90,7 @@ export class Runner<State = unknown> {
       const { node, ownsNode } = await this.connectNode();
       this.nodeHost = node.host;
       this.nodePort = node.port;
+      this.nodeUrl = node.url;
       try {
         reporter.starting('Discovering devices…');
         const pool = await discoverPool(node, this.config.platform);
@@ -207,7 +210,11 @@ export class Runner<State = unknown> {
       const u = new URL(this.config.node.url);
       const node: SSENode = {
         host: u.hostname,
-        port: Number(u.port),
+        // `u.port` is '' for a default-port URL (https→443, http→80). Number('')
+        // is 0, and connecting to port 0 fails with EADDRNOTAVAIL — derive the
+        // scheme default instead. The full url below is what actually connects.
+        port: u.port ? Number(u.port) : u.protocol === 'https:' ? 443 : 80,
+        url: this.config.node.url,
         recentLog: () => '', // external server's process isn't ours to read
         async stop() {
           /* externally owned */
@@ -500,6 +507,7 @@ export class Runner<State = unknown> {
       mcpTransport: 'sse',
       mcpHost: this.nodeHost,
       mcpPort: this.nodePort,
+      mcpUrl: this.nodeUrl,
       deviceUdid: device.udid,
       platform: this.config.platform,
       reportName,

--- a/src/runner/runner.ts
+++ b/src/runner/runner.ts
@@ -93,7 +93,23 @@ export class Runner<State = unknown> {
       this.nodeUrl = node.url;
       try {
         reporter.starting('Discovering devices…');
-        const pool = await discoverPool(node, this.config.platform);
+        // Cloud mode (CLOUD_PROVIDER set): skip local pool discovery — there is
+        // no local device to enumerate. Synthesize a single-entry pool; the
+        // SDK's cloud path ignores the placeholder udid and drives the device
+        // the provider hub returns. Device name is only cosmetic here (used in
+        // reports/logs) — the actual device is chosen by the caps sent to the
+        // grid, either from CLOUD_DEVICE_NAME or from inline capabilities.
+        const cloudProvider = process.env.CLOUD_PROVIDER?.trim();
+        const pool = cloudProvider
+          ? [
+              {
+                name: process.env.CLOUD_DEVICE_NAME || `${cloudProvider} cloud`,
+                udid: 'cloud',
+                state: 'booted' as const,
+                platform: this.config.platform,
+              },
+            ]
+          : await discoverPool(node, this.config.platform);
         if (pool.length === 0) {
           throw new Error(
             `No ${this.config.platform} devices found. Connect a device/emulator and retry.`

--- a/src/runner/types.ts
+++ b/src/runner/types.ts
@@ -137,6 +137,8 @@ export interface RunnerConfig<State = unknown> extends AppClawOptions {
 /** Per-run overrides parsed from the CLI; each wins over the config file. */
 export interface CliOverrides {
   testFilter?: string[];
+  /** `--ignore` patterns; additive — stacked on top of the config's `testIgnore`. */
+  testIgnore?: string[];
   platform?: Platform;
   concurrency?: number;
   retries?: number;

--- a/src/sdk/config-builder.ts
+++ b/src/sdk/config-builder.ts
@@ -24,6 +24,7 @@ const OPTION_TO_ENV_VAR: Partial<Record<keyof AppClawOptions, string>> = {
   mcpTransport: 'MCP_TRANSPORT',
   mcpHost: 'MCP_HOST',
   mcpPort: 'MCP_PORT',
+  mcpUrl: 'MCP_URL',
   // `silent`, `video`, `report`, `reportName` are SDK-only — no env-var equivalents.
 };
 

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -101,7 +101,7 @@ export class AppClaw {
     // every command would silently run in DOM mode. (With multiple instances in one
     // process the last constructed config wins, same as the pre-existing singleton.)
     applyConfig(this.config);
-    this.session = new McpSession(this.config);
+    this.session = new McpSession(this.config, options.capabilities);
 
     // `silent` controls per-step log lines (✓ #1 tap "label" ...). Default is
     // FALSE — most SDK consumers want to see what's happening on the device,

--- a/src/sdk/mcp-session.ts
+++ b/src/sdk/mcp-session.ts
@@ -35,7 +35,10 @@ const LOCAL_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '0.0.0.0', '']);
  */
 export function isLocalNode(config: AppClawConfig): boolean {
   if (config.MCP_TRANSPORT === 'stdio') return true;
-  return LOCAL_HOSTS.has(config.MCP_HOST.trim().toLowerCase());
+  // A full MCP_URL wins over MCP_HOST — derive the host from it so a URL-only
+  // config (no explicit MCP_HOST) is still correctly classified as remote.
+  const host = config.MCP_URL ? new URL(config.MCP_URL).hostname : config.MCP_HOST;
+  return LOCAL_HOSTS.has(host.trim().toLowerCase());
 }
 
 /**
@@ -95,6 +98,7 @@ export class McpSession {
         transport: this.config.MCP_TRANSPORT,
         host: this.config.MCP_HOST,
         port: this.config.MCP_PORT,
+        url: this.config.MCP_URL || undefined,
       });
       const platform = (this.config.PLATFORM || 'android') as Platform;
       // Allocate unique ports per instance so parallel tests don't collide on

--- a/src/sdk/mcp-session.ts
+++ b/src/sdk/mcp-session.ts
@@ -79,13 +79,15 @@ export interface ConnectedSession {
 
 export class McpSession {
   private readonly config: AppClawConfig;
+  private readonly inlineCaps?: Record<string, unknown>;
   private handle: SharedMCPClient | null = null;
   private scopedClient: MCPClient | null = null;
   private cachedTools: MCPToolInfo[] = [];
   private cachedAppResolver: AppResolver | null = null;
 
-  constructor(config: AppClawConfig) {
+  constructor(config: AppClawConfig, inlineCaps?: Record<string, unknown>) {
     this.config = config;
+    this.inlineCaps = inlineCaps;
   }
 
   /**
@@ -120,7 +122,8 @@ export class McpSession {
           this.config,
           platform,
           undefined,
-          extraCaps
+          extraCaps,
+          this.inlineCaps
         );
         this.scopedClient = scopedMcp;
         this.cachedTools = await this.handle.listTools();

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -132,6 +132,13 @@ export interface AppClawOptions {
   /** appium-mcp port when transport is 'sse'. Default: 8080. */
   mcpPort?: number;
   /**
+   * Full appium-mcp SSE URL (e.g. an https ngrok/cloud tunnel like
+   * `https://abc.ngrok-free.app/sse`). When set it takes precedence over
+   * `mcpHost`/`mcpPort` and preserves the scheme + path, so https tunnels and
+   * non-default ports work. Only used when transport is 'sse'.
+   */
+  mcpUrl?: string;
+  /**
    * Stream verbose appium-mcp logs (subprocess stderr + per-tool timing) to the console.
    * When `false`, suppresses these even if the `MCP_DEBUG=1` env var is set — useful for
    * keeping test output clean. When `true`, forces them on. When unset, defers to MCP_DEBUG.

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -64,6 +64,19 @@ export interface AppClawOptions {
    * Maps to the CAPABILITIES_FILE env var.
    */
   capabilitiesFile?: string;
+  /**
+   * Inline Appium capabilities merged into the session — useful for keeping
+   * provider-specific caps (`lt:options`, `bstack:options`, `sauce:options`,
+   * or plain `appium:*` fields) alongside the rest of your config instead of
+   * in a separate JSON file. Accepts the same shape as `capabilitiesFile`,
+   * including the platform-scoped form `{ android: {...}, ios: {...} }`.
+   *
+   * Precedence (later wins): config defaults < `capabilities` <
+   * `capabilitiesFile` < framework-managed caps (parallel ports, pinned udid).
+   * So `capabilitiesFile` acts as an environment-specific override on top of
+   * this inline baseline.
+   */
+  capabilities?: Record<string, unknown>;
   /** Interaction strategy: DOM locators (default) or AI vision. */
   agentMode?: AgentMode;
   /** Maximum number of agent steps before giving up. Default: 30. */

--- a/src/ui/ink/components/PlaygroundBottomBar.tsx
+++ b/src/ui/ink/components/PlaygroundBottomBar.tsx
@@ -45,6 +45,11 @@ export function PlaygroundBottomBar({
         <Sep />
         <Text color={COLORS.label}>mode</Text>
         <Text color={COLORS.dimmed}>{mode}</Text>
+        <Sep />
+        <Text color={COLORS.label}>mcp</Text>
+        <Text color={transport === 'sse' ? COLORS.yellow : COLORS.green}>
+          {transport === 'sse' ? 'remote' : 'local'}
+        </Text>
         {app ? (
           <>
             <Sep />

--- a/src/vision/stark-locate.ts
+++ b/src/vision/stark-locate.ts
@@ -10,7 +10,7 @@
 import starkVision from 'df-vision';
 import sharp from 'sharp';
 
-import type { MCPClient, MCPToolResult } from '../mcp/types.js';
+import type { MCPClient } from '../mcp/types.js';
 
 const {
   StarkVisionClient,
@@ -55,33 +55,11 @@ async function downscaleForVision(base64: string): Promise<string> {
   }
 }
 
-function textFromMcpResult(result: MCPToolResult): string {
-  for (const content of result.content) {
-    if (content.type === 'text') return content.text;
-  }
-  return '';
-}
-
 /** Same behavior as mcp/tools.screenshot — kept local to avoid circular imports. */
 async function captureScreenshotBase64(mcp: MCPClient): Promise<string | null> {
-  const result = await mcp.callTool('appium_screenshot', {});
+  const result = await mcp.callTool('appium_screenshot', { returnRawBase64: true });
   for (const content of result.content) {
     if (content.type === 'image') return content.data;
-  }
-  const text = textFromMcpResult(result);
-  if (text.startsWith('iVBOR') || text.startsWith('/9j/')) {
-    return text;
-  }
-  if (text.includes('screenshot') && text.includes('/')) {
-    try {
-      const pathMatch = text.match(/:\s*(.+\.png)/);
-      if (pathMatch) {
-        const { readFileSync } = await import('fs');
-        return readFileSync(pathMatch[1]).toString('base64');
-      }
-    } catch {
-      /* ignore */
-    }
   }
   return null;
 }

--- a/tests/verify-cloud.ts
+++ b/tests/verify-cloud.ts
@@ -1,0 +1,67 @@
+import { loadConfig } from '../src/config.js';
+import {
+  isCloud,
+  buildCloudHubUrl,
+  buildCloudCapabilities,
+  cloudProviderLabel,
+} from '../src/device/cloud.js';
+
+function show(name: string, overrides: Record<string, string>) {
+  const cfg = loadConfig(overrides);
+  console.log(`\n=== ${name} (${cloudProviderLabel(cfg)}) isCloud=${isCloud(cfg)}`);
+  console.log('hub :', buildCloudHubUrl(cfg).replace(/:[^@/]+@/, ':***@'));
+  console.log('caps:', JSON.stringify(buildCloudCapabilities(cfg, 'android')));
+}
+
+show('browserstack', {
+  CLOUD_PROVIDER: 'browserstack',
+  CLOUD_USERNAME: 'user1',
+  CLOUD_ACCESS_KEY: 'key1',
+  CLOUD_DEVICE_NAME: 'Google Pixel 8',
+  CLOUD_OS_VERSION: '14',
+  CLOUD_APP: 'bs://abc',
+  CLOUD_BUILD_NAME: 'smoke',
+  CLOUD_PROJECT_NAME: 'AppClaw',
+});
+
+show('saucelabs eu', {
+  CLOUD_PROVIDER: 'saucelabs',
+  CLOUD_USERNAME: 'u',
+  CLOUD_ACCESS_KEY: 'k',
+  CLOUD_DEVICE_NAME: 'iPhone 14',
+  CLOUD_OS_VERSION: '16',
+  CLOUD_REGION: 'eu-central-1',
+});
+
+show('lambdatest', {
+  CLOUD_PROVIDER: 'lambdatest',
+  CLOUD_USERNAME: 'u',
+  CLOUD_ACCESS_KEY: 'k',
+  CLOUD_DEVICE_NAME: 'Galaxy S24',
+  CLOUD_OS_VERSION: '14',
+  CLOUD_BUILD_NAME: 'b1',
+});
+
+show('custom (auth-in-url)', {
+  CLOUD_PROVIDER: 'custom',
+  CLOUD_SERVER_URL: 'https://me:secret@grid.internal:4444/wd/hub',
+  CLOUD_DEVICE_NAME: 'Pixel_7',
+  CLOUD_OS_VERSION: '14',
+});
+
+try {
+  loadConfig({ CLOUD_PROVIDER: 'custom', CLOUD_DEVICE_NAME: 'x', CLOUD_OS_VERSION: '1' });
+  console.log('\nFAIL: custom without CLOUD_SERVER_URL did not throw');
+} catch (e) {
+  console.log('\nOK: custom w/o URL throws →', (e as Error).message);
+}
+
+try {
+  loadConfig({ CLOUD_PROVIDER: 'browserstack', CLOUD_DEVICE_NAME: 'x', CLOUD_OS_VERSION: '1' });
+  console.log('FAIL: browserstack without creds did not throw');
+} catch (e) {
+  console.log('OK: bstack w/o creds throws →', (e as Error).message);
+}
+
+const local = loadConfig({});
+console.log('\nlocal isCloud=', isCloud(local), 'label=', cloudProviderLabel(local));


### PR DESCRIPTION
This pull request introduces comprehensive support and documentation for running AppClaw tests on cloud device providers (BrowserStack, Sauce Labs, TestMuAI/LambdaTest, and custom/self-hosted grids). It updates the documentation to cover cloud configuration, environment variables, usage examples, and capability merging, and generalizes previous LambdaTest-specific sections to a unified "Cloud Providers" approach. Minor updates to example configs and test capabilities are also included.

**Cloud device provider support and documentation:**

* Added a new "Cloud devices" section to the `README.md`, explaining how to configure AppClaw to use remote Appium grids with environment variables, provider-specific options, and capability merging.
* Expanded the `.env` variable reference in `README.md` to include all cloud provider environment variables and linked to the new documentation section.
* Major rewrite of the "Usage Guide" (`landing/public/usage.html`) to generalize cloud provider support, add quick reference tables, detailed setup instructions for each provider, environment variable documentation, and examples for CLI/SDK usage and provider-specific options. [[1]](diffhunk://#diff-c5d155887d229c46af04649f0ab0e7cac2c6562917ce8e8e3e600e39d13ed79aR2792-R2798) [[2]](diffhunk://#diff-c5d155887d229c46af04649f0ab0e7cac2c6562917ce8e8e3e600e39d13ed79aL2921-R3108) [[3]](diffhunk://#diff-c5d155887d229c46af04649f0ab0e7cac2c6562917ce8e8e3e600e39d13ed79aL2983-R3126) [[4]](diffhunk://#diff-c5d155887d229c46af04649f0ab0e7cac2c6562917ce8e8e3e600e39d13ed79aL2996-R3140) [[5]](diffhunk://#diff-c5d155887d229c46af04649f0ab0e7cac2c6562917ce8e8e3e600e39d13ed79aL3010-R3150)
* Updated sidebar navigation and section headings in the usage guide to use "Cloud Providers" instead of "LambdaTest Cloud" and added links to new subsections. [[1]](diffhunk://#diff-c5d155887d229c46af04649f0ab0e7cac2c6562917ce8e8e3e600e39d13ed79aL1429-R1429) [[2]](diffhunk://#diff-c5d155887d229c46af04649f0ab0e7cac2c6562917ce8e8e3e600e39d13ed79aL1441-R1444)

**Example configuration and test updates:**

* Updated the example `appclaw.config.ts` to use a remote SSE server URL.
* Changed the test `caps.json` to use an HTTP URL for the app and added the `appium:mjpegServerPort` capability.