### PR TITLE
feat(flow): first-class double-tap support across all surfaces

### DIFF
--- a/packages/cli/src/playground/index.ts
+++ b/packages/cli/src/playground/index.ts
@@ -92,6 +92,8 @@ function spinnerDetail(step: FlowStep): string {
   switch (step.kind) {
     case 'tap':
       return 'tapping the screen…';
+    case 'doubleTap':
+      return 'double-tapping the screen…';
     case 'longPress':
       return 'long-pressing the screen…';
     case 'type':
@@ -130,6 +132,7 @@ function spinnerDetail(step: FlowStep): string {
 // Action glyph per step kind — mirrors the Ink StepLine look.
 const KIND_ICON: Record<string, string> = {
   tap: '●',
+  doubleTap: '●',
   longPress: '●',
   type: '⊞',
   swipe: '↕',
@@ -217,6 +220,8 @@ function stepToYaml(step: FlowStep): unknown {
       return `open ${step.query} app`;
     case 'tap':
       return `tap ${step.label}`;
+    case 'doubleTap':
+      return `double tap ${step.label}`;
     case 'longPress':
       return step.duration != null
         ? `long press ${step.label} for ${step.duration}ms`

--- a/packages/core/src/flow/llm-parser.ts
+++ b/packages/core/src/flow/llm-parser.ts
@@ -51,6 +51,11 @@ const stepSchema = z.discriminatedUnion('kind', [
     proximity: proximitySchema,
   }),
   z.object({
+    kind: z.literal('doubleTap'),
+    label: z.string().describe('Element label/text to double-tap'),
+    proximity: proximitySchema,
+  }),
+  z.object({
     kind: z.literal('longPress'),
     label: z.string().describe('Element label/text to long-press'),
     duration: z.number().optional().describe('Hold duration in ms, default 2000'),
@@ -110,6 +115,7 @@ const SYSTEM_PROMPT =
   `- "open/launch/start <app>" → openApp\n` +
   `- "close/terminate/quit/kill <app>" → closeApp (query = app name); "close the app" → closeApp with no query (closes current app)\n` +
   `- "click/tap/press/select <element>" → tap\n` +
+  `- "double tap/double-tap/double click <element>" → doubleTap\n` +
   `- "long press/long-press/press and hold <element>" → longPress\n` +
   `- "type/enter/input <text>" or "search for <text>" → type\n` +
   `- "wait for <element> to be visible/appear" → waitUntil (visible)\n` +

--- a/packages/core/src/flow/natural-line.ts
+++ b/packages/core/src/flow/natural-line.ts
@@ -161,6 +161,17 @@ export function tryParseNaturalFlowLine(line: string): FlowStep | null {
       return { kind: 'longPress', label, ...(duration != null ? { duration } : {}), verbatim };
   }
 
+  // "double tap X" / "double-tap X" / "double click [on] X" — must run before
+  // the single-tap match so the "double" prefix isn't swallowed into the label.
+  const doubleTapMatch = t.match(/^double[\s-](?:tap|click|press)(?:\s+on)?\s+(?:the\s+)?(.+)$/i);
+  if (doubleTapMatch) {
+    const label = trimPunct(doubleTapMatch[1].trim());
+    if (label) {
+      const { label: bare, proximity } = splitProximity(label);
+      return { kind: 'doubleTap', label: bare, ...(proximity ? { proximity } : {}), verbatim };
+    }
+  }
+
   const clickMatch = t.match(/^(?:click|tap|select|choose|pick)(?:\s+on)?\s+(?:the\s+)?(.+)$/i);
   if (clickMatch) {
     const label = trimPunct(clickMatch[1].trim());

--- a/packages/core/src/flow/parse-yaml-flow.ts
+++ b/packages/core/src/flow/parse-yaml-flow.ts
@@ -206,6 +206,7 @@ export function normalizeStructured(raw: unknown, index: number): FlowStep | nul
       );
     }
     if (k === 'tap') return { kind: 'tap', label: String(v) };
+    if (k === 'doubleTap' || k === 'double_tap') return { kind: 'doubleTap', label: String(v) };
     if (k === 'zoom') {
       const scale = Number(v);
       if (!Number.isFinite(scale) || scale <= 0) {

--- a/packages/core/src/flow/run-yaml-flow.ts
+++ b/packages/core/src/flow/run-yaml-flow.ts
@@ -301,6 +301,8 @@ function stepLabel(step: FlowStep): string {
       return `wait until "${step.text}" is visible (${step.timeoutSeconds}s timeout)`;
     case 'tap':
       return `tap "${step.label}"`;
+    case 'doubleTap':
+      return `double-tap "${step.label}"`;
     case 'longPress':
       return `long-press "${step.label}"${step.duration != null ? ` (${step.duration}ms)` : ''}`;
     case 'type':
@@ -971,27 +973,69 @@ async function tryCachedLocator(
   return null;
 }
 
+/**
+ * The tap-family gestures share one resolution pipeline (implicit wait, vision
+ * fallback, proximity/compound, locator cache) and differ only in the
+ * appium-mcp gesture fired at the end.
+ */
+type TapGesture = 'tap' | 'double_tap';
+
+/** Past-tense verb for success messages: "Tapped" / "Double-tapped". */
+function gestureVerb(gesture: TapGesture): string {
+  return gesture === 'double_tap' ? 'Double-tapped' : 'Tapped';
+}
+
+/** Cache action kind for a tap-family gesture — distinct so entries never mix. */
+function gestureCacheKind(gesture: TapGesture): 'tap' | 'doubleTap' {
+  return gesture === 'double_tap' ? 'doubleTap' : 'tap';
+}
+
+/** Fire a tap-family gesture at raw coordinates. `tap` keeps its W3C fallback. */
+async function gestureAtCoordinates(
+  mcp: MCPClient,
+  x: number,
+  y: number,
+  gesture: TapGesture
+): Promise<boolean> {
+  if (gesture === 'tap') return tapAtCoordinates(mcp, x, y);
+  try {
+    const result = await mcp.callTool('appium_gesture', {
+      action: 'double_tap',
+      x: Math.round(x),
+      y: Math.round(y),
+    });
+    const text = result.content?.map((c: any) => (c.type === 'text' ? c.text : '')).join('') ?? '';
+    return !text.toLowerCase().includes('error') && !text.toLowerCase().includes('failed');
+  } catch {
+    return false;
+  }
+}
+
 /** Try to tap an element using vision locate. Returns null if vision can't find it. */
-async function tryTapByVision(mcp: MCPClient, label: string): Promise<ActionResult | null> {
+async function tryTapByVision(
+  mcp: MCPClient,
+  label: string,
+  gesture: TapGesture = 'tap'
+): Promise<ActionResult | null> {
   const uuid = await findByVision(mcp, `UI element labeled or showing "${label}"`);
   if (!uuid) return null;
 
   if (isAIElement(uuid)) {
     const coords = parseAIElementCoords(uuid);
     if (coords) {
-      const tapped = await tapAtCoordinates(mcp, coords.x, coords.y);
+      const tapped = await gestureAtCoordinates(mcp, coords.x, coords.y, gesture);
       if (tapped) {
         return {
           success: true,
-          message: `Tapped "${label}" via vision at [${coords.x}, ${coords.y}]`,
+          message: `${gestureVerb(gesture)} "${label}" via vision at [${coords.x}, ${coords.y}]`,
         };
       }
     }
     return null;
   }
 
-  await mcp.callTool('appium_gesture', { action: 'tap', elementUUID: uuid });
-  return { success: true, message: `Tapped "${label}" via vision` };
+  await mcp.callTool('appium_gesture', { action: gesture, elementUUID: uuid });
+  return { success: true, message: `${gestureVerb(gesture)} "${label}" via vision` };
 }
 
 /** One DOM snapshot: find label and click. Returns null if no match / no UUID (caller may retry). */
@@ -1002,7 +1046,8 @@ type DomTapMiss = { noMatch: true; reason: string };
 async function tryTapByLabelOnDom(
   mcp: MCPClient,
   label: string,
-  proximity?: Proximity
+  proximity?: Proximity,
+  gesture: TapGesture = 'tap'
 ): Promise<ActionResult | DomTapMiss | null> {
   const cacheCtx = getActiveLocatorCache();
   const pageSource = cacheCtx
@@ -1015,13 +1060,16 @@ async function tryTapByLabelOnDom(
   // Spatially-qualified taps never use the cache: they resolve to the picked
   // element's coordinates (no locator to record), and replaying a stored
   // locator would bypass the positional disambiguation entirely.
-  const keyInfo = cacheCtx && !proximity ? buildCacheKey(cacheCtx, pageSource, 'tap', label) : null;
+  const keyInfo =
+    cacheCtx && !proximity
+      ? buildCacheKey(cacheCtx, pageSource, gestureCacheKind(gesture), label)
+      : null;
   if (cacheCtx && keyInfo) {
     const hit = await tryCachedLocator(cacheCtx, mcp, keyInfo, async (uuid) => {
       // Capture the settled tap surface before the gesture navigates away.
       const beforeScreenshot = await capturePreAction(mcp);
-      await mcp.callTool('appium_gesture', { action: 'tap', elementUUID: uuid });
-      return { success: true, message: `Tapped "${label}"`, beforeScreenshot };
+      await mcp.callTool('appium_gesture', { action: gesture, elementUUID: uuid });
+      return { success: true, message: `${gestureVerb(gesture)} "${label}"`, beforeScreenshot };
     });
     if (hit) return hit;
   }
@@ -1049,14 +1097,14 @@ async function tryTapByLabelOnDom(
   if (proximity || picked.coordinateOnly) {
     const beforeScreenshot = await capturePreAction(mcp);
     const [x, y] = pick.center;
-    const tapped = await tapAtCoordinates(mcp, x, y);
+    const tapped = await gestureAtCoordinates(mcp, x, y, gesture);
     if (!tapped) return null;
     const where = proximity
       ? ` (${relationPhrase(proximity.relation)} ${describeAnchor(proximity)})`
       : '';
     return {
       success: true,
-      message: `Tapped "${label}"${where} at [${x}, ${y}]`,
+      message: `${gestureVerb(gesture)} "${label}"${where} at [${x}, ${y}]`,
       beforeScreenshot,
     };
   }
@@ -1072,7 +1120,7 @@ async function tryTapByLabelOnDom(
   // gesture so the report shows the screen the tap happened ON — with the dot
   // on the target — not the page it navigates to.
   const beforeScreenshot = await capturePreAction(mcp);
-  await mcp.callTool('appium_gesture', { action: 'tap', elementUUID: resolved.uuid });
+  await mcp.callTool('appium_gesture', { action: gesture, elementUUID: resolved.uuid });
   const coords = pick.center;
   // Record the winning locator so the next run for the same label on the same
   // screen hits the cache fast-path above.
@@ -1086,7 +1134,7 @@ async function tryTapByLabelOnDom(
   }
   return {
     success: true,
-    message: `Tapped "${label}" at [${coords[0]}, ${coords[1]}]`,
+    message: `${gestureVerb(gesture)} "${label}" at [${coords[0]}, ${coords[1]}]`,
     beforeScreenshot,
   };
 }
@@ -1095,14 +1143,15 @@ async function tapByLabel(
   mcp: MCPClient,
   label: string,
   poll: FlowTapPollOptions,
-  proximity?: Proximity
+  proximity?: Proximity,
+  gesture: TapGesture = 'tap'
 ): Promise<ActionResult> {
   // ── Vision-first mode: skip DOM entirely ──
   // Poll the full budget so the element is implicitly waited for until it
   // renders (or the wait budget is exhausted) — no explicit `wait` needed.
   if (isVisionMode()) {
     for (let attempt = 0; attempt < poll.maxAttempts; attempt++) {
-      const visionTap = await tryTapByVision(mcp, label);
+      const visionTap = await tryTapByVision(mcp, label, gesture);
       if (visionTap) return visionTap;
       if (attempt + 1 < poll.maxAttempts) {
         ui.printAgentBullet(
@@ -1128,13 +1177,13 @@ async function tapByLabel(
   let triedVisionEarly = false;
   let lastMissReason: string | undefined;
   for (let attempt = 0; attempt < poll.maxAttempts; attempt++) {
-    const domTap = await tryTapByLabelOnDom(mcp, label, proximity);
+    const domTap = await tryTapByLabelOnDom(mcp, label, proximity, gesture);
     if (domTap && !('noMatch' in domTap)) return domTap;
     if (domTap) {
       lastMissReason = domTap.reason;
       if (!triedVisionEarly && visionOk) {
         triedVisionEarly = true;
-        const visionTap = await tryTapByVision(mcp, label);
+        const visionTap = await tryTapByVision(mcp, label, gesture);
         if (visionTap) return visionTap;
       }
     }
@@ -1152,7 +1201,7 @@ async function tapByLabel(
   // (the element may have only just rendered on the final DOM poll).
   if (visionOk) {
     ui.printAgentBullet(`"${label}" not found in page source, trying vision…`);
-    const visionTap = await tryTapByVision(mcp, label);
+    const visionTap = await tryTapByVision(mcp, label, gesture);
     if (visionTap) return visionTap;
   }
 
@@ -2032,6 +2081,8 @@ export async function executeStep(
       return waitUntilCondition(mcp, step.condition, step.text, step.timeoutSeconds, tapPoll);
     case 'tap':
       return tapByLabel(mcp, step.label, tapPoll, step.proximity);
+    case 'doubleTap':
+      return tapByLabel(mcp, step.label, tapPoll, step.proximity, 'double_tap');
     case 'longPress':
       return longPressByLabel(mcp, step.label, step.duration);
     case 'type':

--- a/packages/core/src/flow/types.ts
+++ b/packages/core/src/flow/types.ts
@@ -89,6 +89,7 @@ export type FlowStep =
       timeoutSeconds: number;
     } & Verbatim)
   | ({ kind: 'tap'; label: string; proximity?: Proximity } & Verbatim)
+  | ({ kind: 'doubleTap'; label: string; proximity?: Proximity } & Verbatim)
   | ({ kind: 'longPress'; label: string; duration?: number } & Verbatim)
   | ({ kind: 'type'; text: string; target?: string; proximity?: Proximity } & Verbatim)
   | ({ kind: 'enter' } & Verbatim)

--- a/packages/core/src/sdk/locator-cache.ts
+++ b/packages/core/src/sdk/locator-cache.ts
@@ -29,7 +29,14 @@ const DEAD_THRESHOLD = 0.05;
 
 export type LocatorStrategy = 'accessibility id' | 'id' | 'xpath';
 
-export type LocatorActionKind = 'tap' | 'type' | 'longPress' | 'swipe' | 'drag' | 'scrollAssert';
+export type LocatorActionKind =
+  | 'tap'
+  | 'doubleTap'
+  | 'type'
+  | 'longPress'
+  | 'swipe'
+  | 'drag'
+  | 'scrollAssert';
 
 export interface LocatorCacheEntry {
   id: string;

--- a/packages/core/src/ui/step-printer.ts
+++ b/packages/core/src/ui/step-printer.ts
@@ -27,6 +27,8 @@ export function stepAction(step: FlowStep): string {
       return 'close';
     case 'tap':
       return 'tap';
+    case 'doubleTap':
+      return 'doubletap';
     case 'longPress':
       return 'longpress';
     case 'type':
@@ -68,6 +70,8 @@ export function stepTarget(step: FlowStep): string {
     case 'closeApp':
       return step.query ?? 'current app';
     case 'tap':
+      return `"${step.label}"`;
+    case 'doubleTap':
       return `"${step.label}"`;
     case 'longPress':
       return `"${step.label}"${step.duration != null ? ` (${step.duration}ms)` : ''}`;

--- a/tests/flow/natural-line.test.ts
+++ b/tests/flow/natural-line.test.ts
@@ -477,3 +477,28 @@ describe('natural-line: returns null for unrecognized', () => {
     expect(r === null || r.kind !== undefined).toBe(true);
   });
 });
+
+describe('natural-line: double tap', () => {
+  test('double tap X', () => {
+    expect(tryParseNaturalFlowLine('double tap Photo')).toMatchObject({
+      kind: 'doubleTap',
+      label: 'Photo',
+    });
+  });
+  test('double-click on the image', () => {
+    expect(tryParseNaturalFlowLine('double-click on the image')).toMatchObject({
+      kind: 'doubleTap',
+      label: 'image',
+    });
+  });
+  test('double tap carries a spatial qualifier', () => {
+    expect(tryParseNaturalFlowLine('double tap YESBANK to the left of BSE')).toMatchObject({
+      kind: 'doubleTap',
+      label: 'YESBANK',
+      proximity: { relation: 'toLeftOf', anchor: 'BSE' },
+    });
+  });
+  test('single tap is unaffected', () => {
+    expect(tryParseNaturalFlowLine('tap Photo')).toMatchObject({ kind: 'tap', label: 'Photo' });
+  });
+});

--- a/tests/flow/run-instruction-proximity.test.ts
+++ b/tests/flow/run-instruction-proximity.test.ts
@@ -226,3 +226,30 @@ describe('runOneInstruction: spatially-qualified tap (playground/SDK path)', () 
     expect(taps[0].args).toHaveProperty('elementUUID');
   });
 });
+
+describe('runOneInstruction: double tap', () => {
+  function doubleTaps(): ToolCall[] {
+    return calls.filter((c) => c.name === 'appium_gesture' && c.args.action === 'double_tap');
+  }
+
+  test('"Double tap on YESBANK to the left of BSE" fires double_tap at row-2 coords', async () => {
+    const { step, result } = await runOneInstruction(
+      mockMcp(),
+      'Double tap on YESBANK to the left of BSE'
+    );
+    expect(step).toMatchObject({ kind: 'doubleTap', label: 'YESBANK' });
+    expect(result.success).toBe(true);
+    expect(result.message).toContain('Double-tapped');
+    expect(gestureTaps()).toHaveLength(0); // no single tap fired
+    expect(doubleTaps()).toHaveLength(1);
+    expect(doubleTaps()[0].args).toMatchObject({ x: 160, y: 680 });
+  });
+
+  test('plain "double tap YESBANK" double-taps by element UUID', async () => {
+    const { result } = await runOneInstruction(mockMcp(), 'double tap YESBANK');
+    expect(result.success).toBe(true);
+    expect(calls.some((c) => c.name === 'appium_find_element')).toBe(true);
+    expect(doubleTaps()).toHaveLength(1);
+    expect(doubleTaps()[0].args).toHaveProperty('elementUUID');
+  });
+});


### PR DESCRIPTION
The device layer (appium-mcp appium_gesture) already supported double_tap; AppClaw had no way to express it — "double tap X" fell through to the LLM parser, which silently coerced it into a single tap.

Add a doubleTap FlowStep kind wired through the existing tap pipeline via a gesture parameter, so double-tap inherits everything taps have: implicit wait, vision-locate fallback, spatial qualifiers (proximity, compound labels, chained anchors, coordinate taps for spatial picks), and the SDK locator cache (distinct doubleTap action kind).

Surfaces: natural language ("double tap / double-tap / double click [on] X", with spatial qualifiers), YAML flows (doubleTap: "X" or natural-language lines), LLM parser schema + prompt, playground/SDK via the shared pipeline, and step display (badge, spinner, YAML preview).