### PR TITLE
fix: overhaul spatial locator resolution for list-row screens

### DIFF
--- a/.github/workflows/runner-e2e-run.yml
+++ b/.github/workflows/runner-e2e-run.yml
@@ -1,0 +1,117 @@
+name: Runner E2E (reusable)
+
+# Reusable body for the runner E2E: boots TWO Android emulators and runs the
+# example specs (examples/runner) across both with `appclaw-runner --workers 2`.
+# Called by runner-e2e.yml with agent-mode dom (every PR) or vision (label-gated).
+
+on:
+  workflow_call:
+    inputs:
+      agent-mode:
+        description: 'AGENT_MODE for the specs (dom | vision)'
+        required: true
+        type: string
+      provider:
+        description: 'LLM provider'
+        required: false
+        type: string
+        default: 'gemini'
+      model:
+        description: 'LLM model ID (blank = provider default)'
+        required: false
+        type: string
+        default: ''
+    secrets:
+      LLM_API_KEY:
+        required: true
+
+jobs:
+  runner-android:
+    name: Runner — 2 Android emulators (${{ inputs.agent-mode }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    env:
+      API_LEVEL: '33'
+      TARGET: default
+      ARCH: x86_64
+      PROFILE: pixel_6
+      AGENT_MODE: ${{ inputs.agent-mode }}
+      LLM_PROVIDER: ${{ inputs.provider }}
+      LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+      LLM_MODEL: ${{ inputs.model }}
+      # Point the example config at a CI caps file that installs VodQA from a URL
+      # (the committed caps.json uses a machine-local APK path).
+      APPCLAW_CAPS: ./tests/caps.ci.json
+      # Force the plain reporter (no TUI dashboard) for readable CI logs.
+      APPCLAW_TUI: 'off'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+
+      # ── Build the workspace (npm ci also installs & links examples/runner,
+      #    a workspace member, and exposes the `appclaw-runner` bin) ────────────
+      - name: Build AppClaw
+        run: |
+          npm ci
+          npm run build
+
+      # ── Android emulator acceleration ───────────────────────────────────────
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: AVD cache
+        uses: actions/cache@v4
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-${{ env.API_LEVEL }}-${{ env.TARGET }}-${{ env.ARCH }}
+
+      # ── Run the runner across two emulators ─────────────────────────────────
+      # reactivecircus/android-emulator-runner boots one AVD ("test", emulator-5554)
+      # and runs `script`. Inside the script we boot a SECOND emulator on port 5556,
+      # wait for both to finish booting, then run `appclaw-runner --workers 2` so the
+      # specs fan out across both devices.
+      - name: Boot 2 emulators & run specs
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ env.API_LEVEL }}
+          target: ${{ env.TARGET }}
+          arch: ${{ env.ARCH }}
+          profile: ${{ env.PROFILE }}
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none
+          disable-animations: true
+          script: |
+            # android-emulator-runner executes this with /usr/bin/sh (dash) and
+            # does not honour backslash line-continuations — keep each command on
+            # a single line, and use POSIX flags only (no `pipefail`).
+            set -eu
+            # Boot the second emulator (the first is already up as emulator-5554).
+            echo "no" | avdmanager create avd -n test2 -k "system-images;android-${API_LEVEL};${TARGET};${ARCH}" -d "${PROFILE}" --force
+            nohup "$ANDROID_HOME/emulator/emulator" -avd test2 -port 5556 -no-snapshot -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none > "$RUNNER_TEMP/emulator-5556.log" 2>&1 &
+            # Wait for both emulators to finish booting.
+            for serial in emulator-5554 emulator-5556; do echo "Waiting for $serial to boot..."; adb -s "$serial" wait-for-device; timeout 300 adb -s "$serial" shell 'while [ -z "$(getprop sys.boot_completed | tr -d "\r")" ]; do sleep 2; done'; adb -s "$serial" shell input keyevent 82 || true; done
+            adb devices
+            # Run the example specs across both emulators. Each line runs in its
+            # own `sh -c`, so `cd` must be chained with the command that needs it.
+            cd examples/runner && npx appclaw-runner --workers 2 --retries 1 --reporter plain
+
+      - name: Upload runner report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: runner-report-${{ inputs.agent-mode }}
+          path: examples/runner/.appclaw/runs/
+          if-no-files-found: ignore

--- a/.github/workflows/runner-e2e.yml
+++ b/.github/workflows/runner-e2e.yml
@@ -19,7 +19,8 @@ on:
         default: ''
   pull_request:
     paths:
-      - 'src/runner/**'
+      - 'packages/runner/**'
+      - 'packages/core/src/flow/parallel-runner.ts'
       - 'examples/runner/**'
       - '.github/workflows/runner-e2e.yml'
 

--- a/.github/workflows/runner-e2e.yml
+++ b/.github/workflows/runner-e2e.yml
@@ -1,10 +1,17 @@
 name: Runner E2E (2 Android emulators)
 
-# End-to-end test of the parallel runner (examples/runner): boots TWO Android
-# emulators and runs the example specs across both with `appclaw-runner --workers 2`.
+# End-to-end test of the parallel runner (examples/runner), split into two routes:
 #
-# This is heavy (2 emulators + LLM calls), so it does NOT run on every PR. It
-# runs on demand (Actions tab) and when the runner itself changes.
+#   dom    — AGENT_MODE=dom. Text-only LLM calls (step parsing / assertions),
+#            cheap enough to gate every PR.
+#   vision — AGENT_MODE=vision. Gemini vision on screenshots, expensive; runs
+#            only when a maintainer applies the "AI" label to the PR (labels
+#            need triage+ permission, so the label IS the admin gate). Once
+#            labeled, later pushes to the PR re-run the vision route too.
+#
+# Both routes share the same reusable body (runner-e2e-run.yml): 2 emulators,
+# `appclaw-runner --workers 2` over the example specs. Manual runs from the
+# Actions tab execute the dom route.
 
 on:
   workflow_dispatch:
@@ -18,102 +25,31 @@ on:
         required: false
         default: ''
   pull_request:
-    paths:
-      - 'packages/runner/**'
-      - 'packages/core/src/flow/parallel-runner.ts'
-      - 'examples/runner/**'
-      - '.github/workflows/runner-e2e.yml'
-
-concurrency:
-  group: runner-e2e-${{ github.ref }}
-  cancel-in-progress: true
+    types: [opened, synchronize, reopened, labeled]
 
 jobs:
-  runner-android:
-    name: Runner — 2 Android emulators
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
+  dom:
+    name: DOM route
+    # A bare "labeled" event only concerns the vision route — don't re-run dom.
+    if: github.event.action != 'labeled'
+    concurrency:
+      group: runner-e2e-dom-${{ github.ref }}
+      cancel-in-progress: true
+    uses: ./.github/workflows/runner-e2e-run.yml
+    with:
+      agent-mode: dom
+      provider: ${{ github.event.inputs.provider || 'gemini' }}
+      model: ${{ github.event.inputs.model || '' }}
+    secrets: inherit
 
-    env:
-      API_LEVEL: '33'
-      TARGET: default
-      ARCH: x86_64
-      PROFILE: pixel_6
-      LLM_PROVIDER: ${{ github.event.inputs.provider || 'gemini' }}
-      LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
-      LLM_MODEL: ${{ github.event.inputs.model }}
-      # Point the example config at a CI caps file that installs VodQA from a URL
-      # (the committed caps.json uses a machine-local APK path).
-      APPCLAW_CAPS: ./tests/caps.ci.json
-      # Force the plain reporter (no TUI dashboard) for readable CI logs.
-      APPCLAW_TUI: 'off'
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: npm
-
-      # ── Build the workspace (npm ci also installs & links examples/runner,
-      #    a workspace member, and exposes the `appclaw-runner` bin) ────────────
-      - name: Build AppClaw
-        run: |
-          npm ci
-          npm run build
-
-      # ── Android emulator acceleration ───────────────────────────────────────
-      - name: Enable KVM
-        run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
-            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
-
-      - name: AVD cache
-        uses: actions/cache@v4
-        id: avd-cache
-        with:
-          path: |
-            ~/.android/avd/*
-            ~/.android/adb*
-          key: avd-${{ env.API_LEVEL }}-${{ env.TARGET }}-${{ env.ARCH }}
-
-      # ── Run the runner across two emulators ─────────────────────────────────
-      # reactivecircus/android-emulator-runner boots one AVD ("test", emulator-5554)
-      # and runs `script`. Inside the script we boot a SECOND emulator on port 5556,
-      # wait for both to finish booting, then run `appclaw-runner --workers 2` so the
-      # specs fan out across both devices.
-      - name: Boot 2 emulators & run specs
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: ${{ env.API_LEVEL }}
-          target: ${{ env.TARGET }}
-          arch: ${{ env.ARCH }}
-          profile: ${{ env.PROFILE }}
-          force-avd-creation: false
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none
-          disable-animations: true
-          script: |
-            # android-emulator-runner executes this with /usr/bin/sh (dash) and
-            # does not honour backslash line-continuations — keep each command on
-            # a single line, and use POSIX flags only (no `pipefail`).
-            set -eu
-            # Boot the second emulator (the first is already up as emulator-5554).
-            echo "no" | avdmanager create avd -n test2 -k "system-images;android-${API_LEVEL};${TARGET};${ARCH}" -d "${PROFILE}" --force
-            nohup "$ANDROID_HOME/emulator/emulator" -avd test2 -port 5556 -no-snapshot -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none > "$RUNNER_TEMP/emulator-5556.log" 2>&1 &
-            # Wait for both emulators to finish booting.
-            for serial in emulator-5554 emulator-5556; do echo "Waiting for $serial to boot..."; adb -s "$serial" wait-for-device; timeout 300 adb -s "$serial" shell 'while [ -z "$(getprop sys.boot_completed | tr -d "\r")" ]; do sleep 2; done'; adb -s "$serial" shell input keyevent 82 || true; done
-            adb devices
-            # Run the example specs across both emulators. Each line runs in its
-            # own `sh -c`, so `cd` must be chained with the command that needs it.
-            cd examples/runner && npx appclaw-runner --workers 2 --retries 1 --reporter plain
-
-      - name: Upload runner report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: runner-report
-          path: examples/runner/.appclaw/runs/
-          if-no-files-found: ignore
+  vision:
+    name: Vision route (AI label)
+    if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'AI')
+    concurrency:
+      group: runner-e2e-vision-${{ github.ref }}
+      cancel-in-progress: true
+    uses: ./.github/workflows/runner-e2e-run.yml
+    with:
+      agent-mode: vision
+      provider: gemini
+    secrets: inherit

--- a/packages/core/src/flow/llm-parser.ts
+++ b/packages/core/src/flow/llm-parser.ts
@@ -19,6 +19,19 @@ const proximitySchema = z
       .enum(['above', 'below', 'toLeftOf', 'toRightOf', 'near', 'within'])
       .describe('Spatial relation of the target element to the anchor'),
     anchor: z.string().describe('Label/text of the reference element the target is positioned by'),
+    anchorProximity: z
+      .object({
+        relation: z
+          .enum(['above', 'below', 'toLeftOf', 'toRightOf', 'near', 'within'])
+          .describe('Spatial relation of the anchor to ITS reference element'),
+        anchor: z.string().describe('Label/text of the element the anchor is positioned by'),
+      })
+      .optional()
+      .describe(
+        'Chained qualifier picking WHICH anchor when several match, e.g. ' +
+          '"to the left of NSEFO which is near 0.04" → anchor "NSEFO", ' +
+          'anchorProximity {relation: "near", anchor: "0.04"}'
+      ),
   })
   .optional()
   .describe('Only when the instruction positions the target relative to another element');
@@ -117,6 +130,8 @@ const SYSTEM_PROMPT =
   `"the field inside the form"), set proximity={relation, anchor}: relation is one of ` +
   `above|below|toLeftOf|toRightOf|near|within, anchor is the reference element's label. ` +
   `Put only the target's own label in label/target — not the relation or anchor. ` +
+  `When the anchor is itself positioned ("to the left of NSEFO which is near 0.04"), ` +
+  `nest the second relation in proximity.anchorProximity={relation, anchor}. ` +
   `Omit proximity entirely when there is no relative positioning.\n` +
   `Extract the relevant parameters. Works with any language.`;
 

--- a/packages/core/src/flow/natural-line.ts
+++ b/packages/core/src/flow/natural-line.ts
@@ -23,8 +23,10 @@ const PROXIMITY_RELATIONS: Record<string, ProximityRelation> = {
   underneath: 'below',
   'left of': 'toLeftOf',
   'to the left of': 'toLeftOf',
+  'to the left to': 'toLeftOf', // common preposition slip for "of"
   'right of': 'toRightOf',
   'to the right of': 'toRightOf',
+  'to the right to': 'toRightOf', // common preposition slip for "of"
   near: 'near',
   beside: 'near',
   'next to': 'near',
@@ -45,16 +47,31 @@ const PROXIMITY_RE = new RegExp(`^(.+?)\\s+(${RELATION_ALT})\\s+(?:the\\s+)?(.+)
  * Proximity qualifier. e.g. "login button below password field" →
  * { label: "login button", proximity: { relation: 'below', anchor: 'password field' } }.
  * Returns just the label unchanged when no relation phrase is present.
+ *
+ * The anchor phrase may itself carry a chained qualifier picking WHICH anchor:
+ * "YESBANK to the left of NSEFO which is near ₹0.04" (or without the "which is"
+ * connector) nests as proximity.anchorProximity.
  */
 export function splitProximity(label: string): { label: string; proximity?: Proximity } {
   const m = label.match(PROXIMITY_RE);
   if (!m) return { label };
-  const target = trimPunct(m[1].trim());
+  // A trailing connector on the target means the relation opens a qualifier
+  // clause: "YESBANK which is to the left of BSE" → target "YESBANK".
+  const target = trimPunct(m[1].trim()).replace(/\s+(?:which|that)\s+is$/i, '');
   const relWord = m[2].toLowerCase().replace(/\s+/g, ' ');
-  const anchor = trimPunct(m[3].trim());
+  const anchorRest = trimPunct(m[3].trim());
   const relation = PROXIMITY_RELATIONS[relWord];
-  if (!relation || !target || !anchor) return { label };
-  return { label: target, proximity: { relation, anchor } };
+  if (!relation || !target || !anchorRest) return { label };
+  // Recurse on the anchor phrase (dropping an optional "which is"/"that is"
+  // connector) so a qualified anchor nests instead of being matched literally.
+  const nested = splitProximity(anchorRest.replace(/\s+(?:which|that)\s+is\s+/i, ' '));
+  if (nested.proximity && nested.label) {
+    return {
+      label: target,
+      proximity: { relation, anchor: nested.label, anchorProximity: nested.proximity },
+    };
+  }
+  return { label: target, proximity: { relation, anchor: anchorRest } };
 }
 
 /** Build a tap step, peeling off any trailing proximity qualifier. */

--- a/packages/core/src/flow/run-yaml-flow.ts
+++ b/packages/core/src/flow/run-yaml-flow.ts
@@ -355,6 +355,9 @@ const ROLE_WORDS = new Set([
   'label',
   'cell',
   'row',
+  'badge',
+  'chip',
+  'tag',
 ]);
 
 /** Collapse case + separators so "LOG IN", "log-in" and "login" all compare equal. */
@@ -377,7 +380,11 @@ function stripRoleWord(needle: string): string {
 export function scoreTapMatch(el: UIElement, needle: string): number {
   if (el.enabled === false) return -1;
 
-  const fields = [el.text, el.hint ?? '', el.accessibilityId, el.id]
+  // An editable's `text` is its current VALUE (whatever was typed into it),
+  // not a label — "tap YESBANK" must never target the search box just because
+  // "YesBank" was typed there. Editables stay matchable via their real labels:
+  // hint, accessibility id (content-desc), and resource id.
+  const fields = [el.editable ? '' : el.text, el.hint ?? '', el.accessibilityId, el.id]
     .map(squashLabel)
     .filter((f) => f.length > 0);
   if (fields.length === 0) return -1;
@@ -396,7 +403,11 @@ export function scoreTapMatch(el: UIElement, needle: string): number {
         s = 0; // exact
       else if (n.length >= 2 && f.includes(n))
         s = 1; // needle inside field
-      else if (f.length >= 2 && n.includes(f)) s = 2; // field inside needle
+      // Field inside needle counts only when the field covers at least half of
+      // it. Without the floor, a garbled instruction that failed to parse as a
+      // spatial qualifier ("YESBANK to the righ to ₹2.02") silently degrades
+      // into a confident tap on ANY element whose text appears in the phrase.
+      else if (f.length >= 2 && f.length * 2 >= n.length && n.includes(f)) s = 2;
       if (s >= 0 && (best === -1 || s < best)) best = s;
     }
   }
@@ -536,13 +547,155 @@ function relationPhrase(r: ProximityRelation): string {
   }
 }
 
+/** Nearest same-row element to the right of `cur` (vertical overlap, left edge past
+ *  `cur`'s right edge minus half-height slack for badge padding), or null. */
+function nearestRightNeighbor(pool: UIElement[], cur: UIElement): UIElement | null {
+  const c = rectOf(cur);
+  const slack = (c.bottom - c.top) / 2;
+  let best: UIElement | null = null;
+  let bestLeft = Infinity;
+  for (const e of pool) {
+    if (e === cur) continue;
+    const r = rectOf(e);
+    if (r.top >= c.bottom || r.bottom <= c.top) continue; // no vertical overlap
+    if (r.left < c.right - slack) continue; // not to the right
+    if (r.left < bestLeft) {
+      bestLeft = r.left;
+      best = e;
+    }
+  }
+  return best;
+}
+
+/** Union rect of a group as a synthetic (non-DOM) element, for anchoring / coordinate taps. */
+function mergeElements(group: UIElement[]): UIElement {
+  const rects = group.map(rectOf);
+  const left = Math.min(...rects.map((r) => r.left));
+  const right = Math.max(...rects.map((r) => r.right));
+  const top = Math.min(...rects.map((r) => r.top));
+  const bottom = Math.max(...rects.map((r) => r.bottom));
+  return {
+    ...group[0],
+    id: '',
+    accessibilityId: '',
+    text: group.map((g) => g.text).join(' '),
+    bounds: '',
+    center: [Math.round((left + right) / 2), Math.round((top + bottom) / 2)],
+    size: [right - left, bottom - top],
+    clickable: group.some((g) => g.clickable),
+  };
+}
+
+/**
+ * Resolve a label that SPANS multiple adjacent elements — badge clusters like
+ * "NSE FO" + "OPT" for the label "NSEFO OPT". Starting from an element whose
+ * squashed text is a proper prefix of the squashed label, extend rightward
+ * through the nearest same-row neighbour whose text continues the phrase until
+ * it is fully consumed. Returns synthetic elements covering each matching
+ * group's union rect (no DOM identity — callers must anchor on them or tap
+ * their coordinates), in document order; empty when no adjacent run spells
+ * out the label.
+ */
+function resolveCompoundLabelElements(elements: UIElement[], label: string): UIElement[] {
+  const want = squashLabel(label);
+  if (!want) return [];
+  const labeled = elements.filter(
+    (e) => e.enabled !== false && !e.editable && squashLabel(e.text).length > 0
+  );
+  const clusters: UIElement[] = [];
+  for (const start of labeled) {
+    const first = squashLabel(start.text);
+    if (first.length >= want.length || !want.startsWith(first)) continue;
+    let remaining = want.slice(first.length);
+    const group = [start];
+    let cur = start;
+    while (remaining.length > 0) {
+      const next = nearestRightNeighbor(labeled, cur);
+      if (!next) break;
+      const sq = squashLabel(next.text);
+      if (!sq || !remaining.startsWith(sq)) break;
+      remaining = remaining.slice(sq.length);
+      group.push(next);
+      cur = next;
+    }
+    if (remaining.length === 0 && group.length > 1) clusters.push(mergeElements(group));
+  }
+  return clusters;
+}
+
+function resolveCompoundLabelElement(elements: UIElement[], label: string): UIElement | null {
+  return resolveCompoundLabelElements(elements, label)[0] ?? null;
+}
+
 /** Best textual match for an anchor label among parsed elements, or null. */
 function resolveAnchorElement(elements: UIElement[], anchorLabel: string): UIElement | null {
   const scored = elements
     .map((el) => ({ el, s: scoreTapMatch(el, anchorLabel) }))
     .filter((x) => x.s >= 0)
     .sort((a, b) => a.s - b.s);
-  return scored[0]?.el ?? null;
+  const best = scored[0];
+  // Exact match, or the whole anchor contained in one field, is trustworthy.
+  if (best && best.s <= 1) return best.el;
+  // Otherwise the anchor is only PARTIALLY present in any single element —
+  // trust it only when ADJACENT elements spell out the full phrase (badge
+  // clusters like "NSE FO" + "OPT" for "NSEFO OPT"). A fragment match is a
+  // guess: anchoring "NSEFO SAI" on the first "NSE FO" badge would tap a
+  // confidently wrong row, so fail and report the anchor as not found.
+  return resolveCompoundLabelElement(elements, anchorLabel);
+}
+
+/** ALL plausible anchor candidates for a label: every match in the best
+ *  single-element tier, or compound clusters. Same strictness as
+ *  resolveAnchorElement — fragment matches are guesses, not candidates. */
+function anchorCandidateElements(elements: UIElement[], anchorLabel: string): UIElement[] {
+  const scored = elements
+    .map((el) => ({ el, s: scoreTapMatch(el, anchorLabel) }))
+    .filter((x) => x.s >= 0)
+    .sort((a, b) => a.s - b.s);
+  if (scored.length > 0 && scored[0].s <= 1) {
+    const bestTier = scored[0].s;
+    return scored.filter((x) => x.s === bestTier).map((x) => x.el);
+  }
+  return resolveCompoundLabelElements(elements, anchorLabel);
+}
+
+/**
+ * Resolve a proximity's anchor element, honoring a chained qualifier:
+ * "NSEFO which is near ₹0.04" resolves the ₹0.04 element first, then picks
+ * the "NSEFO" candidate that best satisfies `near` relative to it.
+ */
+function resolveAnchor(elements: UIElement[], proximity: Proximity): UIElement | null {
+  const inner = proximity.anchorProximity;
+  if (!inner) return resolveAnchorElement(elements, proximity.anchor);
+  const innerAnchor = resolveAnchor(elements, inner);
+  if (!innerAnchor) return null;
+  const ranked = rankBySpatial(
+    anchorCandidateElements(elements, proximity.anchor),
+    innerAnchor,
+    inner.relation
+  );
+  return ranked[0] ?? null;
+}
+
+/**
+ * A failed tap whose label still contains direction-ish words most likely holds
+ * a MISSPELLED spatial qualifier ("YESBANK to the righ to ₹2.02") that the
+ * parser couldn't recognize, so the whole phrase became the label. Suggest the
+ * correct phrasing instead of leaving a bare "no match".
+ */
+function spatialTypoHint(label: string): string {
+  const directionish =
+    /\b(?:left|lef|right|righ|rigth|above|abov|below|belo|under|beneath|near|beside|inside|within|next)\b/i;
+  return directionish.test(label)
+    ? ' — if you meant a spatial qualifier, phrase it like "<target> to the right of <anchor>"'
+    : '';
+}
+
+/** Human-readable anchor phrase for messages: `"NSEFO" near "₹0.04"` or `"BSE"`. */
+function describeAnchor(p: Proximity): string {
+  return p.anchorProximity
+    ? `"${p.anchor}" ${relationPhrase(p.anchorProximity.relation)} ${describeAnchor(p.anchorProximity)}`
+    : `"${p.anchor}"`;
 }
 
 /**
@@ -558,7 +711,7 @@ export function resolveTapTarget(
   elements: UIElement[],
   label: string,
   proximity?: Proximity
-): { el: UIElement | null; reason?: string } {
+): { el: UIElement | null; reason?: string; coordinateOnly?: boolean } {
   const wantsClickable = trailingRoleWord(label) != null;
   const scored = elements
     .map((el) => ({ el, s: scoreTapMatch(el, label) }))
@@ -570,22 +723,39 @@ export function resolveTapTarget(
       return 0;
     });
 
+  // No single element carries the label, or only loosely (field ⊂ label): the
+  // label may SPAN adjacent elements (badge clusters like "NSE FO" + "OPT").
+  // The merged pick has no DOM identity, so it must be tapped by coordinates.
+  if (!proximity && (scored.length === 0 || scored[0].s >= 2)) {
+    const compound = resolveCompoundLabelElement(elements, label);
+    if (compound) return { el: compound, coordinateOnly: true };
+  }
+
   if (scored.length === 0) return { el: null, reason: `no element matches "${label}"` };
   if (!proximity) return { el: scored[0].el };
 
-  const anchorEl = resolveAnchorElement(elements, proximity.anchor);
-  if (!anchorEl) return { el: null, reason: `anchor "${proximity.anchor}" not found` };
+  const anchorEl = resolveAnchor(elements, proximity);
+  if (!anchorEl) return { el: null, reason: `anchor ${describeAnchor(proximity)} not found` };
 
-  // A spatial pick ranks purely by distance, so it must not consider stray text
-  // that merely contains the word (e.g. a help paragraph mentioning "login
-  // button") — those can sit closer to the anchor than the real control. Prefer
-  // clickable candidates whenever any exist before ranking by position.
+  // A spatial pick ranks purely by distance, so clickable candidates are tried
+  // first — stray text that merely contains the word (e.g. a help paragraph
+  // mentioning "login button") can sit closer to the anchor than the real
+  // control. But lists often expose the visible text on a NON-clickable
+  // TextView (the clickable row container carries no text of its own), so when
+  // no clickable candidate satisfies the relation, retry with the full textual
+  // pool — tapping the text element dispatches to its clickable ancestor.
   const candidateEls = scored.map((x) => x.el);
   const clickable = candidateEls.filter((e) => e.clickable);
-  const pool = clickable.length > 0 ? clickable : candidateEls;
-  const ranked = rankBySpatial(pool, anchorEl, proximity.relation);
+  const clickableRanked = rankBySpatial(clickable, anchorEl, proximity.relation);
+  const ranked =
+    clickableRanked.length > 0
+      ? clickableRanked
+      : rankBySpatial(candidateEls, anchorEl, proximity.relation);
   if (ranked.length === 0) {
-    return { el: null, reason: `no "${label}" ${relationPhrase(proximity.relation)} the anchor` };
+    return {
+      el: null,
+      reason: `${candidateEls.length} element(s) match "${label}" but none is ${relationPhrase(proximity.relation)} the anchor`,
+    };
   }
   return { el: ranked[0] };
 }
@@ -627,8 +797,9 @@ export function resolveEditableForTarget(
 
   // 3. Spatial qualifier narrows by relation to a named anchor.
   if (proximity) {
-    const anchorEl = resolveAnchorElement(elements, proximity.anchor);
-    if (!anchorEl) return { el: null, reason: `anchor "${proximity.anchor}" not found on screen` };
+    const anchorEl = resolveAnchor(elements, proximity);
+    if (!anchorEl)
+      return { el: null, reason: `anchor ${describeAnchor(proximity)} not found on screen` };
     const pool = candidates.length > 0 ? candidates : editables;
     const ranked = rankBySpatial(pool, anchorEl, proximity.relation);
     if (ranked.length === 0) {
@@ -825,11 +996,14 @@ async function tryTapByVision(mcp: MCPClient, label: string): Promise<ActionResu
 
 /** One DOM snapshot: find label and click. Returns null if no match / no UUID (caller may retry). */
 /** Returns: ActionResult on success, "no_match" if label not in DOM, null if matched but UUID failed */
+/** DOM tap miss — the label (or its spatial qualifier) didn't resolve; `reason` says which part. */
+type DomTapMiss = { noMatch: true; reason: string };
+
 async function tryTapByLabelOnDom(
   mcp: MCPClient,
   label: string,
   proximity?: Proximity
-): Promise<ActionResult | 'no_match' | null> {
+): Promise<ActionResult | DomTapMiss | null> {
   const cacheCtx = getActiveLocatorCache();
   const pageSource = cacheCtx
     ? await getStablePageSourceForLocatorCache(mcp)
@@ -837,11 +1011,11 @@ async function tryTapByLabelOnDom(
 
   // SDK locator cache fast-path: skip parse + score + multi-strategy probe when
   // we already know the (strategy, selector) that won for this label on this
-  // screen. On miss / stale, falls through to the existing path below. The cache
-  // label folds in the proximity qualifier so a plain "login" and a spatially
-  // qualified "login below password" never share a cached locator.
-  const cacheLabel = proximity ? `${label}|${proximity.relation}:${proximity.anchor}` : label;
-  const keyInfo = cacheCtx ? buildCacheKey(cacheCtx, pageSource, 'tap', cacheLabel) : null;
+  // screen. On miss / stale, falls through to the existing path below.
+  // Spatially-qualified taps never use the cache: they resolve to the picked
+  // element's coordinates (no locator to record), and replaying a stored
+  // locator would bypass the positional disambiguation entirely.
+  const keyInfo = cacheCtx && !proximity ? buildCacheKey(cacheCtx, pageSource, 'tap', label) : null;
   if (cacheCtx && keyInfo) {
     const hit = await tryCachedLocator(cacheCtx, mcp, keyInfo, async (uuid) => {
       // Capture the settled tap surface before the gesture navigates away.
@@ -857,11 +1031,35 @@ async function tryTapByLabelOnDom(
     platform === 'android' ? parseAndroidPageSource(pageSource) : parseIOSPageSource(pageSource);
 
   // Score textually (with the clickable nudge) and, when a proximity qualifier is
-  // present, narrow to clickable candidates and rank spatially. Any miss (no text
-  // match, anchor not found, no spatial survivor) becomes 'no_match' so the
-  // caller's poll loop keeps waiting — the screen may still be rendering.
-  const pick = resolveTapTarget(elements, label, proximity).el;
-  if (!pick) return 'no_match';
+  // present, rank spatially (clickable preferred, full pool fallback). Any miss
+  // (no text match, anchor not found, no spatial survivor) becomes a DomTapMiss
+  // so the caller's poll loop keeps waiting — the screen may still be rendering —
+  // and the final error can say which part failed.
+  const picked = resolveTapTarget(elements, label, proximity);
+  const pick = picked.el;
+  if (!pick) return { noMatch: true, reason: picked.reason ?? `no element matches "${label}"` };
+
+  // A spatial pick must tap the CHOSEN instance. Re-locating it by id/text
+  // would silently undo the disambiguation whenever the identifier is shared —
+  // list rows typically reuse the same resource-id AND text, so the xpath
+  // `(//*[@text='X'])[1]` lands on the FIRST instance, not the one the
+  // qualifier selected. The picked element's coordinates ARE the resolution,
+  // so tap them directly. Compound picks (label spanning adjacent elements)
+  // have no DOM identity at all, so they're coordinate taps too.
+  if (proximity || picked.coordinateOnly) {
+    const beforeScreenshot = await capturePreAction(mcp);
+    const [x, y] = pick.center;
+    const tapped = await tapAtCoordinates(mcp, x, y);
+    if (!tapped) return null;
+    const where = proximity
+      ? ` (${relationPhrase(proximity.relation)} ${describeAnchor(proximity)})`
+      : '';
+    return {
+      success: true,
+      message: `Tapped "${label}"${where} at [${x}, ${y}]`,
+      beforeScreenshot,
+    };
+  }
 
   const resolved = await findByIdStrategiesDetailed(
     mcp,
@@ -886,10 +1084,9 @@ async function tryTapByLabelOnDom(
     });
     cacheCtx.dirty = true;
   }
-  const where = proximity ? ` (${relationPhrase(proximity.relation)} "${proximity.anchor}")` : '';
   return {
     success: true,
-    message: `Tapped "${label}"${where} at [${coords[0]}, ${coords[1]}]`,
+    message: `Tapped "${label}" at [${coords[0]}, ${coords[1]}]`,
     beforeScreenshot,
   };
 }
@@ -929,16 +1126,20 @@ async function tapByLabel(
   // element the qualifier was meant to exclude.
   const visionOk = isVisionLocateEnabled() && !proximity;
   let triedVisionEarly = false;
+  let lastMissReason: string | undefined;
   for (let attempt = 0; attempt < poll.maxAttempts; attempt++) {
     const domTap = await tryTapByLabelOnDom(mcp, label, proximity);
-    if (domTap && domTap !== 'no_match') return domTap;
-    if (domTap === 'no_match' && !triedVisionEarly && visionOk) {
-      triedVisionEarly = true;
-      const visionTap = await tryTapByVision(mcp, label);
-      if (visionTap) return visionTap;
+    if (domTap && !('noMatch' in domTap)) return domTap;
+    if (domTap) {
+      lastMissReason = domTap.reason;
+      if (!triedVisionEarly && visionOk) {
+        triedVisionEarly = true;
+        const visionTap = await tryTapByVision(mcp, label);
+        if (visionTap) return visionTap;
+      }
     }
     if (attempt + 1 < poll.maxAttempts) {
-      const why = domTap === 'no_match' ? 'not in page source yet' : 'found but not yet tappable';
+      const why = domTap ? 'not in page source yet' : 'found but not yet tappable';
       ui.printAgentBullet(
         `auto-wait: "${label}" ${why} — re-reading page source ` +
           `(attempt ${attempt + 2}/${poll.maxAttempts}, every ${poll.intervalMs}ms)`
@@ -958,8 +1159,9 @@ async function tapByLabel(
   return {
     success: false,
     message: proximity
-      ? `No "${label}" found ${relationPhrase(proximity.relation)} "${proximity.anchor}" on screen`
-      : `No matching element for "${label}"`,
+      ? `No "${label}" found ${relationPhrase(proximity.relation)} ${describeAnchor(proximity)} on screen` +
+        (lastMissReason ? ` — ${lastMissReason}` : '')
+      : `No matching element for "${label}"${spatialTypoHint(label)}`,
   };
 }
 

--- a/packages/core/src/flow/types.ts
+++ b/packages/core/src/flow/types.ts
@@ -65,8 +65,17 @@ export type ProximityRelation = 'above' | 'below' | 'toLeftOf' | 'toRightOf' | '
  * Optional spatial qualifier: "<target> below <anchor>", "<target> near <anchor>".
  * Both fields are set together — `relation` is the geometric relation and
  * `anchor` is the natural-language label of the reference element.
+ *
+ * `anchorProximity` chains a qualifier onto the ANCHOR itself, picking which
+ * of several matching anchors to use: "YESBANK to the left of NSEFO which is
+ * near ₹0.04" → { relation: 'toLeftOf', anchor: 'NSEFO',
+ * anchorProximity: { relation: 'near', anchor: '₹0.04' } }.
  */
-export type Proximity = { relation: ProximityRelation; anchor: string };
+export type Proximity = {
+  relation: ProximityRelation;
+  anchor: string;
+  anchorProximity?: Proximity;
+};
 
 export type FlowStep =
   | ({ kind: 'launchApp' } & Verbatim)

--- a/tests/flow/natural-line.test.ts
+++ b/tests/flow/natural-line.test.ts
@@ -179,6 +179,34 @@ describe('natural-line: proximity', () => {
       expect(r.proximity).toEqual({ relation: 'below', anchor: 'header' });
     }
   });
+  test('chained qualifier with "which is" connector', () => {
+    const r = tryParseNaturalFlowLine('click on YESBANK to the left of NSEFO which is near ₹0.04');
+    expect(r?.kind).toBe('tap');
+    if (r?.kind === 'tap') {
+      expect(r.label).toBe('YESBANK');
+      expect(r.proximity).toEqual({
+        relation: 'toLeftOf',
+        anchor: 'NSEFO',
+        anchorProximity: { relation: 'near', anchor: '₹0.04' },
+      });
+    }
+  });
+  test('chained qualifier without connector', () => {
+    const r = tryParseNaturalFlowLine('tap YESBANK to the left of OPT near ₹2.90');
+    expect(r?.kind === 'tap' && r.proximity).toEqual({
+      relation: 'toLeftOf',
+      anchor: 'OPT',
+      anchorProximity: { relation: 'near', anchor: '₹2.90' },
+    });
+  });
+  test('connector on the target: "X which is below Y"', () => {
+    const r = tryParseNaturalFlowLine('tap YESBANK which is below the search bar');
+    expect(r?.kind === 'tap' && r.label).toBe('YESBANK');
+    expect(r?.kind === 'tap' && r.proximity).toEqual({
+      relation: 'below',
+      anchor: 'search bar',
+    });
+  });
   test('no false positive: plain tap', () => {
     const r = tryParseNaturalFlowLine('tap Settings');
     expect(r?.kind === 'tap' && r.proximity).toBeUndefined();

--- a/tests/flow/proximity.test.ts
+++ b/tests/flow/proximity.test.ts
@@ -197,6 +197,152 @@ describe('resolveTapTarget: WDIO login screen', () => {
   });
 });
 
+// Search-results list (Groww-style). The typed query sits in the search box —
+// a CLICKABLE EditText whose text exact-matches the row titles — while the row
+// titles themselves are non-clickable TextViews inside clickable containers
+// that carry no text. A hard clickable-only spatial pool collapses to the
+// full-width search box, which can never satisfy toLeftOf → the exact
+// "No YESBANK found to the left of BSE" regression.
+describe('resolveTapTarget: list rows with non-clickable text (Groww regression)', () => {
+  const searchBox = el('YesBank', [540, 230], [900, 130], { editable: true, clickable: true });
+  const row1Container = el('', [540, 520], [1080, 180], { clickable: true });
+  const row1Title = el('YESBANK', [160, 500], [220, 60]);
+  const row1Badge = el('NSE', [320, 500], [80, 50]);
+  const row2Container = el('', [540, 700], [1080, 180], { clickable: true });
+  const row2Title = el('YESBANK', [160, 680], [220, 60]);
+  const row2Badge = el('BSE', [320, 680], [80, 50]);
+  const row2Sub = el('Yes Bank Limited', [220, 740], [340, 50]);
+  const screen = [
+    searchBox,
+    row1Container,
+    row1Title,
+    row1Badge,
+    row2Container,
+    row2Title,
+    row2Badge,
+    row2Sub,
+  ];
+
+  test('"YESBANK toLeftOf BSE" → row-2 title, not the search box', () => {
+    const r = resolveTapTarget(screen, 'YESBANK', { relation: 'toLeftOf', anchor: 'BSE' });
+    expect(r.el).toBe(row2Title);
+  });
+  test('"YESBANK near BSE" → row-2 title — typed search text is a value, not a label', () => {
+    // `near` expands its radius until something matches, so a clickable-first
+    // pool holding only the search box would eventually "match" it. The search
+    // box must not be a candidate at all: its text is the typed query.
+    const r = resolveTapTarget(screen, 'YESBANK', { relation: 'near', anchor: 'BSE' });
+    expect(r.el).toBe(row2Title);
+  });
+  test('plain "YESBANK" no longer targets the search box holding the typed query', () => {
+    const r = resolveTapTarget(screen, 'YESBANK');
+    expect(r.el).not.toBe(searchBox);
+  });
+  test('long garbled phrase does not loose-match a short title', () => {
+    const r = resolveTapTarget(screen, 'YESBANK to the righ to ₹2.02');
+    expect(r.el).toBeNull();
+  });
+  test('vertical distance breaks the tie between identical row titles', () => {
+    const r = resolveTapTarget(screen, 'YESBANK', { relation: 'toLeftOf', anchor: 'NSE' });
+    expect(r.el).toBe(row1Title);
+  });
+  test('clickable match still wins over closer stray text when it satisfies the relation', () => {
+    const saveBtn = el('Save', [200, 500], [100, 60], { clickable: true });
+    const strayText = el('Save your work', [250, 500], [180, 60]); // closer to anchor by bbox
+    const cancel = el('Cancel', [600, 500], [100, 60], { clickable: true });
+    const r = resolveTapTarget([saveBtn, strayText, cancel], 'Save', {
+      relation: 'toLeftOf',
+      anchor: 'Cancel',
+    });
+    expect(r.el).toBe(saveBtn);
+  });
+  test('anchor missing → null + reason naming the anchor', () => {
+    const r = resolveTapTarget(screen, 'YESBANK', { relation: 'toLeftOf', anchor: 'NASDAQ' });
+    expect(r.el).toBeNull();
+    expect(r.reason).toMatch(/NASDAQ/);
+  });
+  test('matches exist but wrong side → null + reason saying so', () => {
+    const r = resolveTapTarget(screen, 'YESBANK', { relation: 'toRightOf', anchor: 'BSE' });
+    expect(r.el).toBeNull();
+    expect(r.reason).toMatch(/none is to the right of/i);
+  });
+});
+
+// Badge clusters: "NSE FO" and "OPT" are ADJACENT elements — no single element
+// carries the phrase "NSEFO OPT". The resolver must merge the same-row run of
+// elements whose concatenated text spells the label, instead of loosely
+// matching the first "NSE FO" badge (which sits in the wrong, FUT, row).
+describe('resolveTapTarget: compound labels spanning adjacent elements', () => {
+  const futTitle = el('YESBANK', [160, 930], [220, 60]);
+  const futBadge1 = el('NSE FO', [340, 930], [120, 50]);
+  const futBadge2 = el('FUT', [440, 930], [60, 50]);
+  const optTitle = el('YESBANK', [160, 1130], [220, 60]);
+  const optBadge1 = el('NSE FO', [340, 1130], [120, 50]);
+  const optBadge2 = el('OPT', [440, 1130], [60, 50]);
+  const cePrice = el('₹2.90', [925, 1130], [150, 50]);
+  const peTitle = el('YESBANK', [160, 1330], [220, 60]);
+  const peBadge1 = el('NSE FO', [340, 1330], [120, 50]);
+  const peBadge2 = el('OPT', [440, 1330], [60, 50]);
+  const pePrice = el('₹0.04', [925, 1330], [150, 50]);
+  const screen = [
+    futTitle,
+    futBadge1,
+    futBadge2,
+    optTitle,
+    optBadge1,
+    optBadge2,
+    cePrice,
+    peTitle,
+    peBadge1,
+    peBadge2,
+    pePrice,
+  ];
+
+  test('anchor "NSEFO OPT" merges the badge cluster → OPT-row title, not FUT-row', () => {
+    const r = resolveTapTarget(screen, 'YESBANK', { relation: 'toLeftOf', anchor: 'NSEFO OPT' });
+    expect(r.el).toBe(optTitle);
+  });
+  test('plain label "NSE FO OPT" resolves to the merged cluster, coordinate-only', () => {
+    const r = resolveTapTarget(screen, 'NSE FO OPT');
+    expect(r.coordinateOnly).toBe(true);
+    expect(r.el?.center).toEqual([375, 1130]);
+  });
+  test('single-element anchors are untouched by compound matching ("FUT")', () => {
+    const r = resolveTapTarget(screen, 'YESBANK', { relation: 'toLeftOf', anchor: 'FUT' });
+    expect(r.el).toBe(futTitle);
+  });
+  test('chained anchor: "NSEFO near ₹0.04" picks the PE-row badge → PE-row title', () => {
+    // Three identical "NSE FO" badges — the chained qualifier selects the one
+    // in the ₹0.04 row before the outer relation is applied.
+    const r = resolveTapTarget(screen, 'YESBANK', {
+      relation: 'toLeftOf',
+      anchor: 'NSEFO',
+      anchorProximity: { relation: 'near', anchor: '₹0.04' },
+    });
+    expect(r.el).toBe(peTitle);
+  });
+  test('fragment anchor ("NSEFO SAI") is not guessed → null with reason', () => {
+    // "NSE FO" is a fragment of the anchor, but "SAI" exists nowhere — the
+    // anchor must fail rather than silently resolve to the first "NSE FO".
+    const r = resolveTapTarget(screen, 'YESBANK', { relation: 'toLeftOf', anchor: 'NSEFO SAI' });
+    expect(r.el).toBeNull();
+    expect(r.reason).toMatch(/NSEFO SAI/);
+  });
+  test('anchor with a role-word suffix still resolves ("OPT badge")', () => {
+    const r = resolveTapTarget(screen, 'YESBANK', { relation: 'toLeftOf', anchor: 'OPT badge' });
+    expect(r.el).toBe(optTitle);
+  });
+  test('chained anchor unresolvable → null with the full chain in the reason', () => {
+    const r = resolveTapTarget(screen, 'YESBANK', {
+      relation: 'toLeftOf',
+      anchor: 'NSEFO',
+      anchorProximity: { relation: 'near', anchor: '₹9.99' },
+    });
+    expect(r.el).toBeNull();
+    expect(r.reason).toMatch(/₹9\.99/);
+  });
+});
+
 describe('resolveEditableForTarget: iOS elements', () => {
   // Parser fills the same fields cross-platform; resolver is platform-agnostic.
   const f1 = el('', [400, 600], [700, 110], { hint: 'Email', editable: true, platform: 'ios' });

--- a/tests/flow/run-instruction-proximity.test.ts
+++ b/tests/flow/run-instruction-proximity.test.ts
@@ -1,0 +1,228 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import type { MCPClient } from '@appclaw/core/mcp/types';
+import { runOneInstruction } from '@appclaw/core/flow/run-instruction';
+
+// End-to-end through the shared playground/SDK pipeline (regex → executeStep →
+// tapByLabel) against a Groww-style search-results page source. The regression:
+// the typed query "YesBank" sits in a CLICKABLE full-width EditText while the
+// row titles are non-clickable TextViews with no ids — so the old clickable-only
+// spatial pool collapsed to the search box (→ "No YESBANK found to the left of
+// BSE"), and even a correct pick would then be re-located by text xpath [1],
+// landing on the FIRST row instead of the chosen one.
+const GROWW_XML = `<?xml version='1.0' encoding='UTF-8' standalone='yes' ?>
+<hierarchy rotation="0">
+  <android.widget.FrameLayout class="android.widget.FrameLayout" bounds="[0,0][1080,2400]" clickable="false" enabled="true">
+    <android.widget.EditText class="android.widget.EditText" text="YesBank" resource-id="com.groww:id/search_input" clickable="true" enabled="true" focused="true" bounds="[90,165][990,295]" />
+    <android.view.ViewGroup class="android.view.ViewGroup" resource-id="com.groww:id/row" clickable="true" enabled="true" bounds="[0,430][1080,610]">
+      <android.widget.TextView class="android.widget.TextView" text="YESBANK" clickable="false" enabled="true" bounds="[50,470][270,530]" />
+      <android.widget.TextView class="android.widget.TextView" text="NSE" clickable="false" enabled="true" bounds="[280,475][360,525]" />
+      <android.widget.TextView class="android.widget.TextView" text="Yes Bank Limited" clickable="false" enabled="true" bounds="[50,540][390,590]" />
+    </android.view.ViewGroup>
+    <android.view.ViewGroup class="android.view.ViewGroup" resource-id="com.groww:id/row" clickable="true" enabled="true" bounds="[0,610][1080,790]">
+      <android.widget.TextView class="android.widget.TextView" text="YESBANK" clickable="false" enabled="true" bounds="[50,650][270,710]" />
+      <android.widget.TextView class="android.widget.TextView" text="BSE" clickable="false" enabled="true" bounds="[280,655][360,705]" />
+      <android.widget.TextView class="android.widget.TextView" text="Yes Bank Limited" clickable="false" enabled="true" bounds="[50,720][390,770]" />
+    </android.view.ViewGroup>
+    <android.view.ViewGroup class="android.view.ViewGroup" resource-id="com.groww:id/row" clickable="true" enabled="true" bounds="[0,790][1080,970]">
+      <android.widget.TextView class="android.widget.TextView" text="YESBANK" clickable="false" enabled="true" bounds="[50,830][270,890]" />
+      <android.widget.TextView class="android.widget.TextView" text="NSE FO" clickable="false" enabled="true" bounds="[280,835][400,885]" />
+      <android.widget.TextView class="android.widget.TextView" text="FUT" clickable="false" enabled="true" bounds="[410,835][470,885]" />
+      <android.widget.TextView class="android.widget.TextView" text="25-AUG-26" clickable="false" enabled="true" bounds="[50,900][300,950]" />
+    </android.view.ViewGroup>
+    <android.view.ViewGroup class="android.view.ViewGroup" resource-id="com.groww:id/row" clickable="true" enabled="true" bounds="[0,970][1080,1150]">
+      <android.widget.TextView class="android.widget.TextView" text="YESBANK" clickable="false" enabled="true" bounds="[50,1010][270,1070]" />
+      <android.widget.TextView class="android.widget.TextView" text="NSE FO" clickable="false" enabled="true" bounds="[280,1015][400,1065]" />
+      <android.widget.TextView class="android.widget.TextView" text="OPT" clickable="false" enabled="true" bounds="[410,1015][470,1065]" />
+      <android.widget.TextView class="android.widget.TextView" text="₹2.90" clickable="false" enabled="true" bounds="[850,1015][1000,1065]" />
+      <android.widget.TextView class="android.widget.TextView" text="25-Aug-26 20.00 CE" clickable="false" enabled="true" bounds="[50,1080][390,1130]" />
+    </android.view.ViewGroup>
+    <android.view.ViewGroup class="android.view.ViewGroup" resource-id="com.groww:id/row" clickable="true" enabled="true" bounds="[0,1150][1080,1330]">
+      <android.widget.TextView class="android.widget.TextView" text="YESBANK" clickable="false" enabled="true" bounds="[50,1190][270,1250]" />
+      <android.widget.TextView class="android.widget.TextView" text="NSE FO" clickable="false" enabled="true" bounds="[280,1195][400,1245]" />
+      <android.widget.TextView class="android.widget.TextView" text="OPT" clickable="false" enabled="true" bounds="[410,1195][470,1245]" />
+      <android.widget.TextView class="android.widget.TextView" text="₹0.04" clickable="false" enabled="true" bounds="[850,1195][1000,1245]" />
+      <android.widget.TextView class="android.widget.TextView" text="25-Aug-26 20.00 PE" clickable="false" enabled="true" bounds="[50,1260][390,1310]" />
+    </android.view.ViewGroup>
+  </android.widget.FrameLayout>
+</hierarchy>`;
+
+interface ToolCall {
+  name: string;
+  args: Record<string, unknown>;
+}
+
+let calls: ToolCall[];
+
+function mockMcp(): MCPClient {
+  return {
+    callTool: vi.fn(async (name: string, args: Record<string, unknown> = {}) => {
+      calls.push({ name, args });
+      if (name === 'appium_get_page_source') {
+        return { content: [{ type: 'text' as const, text: GROWW_XML }] };
+      }
+      if (name === 'appium_find_element') {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: 'Successfully found element. Element id 00000000-0000-000b-ffff-ffff000000de',
+            },
+          ],
+        };
+      }
+      return { content: [{ type: 'text' as const, text: 'OK' }] };
+    }),
+    listTools: vi.fn(async () => []),
+    close: vi.fn(async () => {}),
+  } as unknown as MCPClient;
+}
+
+function gestureTaps(): ToolCall[] {
+  return calls.filter((c) => c.name === 'appium_gesture' && c.args.action === 'tap');
+}
+
+beforeEach(() => {
+  calls = [];
+});
+
+describe('runOneInstruction: spatially-qualified tap (playground/SDK path)', () => {
+  test('"Click on YESBANK to the left of BSE" taps the row-2 title coordinates', async () => {
+    const { step, result } = await runOneInstruction(
+      mockMcp(),
+      'Click on YESBANK to the left of BSE'
+    );
+    expect(step).toMatchObject({
+      kind: 'tap',
+      label: 'YESBANK',
+      proximity: { relation: 'toLeftOf', anchor: 'BSE' },
+    });
+    expect(result.success).toBe(true);
+    // Row-2 title center — NOT the search box (540,230) and NOT row 1 (160,500).
+    const taps = gestureTaps();
+    expect(taps).toHaveLength(1);
+    expect(taps[0].args).toMatchObject({ x: 160, y: 680 });
+    expect(result.message).toContain('to the left of "BSE"');
+  });
+
+  test('"Click on YESBANK near BSE" taps the row-2 title, not the search bar', async () => {
+    const { step, result } = await runOneInstruction(mockMcp(), 'Click on YESBANK near BSE');
+    expect(step).toMatchObject({
+      kind: 'tap',
+      label: 'YESBANK',
+      proximity: { relation: 'near', anchor: 'BSE' },
+    });
+    expect(result.success).toBe(true);
+    expect(gestureTaps()[0].args).toMatchObject({ x: 160, y: 680 });
+  });
+
+  test('anchor row disambiguates between identical titles ("… left of NSE" → row 1)', async () => {
+    const { result } = await runOneInstruction(mockMcp(), 'Click on YESBANK to the left of NSE');
+    expect(result.success).toBe(true);
+    expect(gestureTaps()[0].args).toMatchObject({ x: 160, y: 500 });
+  });
+
+  test('spatial tap never re-locates by text xpath (would hit the FIRST duplicate)', async () => {
+    await runOneInstruction(mockMcp(), 'Click on YESBANK to the left of BSE');
+    expect(calls.filter((c) => c.name === 'appium_find_element')).toHaveLength(0);
+  });
+
+  test('compound anchor: "… to the left of NSEFO OPT" → first OPT row, not the first NSE FO row', async () => {
+    // "NSEFO OPT" is no single element — it's the adjacent badges "NSE FO" + "OPT".
+    // A loose single-element match would anchor on the FIRST "NSE FO" badge (a FUT row).
+    const { result } = await runOneInstruction(
+      mockMcp(),
+      'Click on YESBANK to the left of NSEFO OPT'
+    );
+    expect(result.success).toBe(true);
+    expect(gestureTaps()[0].args).toMatchObject({ x: 160, y: 1040 });
+  });
+
+  test('compound tap label: "Click on NSEFO OPT" taps the badge cluster by coordinates', async () => {
+    const { result } = await runOneInstruction(mockMcp(), 'Click on NSEFO OPT');
+    expect(result.success).toBe(true);
+    // Merged rect of "NSE FO" [280..400] + "OPT" [410..470] → center (375, 1040).
+    expect(gestureTaps()[0].args).toMatchObject({ x: 375, y: 1040 });
+    expect(calls.filter((c) => c.name === 'appium_find_element')).toHaveLength(0);
+  });
+
+  test('chained proximity: "… to the left of NSEFO which is near ₹0.04" → PE row', async () => {
+    // Every F&O row has an "NSE FO" badge; the chained qualifier picks the one
+    // in the ₹0.04 row, then taps the YESBANK to its left.
+    const { step, result } = await runOneInstruction(
+      mockMcp(),
+      'Click on YESBANK to the left of NSEFO which is near ₹0.04'
+    );
+    expect(step).toMatchObject({
+      kind: 'tap',
+      label: 'YESBANK',
+      proximity: {
+        relation: 'toLeftOf',
+        anchor: 'NSEFO',
+        anchorProximity: { relation: 'near', anchor: '₹0.04' },
+      },
+    });
+    expect(result.success).toBe(true);
+    expect(gestureTaps()[0].args).toMatchObject({ x: 160, y: 1220 });
+    expect(result.message).toContain('"NSEFO" near "₹0.04"');
+  });
+
+  test('chained proximity without connector: "… to the left of OPT near ₹2.90" → CE row', async () => {
+    const { result } = await runOneInstruction(
+      mockMcp(),
+      'Click on YESBANK to the left of OPT near ₹2.90'
+    );
+    expect(result.success).toBe(true);
+    expect(gestureTaps()[0].args).toMatchObject({ x: 160, y: 1040 });
+  });
+
+  test('garbled qualifier ("to the righ to") fails loudly instead of tapping a random row', async () => {
+    // "righ" + "to" — unparseable as a relation, so the whole phrase becomes
+    // the tap label. It must NOT loose-match a row title and tap it.
+    const { result } = await runOneInstruction(mockMcp(), 'Click on YESBANK to the righ to ₹2.02');
+    expect(result.success).toBe(false);
+    expect(gestureTaps()).toHaveLength(0);
+    expect(result.message).toContain('No matching element');
+    expect(result.message).toContain('spatial qualifier');
+  });
+
+  test('preposition slip "to the right to" parses as toRightOf and fails with real geometry', async () => {
+    const { step, result } = await runOneInstruction(
+      mockMcp(),
+      'Click on YESBANK to the right to ₹2.90'
+    );
+    expect(step).toMatchObject({
+      kind: 'tap',
+      label: 'YESBANK',
+      proximity: { relation: 'toRightOf', anchor: '₹2.90' },
+    });
+    expect(result.success).toBe(false);
+    expect(gestureTaps()).toHaveLength(0);
+    expect(result.message).toContain('to the right of "₹2.90"');
+  });
+
+  test('nonexistent anchor phrase ("NSEFO SAI") fails instead of guessing a fragment', async () => {
+    const { result } = await runOneInstruction(
+      mockMcp(),
+      'Click on the YESBANK to the left of NSEFO SAI'
+    );
+    expect(result.success).toBe(false);
+    expect(gestureTaps()).toHaveLength(0);
+    expect(result.message).toContain('anchor "NSEFO SAI" not found');
+  });
+
+  test('failed qualifier reports the specific reason', async () => {
+    const { result } = await runOneInstruction(mockMcp(), 'Click on YESBANK to the right of BSE');
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('to the right of "BSE"');
+    expect(result.message).toMatch(/none is to the right of/i);
+  });
+
+  test('plain tap (no qualifier) still uses the element-UUID locate path', async () => {
+    const { result } = await runOneInstruction(mockMcp(), 'Click on YESBANK');
+    expect(result.success).toBe(true);
+    expect(calls.some((c) => c.name === 'appium_find_element')).toBe(true);
+    const taps = gestureTaps();
+    expect(taps).toHaveLength(1);
+    expect(taps[0].args).toHaveProperty('elementUUID');
+  });
+});


### PR DESCRIPTION
Driven by real failures on a broker-app search screen (rows of identical "YESBANK" titles with NSE/BSE/"NSE FO"+"OPT" badge clusters):

- Editable elements' text is their typed VALUE, not a label — the search box no longer matches "tap YESBANK" because "YesBank" was typed into it. Editables stay matchable via hint / content-desc / resource-id.
- Spatial picks tap the chosen element's coordinates instead of re-locating by id/text, which landed on the FIRST duplicate and undid the disambiguation. Spatial taps also skip the SDK locator cache.
- Spatial candidate pool is clickable-first with a full-pool fallback — list rows expose text on non-clickable TextViews inside clickable containers.
- Compound labels span adjacent elements: "NSEFO OPT" matches the "NSE FO"+"OPT" badge cluster (merged rect, coordinate tap), both as anchors and as plain tap labels.
- Chained proximity: "YESBANK to the left of NSEFO which is near ₹0.04" — the anchor itself can be qualified to pick WHICH anchor (Proximity.anchorProximity, recursive; "which is" connector optional).
- Anchors are strict: fragment matches ("NSEFO SAI" → "NSE FO") fail with "anchor not found" instead of guessing. Role-word suffixes (badge/chip/tag/…) still strip.
- Loose tap matches require the field to cover ≥ half the needle, so a garbled/unparsed qualifier phrase fails loudly (with a "did you mean a spatial qualifier" hint) instead of tapping a random row. "to the right/left to" preposition slips parse as real relations.
- Proximity misses propagate the specific reason (anchor missing vs wrong side vs no text match) into the step error message.

Tested at three levels: resolver units (tests/flow/proximity.test.ts), parser units (tests/flow/natural-line.test.ts), and end-to-end through the shared playground/SDK pipeline with a mock MCP serving realistic page source (tests/flow/run-instruction-proximity.test.ts).