### PR TITLE
fix: detect iOS TextView as editable

### DIFF
--- a/packages/core/src/perception/dom-trimmer.ts
+++ b/packages/core/src/perception/dom-trimmer.ts
@@ -266,7 +266,8 @@ function walkIOS(node: any, result: TrimmedNode[], parentContext: string = ''): 
     const isFocused = node['@_hasFocus'] === 'true';
     const isSelected = node['@_selected'] === 'true';
 
-    const editableTypes = ['TextField', 'SecureTextField', 'TextEditor', 'SearchField'];
+    // XCUITest exposes UIKit/RN multiline inputs (including KRN composers) as TextView.
+    const editableTypes = ['TextField', 'TextView', 'SecureTextField', 'TextEditor', 'SearchField'];
     const editable = editableTypes.some((t) => tag.includes(t));
     const clickable =
       isAccessible ||

--- a/packages/core/src/perception/ios-parser.ts
+++ b/packages/core/src/perception/ios-parser.ts
@@ -17,7 +17,8 @@ function shortTypeName(xcuiType: string): string {
 
 /** Check if an iOS element type is typically editable */
 function isEditableType(typeName: string): boolean {
-  const editableTypes = ['TextField', 'SecureTextField', 'TextEditor', 'SearchField'];
+  // XCUITest exposes UIKit/RN multiline inputs (including KRN composers) as TextView.
+  const editableTypes = ['TextField', 'TextView', 'SecureTextField', 'TextEditor', 'SearchField'];
   return editableTypes.some((t) => typeName.includes(t));
 }
 

--- a/tests/flow/ios-textview-editable.test.ts
+++ b/tests/flow/ios-textview-editable.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from 'vitest';
+import { resolveEditableForTarget } from '@appclaw/core/flow/run-yaml-flow';
+import { trimDOM } from '@appclaw/core/perception/dom-trimmer';
+import { parseIOSPageSource } from '@appclaw/core/perception/ios-parser';
+
+const krnComposerSource = `<?xml version="1.0" encoding="UTF-8"?>
+<AppiumAUT>
+  <XCUIElementTypeApplication
+    type="XCUIElementTypeApplication"
+    name="快手"
+    label="快手"
+    enabled="true"
+    visible="true"
+    accessible="false"
+    x="0"
+    y="0"
+    width="430"
+    height="932">
+    <XCUIElementTypeTextView
+      type="XCUIElementTypeTextView"
+      name="kitchen-composer-text-input"
+      label="聊天输入框 输入问题..."
+      enabled="true"
+      visible="true"
+      accessible="true"
+      x="35"
+      y="522"
+      width="331"
+      height="30"/>
+  </XCUIElementTypeApplication>
+</AppiumAUT>`;
+
+describe('iOS XCUIElementTypeTextView inputs', () => {
+  test('page-source parser exposes a TextView as an editable type target', () => {
+    const elements = parseIOSPageSource(krnComposerSource);
+    const input = elements.find((element) => element.id === 'kitchen-composer-text-input');
+
+    expect(input).toMatchObject({
+      type: 'TextView',
+      editable: true,
+      action: 'type',
+    });
+    expect(resolveEditableForTarget(elements, 'kitchen-composer-text-input').el).toBe(input);
+  });
+
+  test('DOM trimmer marks a TextView editable and includes it in editableCount', () => {
+    const result = trimDOM(krnComposerSource, 'ios');
+
+    expect(result.editableCount).toBe(1);
+    expect(result.xml).toContain('<TextView');
+    expect(result.xml).toContain('name="kitchen-composer-text-input"');
+    expect(result.xml).toContain('editable="true"');
+  });
+});


### PR DESCRIPTION
## Summary

- treat `XCUIElementTypeTextView` as editable in the normalized iOS page-source parser
- mark `TextView` nodes as `editable="true"` in the trimmed DOM and include them in `editableCount`
- add a regression test based on a real React Native/KRN composer page-source shape

## Root cause

XCUITest exposes UIKit/React Native multiline inputs as `XCUIElementTypeTextView`. AppClaw's two iOS editable-type allowlists covered `TextField`, `SecureTextField`, `TextEditor`, and `SearchField`, but omitted `TextView`.

As a result, a visible and enabled composer such as `kitchen-composer-text-input` was parsed with `editable=false`, the trimmed screen reported `editableCount=0`, and YAML `type` steps failed with `no editable field on screen` even when the accessibility ID was exact.

## Impact

YAML flows can now resolve and type into iOS multiline inputs used by UIKit, React Native, and KRN composers without falling back to direct XCUITest scripts.

## Verification

- `npm test` — 18 test files, 365 tests passed
- Prettier check passed for all changed files
- parsed a captured real-device KRN XML source with the patched build:
  - `type=TextView`
  - `editable=true`
  - `action=type`
  - target resolver returned `kitchen-composer-text-input`
  - trimmed DOM reported `editableCount=1`

## Environment note

A full local CLI rerun against the device was attempted, but the current `main` dependency stack crashed inside `appium-ios-remotexpc` during WDA port forwarding, before AppClaw received any page source. The parser and resolver behavior was therefore verified against the captured real-device XML in addition to the regression test.
