### PR TITLE
feat(ci): add secret-free deterministic Android and iOS checks

### DIFF
--- a/.github/workflows/layer3-branch-test.yml
+++ b/.github/workflows/layer3-branch-test.yml
@@ -20,8 +20,38 @@ on:
         options: [android, ios]
 
 jobs:
-  # ── Test 1: YAML flow on Android ────────────────────────────────────────────
-  # Runs on every PR (default) and on manual dispatch with android + no goal
+  # ── Test 1: Deterministic YAML flow on Android ──────────────────────────────
+  # Runs on every PR, including forks. Strict parsing plus DOM-only execution
+  # makes this a real device smoke test without repository secrets or LLM calls.
+  android-deterministic:
+    name: Android — deterministic YAML flow
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    if: >-
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'workflow_dispatch' &&
+       inputs.platform == 'android' && inputs.goal == '')
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./
+        id: run
+        with:
+          use-local-build: 'true'
+          flow: flows/wdio-android-deterministic.yaml
+          platform: android
+          strict: 'true'
+          agent-mode: dom
+          vision-mode: never
+          report-name: layer3-android-deterministic-${{ github.run_id }}
+
+      - name: Show report path
+        if: always()
+        run: echo "Report → ${{ steps.run.outputs.report-path }}"
+
+  # ── Test 2: Vision YAML flow on Android ─────────────────────────────────────
+  # Runs on same-repository PRs and on manual dispatch with android + no goal
   android-flow:
     name: Android — YAML flow
     runs-on: ubuntu-latest
@@ -51,7 +81,7 @@ jobs:
         if: always()
         run: echo "Report → ${{ steps.run.outputs.report-path }}"
 
-  # ── Test 2: Natural language goal on Android ─────────────────────────────────
+  # ── Test 3: Natural language goal on Android ─────────────────────────────────
   # Runs only on manual dispatch with a goal specified
   android-goal:
     name: Android — natural language goal
@@ -76,12 +106,17 @@ jobs:
         if: always()
         run: echo "Report → ${{ steps.run.outputs.report-path }}"
 
-  # ── Test 3: YAML flow on iOS ─────────────────────────────────────────────────
-  # Runs only on manual dispatch with ios platform selected
-  ios-flow:
-    name: iOS — YAML flow
-    runs-on: macos-14
-    if: false
+  # ── Test 4: Deterministic YAML flow on iOS ───────────────────────────────────
+  # Runs on every PR, including forks, using the same strict DOM-only contract
+  # as Android. This protects simulator/WDA setup without requiring LLM secrets.
+  ios-deterministic:
+    name: iOS — deterministic YAML flow
+    runs-on: macos-15
+    timeout-minutes: 20
+    if: >-
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'workflow_dispatch' &&
+       inputs.platform == 'ios' && inputs.goal == '')
 
     steps:
       - uses: actions/checkout@v4
@@ -90,14 +125,14 @@ jobs:
         id: run
         with:
           use-local-build: 'true'
-          flow: ${{ inputs.flow || 'flows/wdio.yaml' }}
+          flow: flows/wdio-ios-deterministic.yaml
           platform: ios
           ios-device-type: simulator
           mcp-debug: 'true'
-          provider: gemini
-          agent-mode: vision
-          api-key: ${{ secrets.LLM_API_KEY }}
-          report-name: layer3-ios-flow-${{ github.run_id }}
+          strict: 'true'
+          agent-mode: dom
+          vision-mode: never
+          report-name: layer3-ios-deterministic-${{ github.run_id }}
 
       - name: Show report path
         if: always()

--- a/README.md
+++ b/README.md
@@ -41,7 +41,15 @@ npm install -g @appclaw/cli
 appclaw "open the settings app and turn on airplane mode"
 ```
 
-You'll need **Node.js 22+**, a connected device / emulator / simulator, and an **LLM API key** (Anthropic, OpenAI, Google, Groq, or local Ollama). Full setup → **[appclaw.in](https://appclaw.in)**.
+The natural-language Agent mode command above needs **Node.js 22+**, a connected device / emulator /
+simulator, and an **LLM API key** (Anthropic, OpenAI, Google, Groq, or local Ollama).
+
+Deterministic YAML flows do not need an LLM API key when strict parsing, DOM-only interaction, and
+disabled vision fallback are used together. See the
+**[secret-free Android and iOS GitHub Actions example](github-action/examples/deterministic-flow.yml)**
+and the **[GitHub Action guide](github-action/README.md#deterministic-yaml-flow--no-llm-secret)**.
+
+Full setup → **[appclaw.in](https://appclaw.in)**.
 
 ## What it can do
 

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,10 @@ inputs:
     description: 'Path to a YAML flow file (mutually exclusive with goal)'
     required: false
     default: ''
+  strict:
+    description: 'Fail when a YAML step cannot be parsed deterministically instead of using the LLM parser. Default: false'
+    required: false
+    default: 'false'
   goal:
     description: 'Natural language goal for the LLM agent (mutually exclusive with flow)'
     required: false
@@ -31,8 +35,9 @@ inputs:
     required: false
     default: 'gemini'
   api-key:
-    description: 'LLM API key — passed to AppClaw as LLM_API_KEY'
-    required: true
+    description: 'LLM API key — required for goals and non-deterministic flows; optional for strict DOM-only flows with vision-mode=never'
+    required: false
+    default: ''
   model:
     description: 'LLM model ID to use (e.g. gemini-2.0-flash, claude-3-5-haiku-20241022). Defaults to the provider built-in.'
     required: false
@@ -43,6 +48,10 @@ inputs:
     description: 'Interaction strategy: dom (element locators) or vision (screenshot AI)'
     required: false
     default: 'dom'
+  vision-mode:
+    description: 'Vision fallback policy: always, fallback, or never. Use never for deterministic no-LLM flows.'
+    required: false
+    default: 'fallback'
   max-steps:
     description: 'Maximum agent steps before the run is marked failed. Default: 30'
     required: false
@@ -165,29 +174,60 @@ runs:
     # ── Validate ──────────────────────────────────────────────────────────────
     - name: Validate inputs
       shell: bash
+      env:
+        INPUT_FLOW: ${{ inputs.flow }}
+        INPUT_GOAL: ${{ inputs.goal }}
+        INPUT_PLATFORM: ${{ inputs.platform }}
+        INPUT_STRICT: ${{ inputs.strict }}
+        INPUT_AGENT_MODE: ${{ inputs.agent-mode }}
+        INPUT_VISION_MODE: ${{ inputs.vision-mode }}
+        INPUT_API_KEY: ${{ inputs.api-key }}
+        INPUT_CLOUD_PROVIDER: ${{ inputs.cloud-provider }}
+        INPUT_LAMBDATEST_USERNAME: ${{ inputs.lambdatest-username }}
+        INPUT_LAMBDATEST_ACCESS_KEY: ${{ inputs.lambdatest-access-key }}
+        INPUT_LAMBDATEST_DEVICE_NAME: ${{ inputs.lambdatest-device-name }}
+        INPUT_LAMBDATEST_OS_VERSION: ${{ inputs.lambdatest-os-version }}
       run: |
-        if [ -z "${{ inputs.flow }}" ] && [ -z "${{ inputs.goal }}" ]; then
+        if [ -z "$INPUT_FLOW" ] && [ -z "$INPUT_GOAL" ]; then
           echo "::error title=Missing input::Provide either 'flow' (path to YAML) or 'goal' (natural language string)"
           exit 1
         fi
-        if [ -n "${{ inputs.flow }}" ] && [ -n "${{ inputs.goal }}" ]; then
+        if [ -n "$INPUT_FLOW" ] && [ -n "$INPUT_GOAL" ]; then
           echo "::error title=Conflicting inputs::Provide either 'flow' or 'goal', not both"
           exit 1
         fi
-        if [ "${{ inputs.platform }}" != "android" ] && [ "${{ inputs.platform }}" != "ios" ]; then
-          echo "::error title=Invalid platform::platform must be 'android' or 'ios', got '${{ inputs.platform }}'"
+        if [ "$INPUT_PLATFORM" != "android" ] && [ "$INPUT_PLATFORM" != "ios" ]; then
+          echo "::error title=Invalid platform::platform must be 'android' or 'ios', got '$INPUT_PLATFORM'"
           exit 1
         fi
-        if [ -n "${{ inputs.cloud-provider }}" ] && [ "${{ inputs.cloud-provider }}" != "lambdatest" ]; then
-          echo "::error title=Invalid cloud-provider::cloud-provider must be 'lambdatest' or empty, got '${{ inputs.cloud-provider }}'"
+        if [ "$INPUT_STRICT" != "true" ] && [ "$INPUT_STRICT" != "false" ]; then
+          echo "::error title=Invalid strict mode::strict must be 'true' or 'false', got '$INPUT_STRICT'"
           exit 1
         fi
-        if [ "${{ inputs.cloud-provider }}" = "lambdatest" ]; then
-          if [ -z "${{ inputs.lambdatest-username }}" ] || [ -z "${{ inputs.lambdatest-access-key }}" ]; then
+        if [ "$INPUT_AGENT_MODE" != "dom" ] && [ "$INPUT_AGENT_MODE" != "vision" ]; then
+          echo "::error title=Invalid agent mode::agent-mode must be 'dom' or 'vision', got '$INPUT_AGENT_MODE'"
+          exit 1
+        fi
+        if [ "$INPUT_VISION_MODE" != "always" ] && [ "$INPUT_VISION_MODE" != "fallback" ] && [ "$INPUT_VISION_MODE" != "never" ]; then
+          echo "::error title=Invalid vision mode::vision-mode must be 'always', 'fallback', or 'never', got '$INPUT_VISION_MODE'"
+          exit 1
+        fi
+        if [ -z "$INPUT_API_KEY" ]; then
+          if [ -n "$INPUT_GOAL" ] || [ "$INPUT_STRICT" != "true" ] || [ "$INPUT_AGENT_MODE" != "dom" ] || [ "$INPUT_VISION_MODE" != "never" ]; then
+            echo "::error title=Missing LLM API key::api-key may be omitted only for a flow with strict='true', agent-mode='dom', and vision-mode='never'"
+            exit 1
+          fi
+        fi
+        if [ -n "$INPUT_CLOUD_PROVIDER" ] && [ "$INPUT_CLOUD_PROVIDER" != "lambdatest" ]; then
+          echo "::error title=Invalid cloud-provider::cloud-provider must be 'lambdatest' or empty, got '$INPUT_CLOUD_PROVIDER'"
+          exit 1
+        fi
+        if [ "$INPUT_CLOUD_PROVIDER" = "lambdatest" ]; then
+          if [ -z "$INPUT_LAMBDATEST_USERNAME" ] || [ -z "$INPUT_LAMBDATEST_ACCESS_KEY" ]; then
             echo "::error title=Missing LambdaTest credentials::lambdatest-username and lambdatest-access-key are required when cloud-provider=lambdatest"
             exit 1
           fi
-          if [ -z "${{ inputs.lambdatest-device-name }}" ] || [ -z "${{ inputs.lambdatest-os-version }}" ]; then
+          if [ -z "$INPUT_LAMBDATEST_DEVICE_NAME" ] || [ -z "$INPUT_LAMBDATEST_OS_VERSION" ]; then
             echo "::error title=Missing device info::lambdatest-device-name and lambdatest-os-version are required when cloud-provider=lambdatest"
             exit 1
           fi
@@ -232,6 +272,7 @@ runs:
         LLM_MODEL: ${{ inputs.model }}
         LLM_THINKING: ${{ inputs.llm-thinking }}
         AGENT_MODE: ${{ inputs.agent-mode }}
+        VISION_MODE: ${{ inputs.vision-mode }}
         MAX_STEPS: ${{ inputs.max-steps }}
         STEP_DELAY: ${{ inputs.step-delay }}
         PLATFORM: ${{ inputs.platform }}
@@ -241,7 +282,10 @@ runs:
         LAMBDATEST_DEVICE_NAME: ${{ inputs.lambdatest-device-name }}
         LAMBDATEST_OS_VERSION: ${{ inputs.lambdatest-os-version }}
         LAMBDATEST_APP: ${{ inputs.lambdatest-app }}
-      run: appclaw --flow "${{ inputs.flow }}" --platform ${{ inputs.platform }}
+      run: |
+        args=(--flow "${{ inputs.flow }}" --platform "${{ inputs.platform }}")
+        if [ "${{ inputs.strict }}" = "true" ]; then args+=(--strict); fi
+        appclaw "${args[@]}"
 
     # ── LambdaTest — natural language goal ────────────────────────────────────
     - name: Run goal on LambdaTest
@@ -253,6 +297,7 @@ runs:
         LLM_MODEL: ${{ inputs.model }}
         LLM_THINKING: ${{ inputs.llm-thinking }}
         AGENT_MODE: ${{ inputs.agent-mode }}
+        VISION_MODE: ${{ inputs.vision-mode }}
         MAX_STEPS: ${{ inputs.max-steps }}
         STEP_DELAY: ${{ inputs.step-delay }}
         PLATFORM: ${{ inputs.platform }}
@@ -284,6 +329,7 @@ runs:
         LLM_MODEL: ${{ inputs.model }}
         LLM_THINKING: ${{ inputs.llm-thinking }}
         AGENT_MODE: ${{ inputs.agent-mode }}
+        VISION_MODE: ${{ inputs.vision-mode }}
         MAX_STEPS: ${{ inputs.max-steps }}
         STEP_DELAY: ${{ inputs.step-delay }}
         PLATFORM: android
@@ -294,7 +340,10 @@ runs:
         target: ${{ inputs.android-target }}
         emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
         disable-animations: true
-        script: appclaw --flow "${{ inputs.flow }}" --platform android
+        script: |
+          args=(--flow "${{ inputs.flow }}" --platform android)
+          if [ "${{ inputs.strict }}" = "true" ]; then args+=(--strict); fi
+          appclaw "${args[@]}"
 
     # ── Android — natural language goal ───────────────────────────────────────
     - name: Run goal on Android emulator
@@ -306,6 +355,7 @@ runs:
         LLM_MODEL: ${{ inputs.model }}
         LLM_THINKING: ${{ inputs.llm-thinking }}
         AGENT_MODE: ${{ inputs.agent-mode }}
+        VISION_MODE: ${{ inputs.vision-mode }}
         MAX_STEPS: ${{ inputs.max-steps }}
         STEP_DELAY: ${{ inputs.step-delay }}
         PLATFORM: android
@@ -410,6 +460,7 @@ runs:
         LLM_MODEL: ${{ inputs.model }}
         LLM_THINKING: ${{ inputs.llm-thinking }}
         AGENT_MODE: ${{ inputs.agent-mode }}
+        VISION_MODE: ${{ inputs.vision-mode }}
         MAX_STEPS: ${{ inputs.max-steps }}
         STEP_DELAY: ${{ inputs.step-delay }}
         PLATFORM: ios
@@ -417,7 +468,10 @@ runs:
         DEVICE_UDID: ${{ inputs.device-udid || env.IOS_SIMULATOR_UDID }}
         MCP_DEBUG: ${{ inputs.mcp-debug == 'true' && '1' || '0' }}
         MCP_TIMEOUT_MS: ${{ inputs.mcp-timeout-ms }}
-      run: appclaw --flow "${{ inputs.flow }}" --platform ios
+      run: |
+        args=(--flow "${{ inputs.flow }}" --platform ios)
+        if [ "${{ inputs.strict }}" = "true" ]; then args+=(--strict); fi
+        appclaw "${args[@]}"
 
     # ── iOS — natural language goal ───────────────────────────────────────────
     - name: Run goal on iOS simulator
@@ -429,6 +483,7 @@ runs:
         LLM_MODEL: ${{ inputs.model }}
         LLM_THINKING: ${{ inputs.llm-thinking }}
         AGENT_MODE: ${{ inputs.agent-mode }}
+        VISION_MODE: ${{ inputs.vision-mode }}
         MAX_STEPS: ${{ inputs.max-steps }}
         STEP_DELAY: ${{ inputs.step-delay }}
         PLATFORM: ios

--- a/flows/wdio-android-deterministic.yaml
+++ b/flows/wdio-android-deterministic.yaml
@@ -1,0 +1,12 @@
+appId: com.wdiodemoapp
+app: https://github.com/webdriverio/native-demo-app/releases/download/v2.2.0/android.wdio.native.app.v2.2.0.apk
+name: WDIO Android deterministic smoke
+platform: android
+---
+steps:
+  - launchApp
+  - waitUntil: Login
+  - tap: Login
+  - enter appclaw@gmail.com in input-email
+  - assert: input-email
+  - done

--- a/flows/wdio-ios-deterministic.yaml
+++ b/flows/wdio-ios-deterministic.yaml
@@ -1,0 +1,12 @@
+appId: org.wdiodemoapp
+app: https://github.com/webdriverio/native-demo-app/releases/download/v2.2.0/ios.simulator.wdio.native.app.v2.2.0.zip
+name: WDIO iOS deterministic smoke
+platform: ios
+---
+steps:
+  - launchApp
+  - waitUntil: Login
+  - tap: Login
+  - enter appclaw@gmail.com in input-email
+  - assert: input-email
+  - done

--- a/github-action/README.md
+++ b/github-action/README.md
@@ -9,6 +9,22 @@ Run [AppClaw](https://github.com/AppiumTestDistribution/AppClaw) mobile UI autom
 
 ## Quick start
 
+### Deterministic YAML flow — no LLM secret
+
+Use strict parsing, DOM-only interaction, and disable vision fallback together to guarantee that
+the Action cannot fall through to an LLM call. This configuration is safe for pull requests from
+forks because it does not require repository secrets.
+
+```yaml
+- uses: AppiumTestDistribution/AppClaw@v1
+  with:
+    flow: flows/login.yaml
+    platform: android # also supports ios on a macOS runner
+    strict: 'true'
+    agent-mode: dom
+    vision-mode: never
+```
+
 ### Android — run a YAML flow
 
 ```yaml
@@ -63,12 +79,14 @@ jobs:
 | Input                    | Required | Default              | Description                                                                    |
 | ------------------------ | :------: | -------------------- | ------------------------------------------------------------------------------ |
 | `flow`                   | one of¹  | —                    | Path to a YAML flow file relative to repo root                                 |
+| `strict`                 |    no    | `false`              | Fail on unrecognized YAML instead of using the LLM parser                      |
 | `goal`                   | one of¹  | —                    | Natural language goal executed by the LLM agent                                |
 | `platform`               |    no    | `android`            | Target platform: `android` or `ios`                                            |
 | `provider`               |    no    | `gemini`             | LLM provider: `gemini`, `anthropic`, `openai`, `groq`                          |
-| `api-key`                | **yes**  | —                    | LLM API key — stored as `LLM_API_KEY` in the environment                       |
+| `api-key`                |   no³    | —                    | LLM API key — stored as `LLM_API_KEY` in the environment                       |
 | `model`                  |    no    | _(provider default)_ | LLM model ID to pin (e.g. `gemini-2.0-flash`, `claude-3-5-haiku-20241022`)     |
 | `agent-mode`             |    no    | `dom`                | `dom` (element locators) or `vision` (screenshot AI)                           |
+| `vision-mode`            |    no    | `fallback`           | Vision policy: `always`, `fallback`, or `never`                                |
 | `max-steps`              |    no    | `30`                 | Maximum agent steps before the run fails                                       |
 | `step-delay`             |    no    | `500`                | Milliseconds between steps                                                     |
 | `android-api-level`      |    no    | `33`                 | Android emulator API level (33 = Android 13)                                   |
@@ -90,6 +108,8 @@ jobs:
 
 ¹ Provide either `flow` **or** `goal`, not both.
 ² Required when `cloud-provider: lambdatest`.
+³ Required for goals and non-deterministic flows. It may be omitted only when `strict: 'true'`,
+`agent-mode: dom`, and `vision-mode: never` are all set.
 
 ## Outputs
 
@@ -122,6 +142,9 @@ See the [AppClaw YAML flow docs](https://github.com/AppiumTestDistribution/AppCl
 ---
 
 ## Secrets setup
+
+Skip this section for a deterministic no-LLM flow configured with `strict: 'true'`,
+`agent-mode: dom`, and `vision-mode: never`.
 
 Go to your repo → **Settings → Secrets and variables → Actions → New repository secret**:
 

--- a/github-action/examples/deterministic-flow.yml
+++ b/github-action/examples/deterministic-flow.yml
@@ -1,0 +1,34 @@
+name: Deterministic Mobile Tests
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  android:
+    name: Android — no LLM
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: AppiumTestDistribution/AppClaw@v1
+        with:
+          flow: flows/login.yaml
+          platform: android
+          strict: 'true'
+          agent-mode: dom
+          vision-mode: never
+
+  ios:
+    name: iOS — no LLM
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: AppiumTestDistribution/AppClaw@v1
+        with:
+          flow: flows/ios-login.yaml
+          platform: ios
+          strict: 'true'
+          agent-mode: dom
+          vision-mode: never

--- a/landing/public/usage.html
+++ b/landing/public/usage.html
@@ -4472,6 +4472,26 @@ console<span class="p">.</span>log<span class="p">(</span><span class="s">'All f
         <section id="gha-quick-start" class="reveal">
           <h2>Quick Start</h2>
 
+          <h3>Deterministic YAML flow — no LLM secret</h3>
+          <p>
+            Strict parsing, DOM-only interaction, and disabled vision fallback prevent automatic LLM
+            parsing and vision fallback. This configuration is safe for pull requests from forks and
+            needs no LLM secret.
+          </p>
+          <div class="code-block">
+            <div class="code-block-header">
+              <div class="code-block-dots"><span></span><span></span><span></span></div>
+              <span class="code-block-label">deterministic-flow.yml</span>
+            </div>
+            <pre>- <span class="k">uses:</span> <span class="s">AppiumTestDistribution/AppClaw@v1</span>
+  <span class="k">with:</span>
+    <span class="k">flow:</span> <span class="s">flows/login.yaml</span>
+    <span class="k">platform:</span> <span class="s">android</span>
+    <span class="k">strict:</span> <span class="s">'true'</span>
+    <span class="k">agent-mode:</span> <span class="s">dom</span>
+    <span class="k">vision-mode:</span> <span class="s">never</span></pre>
+          </div>
+
           <h3>Android — run a YAML flow</h3>
           <div class="code-block">
             <div class="code-block-header">
@@ -4548,6 +4568,12 @@ console<span class="p">.</span>log<span class="p">(</span><span class="s">'All f
                 <td>Path to a YAML flow file relative to repo root</td>
               </tr>
               <tr>
+                <td><code>strict</code></td>
+                <td>no</td>
+                <td><code>false</code></td>
+                <td>Fail on unrecognized YAML instead of using the LLM parser</td>
+              </tr>
+              <tr>
                 <td><code>goal</code></td>
                 <td>one of*</td>
                 <td>—</td>
@@ -4570,7 +4596,7 @@ console<span class="p">.</span>log<span class="p">(</span><span class="s">'All f
               </tr>
               <tr>
                 <td><code>api-key</code></td>
-                <td><strong>yes</strong></td>
+                <td>no***</td>
                 <td>—</td>
                 <td>LLM API key — stored as <code>LLM_API_KEY</code></td>
               </tr>
@@ -4585,6 +4611,14 @@ console<span class="p">.</span>log<span class="p">(</span><span class="s">'All f
                 <td>no</td>
                 <td><code>dom</code></td>
                 <td><code>dom</code> (element locators) or <code>vision</code> (screenshot AI)</td>
+              </tr>
+              <tr>
+                <td><code>vision-mode</code></td>
+                <td>no</td>
+                <td><code>fallback</code></td>
+                <td>
+                  Vision policy: <code>always</code>, <code>fallback</code>, or <code>never</code>
+                </td>
               </tr>
               <tr>
                 <td><code>max-steps</code></td>
@@ -4703,10 +4737,20 @@ console<span class="p">.</span>log<span class="p">(</span><span class="s">'All f
           </table>
           <p>* Provide either <code>flow</code> <strong>or</strong> <code>goal</code>, not both.</p>
           <p>** Required when <code>cloud-provider: lambdatest</code>.</p>
+          <p>
+            *** Required for goals and non-deterministic flows. It may be omitted only when
+            <code>strict: 'true'</code>, <code>agent-mode: dom</code>, and
+            <code>vision-mode: never</code> are all set.
+          </p>
         </section>
 
         <section id="gha-secrets" class="reveal">
           <h2>Secrets Setup</h2>
+          <p>
+            Skip LLM secret setup for a deterministic flow configured with
+            <code>strict: 'true'</code>, <code>agent-mode: dom</code>, and
+            <code>vision-mode: never</code>.
+          </p>
           <p>
             Go to your repo &rarr;
             <strong

--- a/tests/flow/action-deterministic-contract.test.ts
+++ b/tests/flow/action-deterministic-contract.test.ts
@@ -1,0 +1,148 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { describe, expect, test } from 'vitest';
+import { parse } from 'yaml';
+
+import { parseFlowYamlFile } from '@appclaw/core/flow/parse-yaml-flow';
+
+type ActionStep = {
+  name?: string;
+  env?: Record<string, string>;
+  run?: string;
+  with?: Record<string, string>;
+};
+
+type ActionDefinition = {
+  inputs: Record<string, { default?: string; required?: boolean }>;
+  runs: { steps: ActionStep[] };
+};
+
+type WorkflowJob = {
+  if?: string | boolean;
+  'runs-on': string;
+  steps: Array<{ uses?: string; with?: Record<string, string> }>;
+};
+
+type WorkflowDefinition = {
+  jobs: Record<string, WorkflowJob>;
+};
+
+function readYaml<T>(path: string): T {
+  return parse(readFileSync(resolve(process.cwd(), path), 'utf8')) as T;
+}
+
+function runInputValidation(overrides: Record<string, string> = {}) {
+  const action = readYaml<ActionDefinition>('action.yml');
+  const validation = action.runs.steps.find((step) => step.name === 'Validate inputs');
+  if (!validation?.run) throw new Error('Validate inputs step is missing');
+
+  return spawnSync('bash', ['-euo', 'pipefail', '-c', validation.run], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      INPUT_FLOW: 'flows/wdio-android-deterministic.yaml',
+      INPUT_GOAL: '',
+      INPUT_PLATFORM: 'android',
+      INPUT_STRICT: 'true',
+      INPUT_AGENT_MODE: 'dom',
+      INPUT_VISION_MODE: 'never',
+      INPUT_API_KEY: '',
+      INPUT_CLOUD_PROVIDER: '',
+      INPUT_LAMBDATEST_USERNAME: '',
+      INPUT_LAMBDATEST_ACCESS_KEY: '',
+      INPUT_LAMBDATEST_DEVICE_NAME: '',
+      INPUT_LAMBDATEST_OS_VERSION: '',
+      ...overrides,
+    },
+  });
+}
+
+describe('deterministic GitHub Action contract', () => {
+  test('makes the API key optional only through explicit deterministic inputs', () => {
+    const action = readYaml<ActionDefinition>('action.yml');
+
+    expect(action.inputs['api-key']).toMatchObject({ required: false, default: '' });
+    expect(action.inputs.strict).toMatchObject({ required: false, default: 'false' });
+    expect(action.inputs['vision-mode']).toMatchObject({
+      required: false,
+      default: 'fallback',
+    });
+
+    expect(runInputValidation().status).toBe(0);
+
+    const nonStrict = runInputValidation({ INPUT_STRICT: 'false' });
+    expect(nonStrict.status).toBe(1);
+    expect(nonStrict.stdout).toContain('Missing LLM API key');
+
+    const visionFallback = runInputValidation({ INPUT_VISION_MODE: 'fallback' });
+    expect(visionFallback.status).toBe(1);
+    expect(visionFallback.stdout).toContain('Missing LLM API key');
+
+    const goal = runInputValidation({ INPUT_FLOW: '', INPUT_GOAL: 'open Settings' });
+    expect(goal.status).toBe(1);
+    expect(goal.stdout).toContain('Missing LLM API key');
+
+    expect(
+      runInputValidation({
+        INPUT_STRICT: 'false',
+        INPUT_VISION_MODE: 'fallback',
+        INPUT_API_KEY: 'test-key',
+      }).status
+    ).toBe(0);
+  });
+
+  test('passes the vision policy and strict flag to every YAML flow surface', () => {
+    const action = readYaml<ActionDefinition>('action.yml');
+    const flowSteps = action.runs.steps.filter((step) => step.name?.startsWith('Run YAML flow'));
+
+    expect(flowSteps).toHaveLength(3);
+    for (const step of flowSteps) {
+      expect(step.env?.VISION_MODE).toBe('${{ inputs.vision-mode }}');
+      const command = step.run ?? step.with?.script ?? '';
+      expect(command).toContain('${{ inputs.strict }}');
+      expect(command).toContain('--strict');
+    }
+  });
+
+  test.each([
+    ['flows/wdio-android-deterministic.yaml', 'com.wdiodemoapp'],
+    ['flows/wdio-ios-deterministic.yaml', 'org.wdiodemoapp'],
+  ])('%s is fully parseable without an LLM fallback', async (path, appId) => {
+    const flow = await parseFlowYamlFile(resolve(process.cwd(), path), { strict: true });
+
+    expect(flow.meta.appId).toBe(appId);
+    expect(flow.steps.map((step) => step.kind)).toEqual([
+      'launchApp',
+      'waitUntil',
+      'tap',
+      'type',
+      'assert',
+      'done',
+    ]);
+  });
+});
+
+describe('fork-safe deterministic device jobs', () => {
+  test.each([
+    ['android-deterministic', 'flows/wdio-android-deterministic.yaml'],
+    ['ios-deterministic', 'flows/wdio-ios-deterministic.yaml'],
+  ])('%s requires no secret or vision fallback', (id, flowPath) => {
+    const workflow = readYaml<WorkflowDefinition>('.github/workflows/layer3-branch-test.yml');
+    const job = workflow.jobs[id];
+    const actionStep = job.steps.find((step) => step.uses === './');
+
+    expect(job.if).not.toBe(false);
+    expect(String(job.if)).toContain("github.event_name == 'pull_request'");
+    expect(actionStep?.with).toMatchObject({
+      flow: flowPath,
+      strict: 'true',
+      'agent-mode': 'dom',
+      'vision-mode': 'never',
+    });
+    expect(actionStep?.with).not.toHaveProperty('api-key');
+    if (id === 'ios-deterministic') {
+      expect(job['runs-on']).toBe('macos-15');
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- allow the GitHub Action to omit `api-key` only for strict, DOM-only YAML flows with vision fallback disabled
- run deterministic Android and iOS device smoke tests on every pull request, including forks
- add fixed WDIO fixtures, Action contract tests, a reusable workflow example, and matching documentation

## Why

Fork pull requests cannot access repository LLM secrets, so the existing secret-backed jobs could fail before exercising AppClaw or a device. The iOS YAML job was also disabled. This change separates deterministic core execution coverage from AI-backed coverage without weakening the existing same-repository and manual LLM/vision checks.

External contributors now get meaningful Android and iOS checks without secrets, while natural-language goals, non-strict parsing, and vision fallback continue to require an API key.

## Validation

- `npm test` — 21 test files, 409 tests passed
- `npm run lint`
- `npm run format:check`
- `actionlint v1.7.7`
- Android 13 / API 33 emulator — deterministic fixture passed 6/6 steps with all LLM and vision keys empty
- iOS simulator — deterministic fixture passed 6/6 steps with all LLM and vision keys empty
- `git diff --check`
