### PR TITLE
feat: Feat/anchored scroll assert

### DIFF
--- a/landing/public/usage.html
+++ b/landing/public/usage.html
@@ -2208,9 +2208,21 @@
           <div class="code-block">
             <div class="code-block-header">
               <div class="code-block-dots"><span></span><span></span><span></span></div>
+              <span class="code-block-label">Double tap</span>
+            </div>
+            <pre><span class="c"># Same matching as tap, fires a double-tap gesture</span>
+<span class="p">-</span> double tap the Photo
+<span class="p">-</span> double-click on the image
+<span class="p">-</span> double tap YESBANK to the left of BSE</pre>
+          </div>
+
+          <div class="code-block">
+            <div class="code-block-header">
+              <div class="code-block-dots"><span></span><span></span><span></span></div>
               <span class="code-block-label">Structured YAML</span>
             </div>
-            <pre><span class="p">-</span> <span class="k">tap</span><span class="p">:</span> <span class="s">"Login Button"</span></pre>
+            <pre><span class="p">-</span> <span class="k">tap</span><span class="p">:</span> <span class="s">"Login Button"</span>
+<span class="p">-</span> <span class="k">doubleTap</span><span class="p">:</span> <span class="s">"Photo"</span></pre>
           </div>
         </section>
 
@@ -2220,7 +2232,9 @@
             When several elements share the same label &mdash; e.g. a &ldquo;Login&rdquo; tab, a
             &ldquo;Login&rdquo; nav item, and the actual <code>LOGIN</code> button &mdash; add a
             spatial qualifier to pick the right one by its position relative to another element.
-            Works on both <code>tap</code> and <code>type</code>.
+            Works on <code>tap</code>, <code>doubleTap</code>, <code>type</code>, and scroll-area
+            anchors (see Scroll / Swipe). Qualifiers chain when the anchor itself needs picking:
+            <code>tap YESBANK to the left of NSEFO which is near &#8377;0.04</code>.
           </p>
 
           <div class="code-block">
@@ -2453,10 +2467,44 @@
           <div class="code-block">
             <div class="code-block-header">
               <div class="code-block-dots"><span></span><span></span><span></span></div>
+              <span class="code-block-label">Anchored swipe — inside a carousel / strip</span>
+            </div>
+            <pre><span class="c"># Start the gesture from a named element instead of screen center,</span>
+<span class="c"># so a horizontal rail scrolls instead of the page</span>
+<span class="p">-</span> swipe the FII/DII left
+<span class="p">-</span> swipe the FII/DII left 2 times</pre>
+          </div>
+
+          <div class="code-block">
+            <div class="code-block-header">
+              <div class="code-block-dots"><span></span><span></span><span></span></div>
+              <span class="code-block-label">Swipe a carousel until an element appears</span>
+            </div>
+            <pre><span class="c"># Keep swiping inside the strip until the element shows up.</span>
+<span class="c"># The anchor is resolved once &mdash; it may scroll away; its spot stays.</span>
+<span class="p">-</span> swipe the FII/DII left until <span class="s">"Goal calculator"</span> is visible
+
+<span class="c"># Several scroll areas? Qualify WHICH one spatially:</span>
+<span class="p">-</span> swipe the FII/DII below <span class="s">"Post-Market Insights"</span> left until <span class="s">"Goal calculator"</span> is visible
+
+<span class="c"># Or describe the region itself &mdash; no element text needed.</span>
+<span class="c"># "area/section/strip" resolves to the nearest element on that side:</span>
+<span class="p">-</span> swipe left inside the area above <span class="s">"View All"</span> until <span class="s">"Goal calculator"</span> is visible</pre>
+          </div>
+
+          <div class="code-block">
+            <div class="code-block-header">
+              <div class="code-block-dots"><span></span><span></span><span></span></div>
               <span class="code-block-label">Structured YAML</span>
             </div>
             <pre><span class="p">-</span> <span class="k">scrollAssert</span><span class="p">:</span> <span class="s">"Terms &amp; Conditions"</span>
   <span class="k">direction</span><span class="p">:</span> <span class="s">down</span>
+  <span class="k">maxScrolls</span><span class="p">:</span> <span class="n">5</span>
+
+<span class="c"># Anchored inside a carousel</span>
+<span class="p">-</span> <span class="k">scrollAssert</span><span class="p">:</span> <span class="s">"Goal calculator"</span>
+  <span class="k">direction</span><span class="p">:</span> <span class="s">left</span>
+  <span class="k">target</span><span class="p">:</span> <span class="s">"FII/DII"</span>
   <span class="k">maxScrolls</span><span class="p">:</span> <span class="n">5</span></pre>
           </div>
         </section>
@@ -2601,6 +2649,11 @@
                 <td>Tap element by visible text/label</td>
               </tr>
               <tr>
+                <td>doubleTap</td>
+                <td>label</td>
+                <td>Double-tap element by visible text/label</td>
+              </tr>
+              <tr>
                 <td>type</td>
                 <td>text, target?</td>
                 <td>Type text, optionally into a named field</td>
@@ -2632,8 +2685,8 @@
               </tr>
               <tr>
                 <td>swipe</td>
-                <td>direction, repeat?</td>
-                <td>Swipe up/down/left/right</td>
+                <td>direction, target?, repeat?</td>
+                <td>Swipe up/down/left/right; target anchors the gesture on an element</td>
               </tr>
               <tr>
                 <td>drag</td>
@@ -2647,8 +2700,8 @@
               </tr>
               <tr>
                 <td>scrollAssert</td>
-                <td>text, direction, maxScrolls</td>
-                <td>Scroll until text found</td>
+                <td>text, direction, maxScrolls, target?</td>
+                <td>Scroll until text found; target (plus an optional spatial qualifier) anchors the swipes inside a carousel</td>
               </tr>
               <tr>
                 <td>getInfo</td>

--- a/landing/public/usage.html
+++ b/landing/public/usage.html
@@ -2701,7 +2701,10 @@
               <tr>
                 <td>scrollAssert</td>
                 <td>text, direction, maxScrolls, target?</td>
-                <td>Scroll until text found; target (plus an optional spatial qualifier) anchors the swipes inside a carousel</td>
+                <td>
+                  Scroll until text found; target (plus an optional spatial qualifier) anchors the
+                  swipes inside a carousel
+                </td>
               </tr>
               <tr>
                 <td>getInfo</td>

--- a/packages/core/src/flow/llm-parser.ts
+++ b/packages/core/src/flow/llm-parser.ts
@@ -87,6 +87,12 @@ const stepSchema = z.discriminatedUnion('kind', [
     text: z.string(),
     direction: z.enum(['up', 'down', 'left', 'right']),
     maxScrolls: z.number(),
+    target: z
+      .string()
+      .optional()
+      .describe(
+        'Anchor element to swipe from (e.g. an item inside a horizontal carousel) instead of screen center'
+      ),
   }),
   z.object({
     kind: z.literal('drag'),
@@ -127,7 +133,8 @@ const SYSTEM_PROMPT =
   `- "zoom in [Nx] [on/into/the <element>]" → zoom (scale > 1), "zoom out [on <element>]" → zoom (scale < 1). e.g. "zoom in the map", "zoom in 2x on the image"\n` +
   `- "pinch in/out [on/into/the <element>]" → zoom\n` +
   `- "verify/check/assert <text>" → assert\n` +
-  `- "scroll until <text> visible" → scrollAssert\n` +
+  `- "scroll until <text> visible" → scrollAssert ` +
+  `(swiping inside a named carousel — "swipe the <item> left until <text> visible" — sets target=<item>)\n` +
   `- "go back" → back, "go home" → home\n` +
   `- "press enter/submit/search" → enter\n` +
   `- "done" → done\n` +

--- a/packages/core/src/flow/llm-parser.ts
+++ b/packages/core/src/flow/llm-parser.ts
@@ -91,7 +91,20 @@ const stepSchema = z.discriminatedUnion('kind', [
       .string()
       .optional()
       .describe(
-        'Anchor element to swipe from (e.g. an item inside a horizontal carousel) instead of screen center'
+        'Anchor element to swipe from (e.g. an item inside a horizontal carousel) instead of ' +
+          'screen center. Generic region nouns ("area", "section") are allowed when combined ' +
+          'with targetProximity'
+      ),
+    targetProximity: z
+      .object({
+        relation: z.enum(['above', 'below', 'toLeftOf', 'toRightOf', 'near', 'within']),
+        anchor: z.string(),
+      })
+      .optional()
+      .describe(
+        'Spatial qualifier picking WHICH scroll area, e.g. "swipe left inside the area above ' +
+          'View All until X visible" → target "area", targetProximity {relation: "above", ' +
+          'anchor: "View All"}'
       ),
   }),
   z.object({

--- a/packages/core/src/flow/natural-line.ts
+++ b/packages/core/src/flow/natural-line.ts
@@ -57,14 +57,21 @@ export function splitProximity(label: string): { label: string; proximity?: Prox
   if (!m) return { label };
   // A trailing connector on the target means the relation opens a qualifier
   // clause: "YESBANK which is to the left of BSE" → target "YESBANK".
-  const target = trimPunct(m[1].trim()).replace(/\s+(?:which|that)\s+is$/i, '');
+  // Strip trailing connector filler ("which is", "that is located", "located")
+  // left behind when the relation opens a qualifier clause.
+  const target = trimPunct(m[1].trim()).replace(
+    /\s+(?:(?:which|that)\s+is\s*)?(?:located|positioned|placed|situated)?$/i,
+    ''
+  );
   const relWord = m[2].toLowerCase().replace(/\s+/g, ' ');
   const anchorRest = trimPunct(m[3].trim());
   const relation = PROXIMITY_RELATIONS[relWord];
   if (!relation || !target || !anchorRest) return { label };
   // Recurse on the anchor phrase (dropping an optional "which is"/"that is"
   // connector) so a qualified anchor nests instead of being matched literally.
-  const nested = splitProximity(anchorRest.replace(/\s+(?:which|that)\s+is\s+/i, ' '));
+  const nested = splitProximity(
+    anchorRest.replace(/\s+(?:which|that)\s+is\s+(?:located\s+|positioned\s+|placed\s+)?/i, ' ')
+  );
   if (nested.proximity && nested.label) {
     return {
       label: target,
@@ -259,17 +266,48 @@ export function tryParseNaturalFlowLine(line: string): FlowStep | null {
     /^(?:scroll|swipe)\s+(?:(?:the\s+)?(.+?)\s+)?(up|down|left|right)\s+(?:(\d+)\s+times?\s+)?(?:until|to\s+(?:find|see|check|verify))\s+["']?(.+?)["']?\s*(?:is\s+(?:visible|present|shown|displayed|seen|found|there))?$/i
   );
   if (scrollAssertMatch) {
-    const target = scrollAssertMatch[1] ? trimPunct(scrollAssertMatch[1].trim()) : undefined;
+    const rawTarget = scrollAssertMatch[1] ? trimPunct(scrollAssertMatch[1].trim()) : undefined;
     const direction = scrollAssertMatch[2].toLowerCase() as 'up' | 'down' | 'left' | 'right';
     const maxScrolls = scrollAssertMatch[3] ? Number(scrollAssertMatch[3]) : 3;
     const text = stripTextPrefix(trimPunct(scrollAssertMatch[4].trim()));
+    // The anchor may itself carry a spatial qualifier picking WHICH scroll area:
+    // "swipe the FII/DII below Post-Market Insights left until … is visible".
+    const split: { label?: string; proximity?: Proximity } = rawTarget
+      ? splitProximity(rawTarget)
+      : {};
     if (text)
       return {
         kind: 'scrollAssert',
         text,
         direction,
         maxScrolls,
-        ...(target ? { target } : {}),
+        ...(split.label ? { target: split.label } : {}),
+        ...(split.proximity ? { targetProximity: split.proximity } : {}),
+        verbatim,
+      };
+  }
+
+  // Direction-first anchored form: "swipe left inside the area above View All
+  // until Goal calculator is visible". The region phrase may be a real element
+  // label or a spatial phrase whose noun is generic ("area", "section") — the
+  // executor then swipes from the nearest element on that side of the anchor.
+  const insideScrollAssertMatch = t.match(
+    /^(?:scroll|swipe)\s+(up|down|left|right)\s+(?:(\d+)\s+times?\s+)?(?:inside|within|in|on)\s+(?:the\s+)?(.+?)\s+(?:until|to\s+(?:find|see|check|verify))\s+["']?(.+?)["']?\s*(?:is\s+(?:visible|present|shown|displayed|seen|found|there))?$/i
+  );
+  if (insideScrollAssertMatch) {
+    const direction = insideScrollAssertMatch[1].toLowerCase() as 'up' | 'down' | 'left' | 'right';
+    const maxScrolls = insideScrollAssertMatch[2] ? Number(insideScrollAssertMatch[2]) : 3;
+    const region = trimPunct(insideScrollAssertMatch[3].trim());
+    const text = stripTextPrefix(trimPunct(insideScrollAssertMatch[4].trim()));
+    const split = splitProximity(region);
+    if (text)
+      return {
+        kind: 'scrollAssert',
+        text,
+        direction,
+        maxScrolls,
+        ...(split.label ? { target: split.label } : {}),
+        ...(split.proximity ? { targetProximity: split.proximity } : {}),
         verbatim,
       };
   }

--- a/packages/core/src/flow/natural-line.ts
+++ b/packages/core/src/flow/natural-line.ts
@@ -57,12 +57,16 @@ export function splitProximity(label: string): { label: string; proximity?: Prox
   if (!m) return { label };
   // A trailing connector on the target means the relation opens a qualifier
   // clause: "YESBANK which is to the left of BSE" → target "YESBANK".
-  // Strip trailing connector filler ("which is", "that is located", "located")
-  // left behind when the relation opens a qualifier clause.
-  const target = trimPunct(m[1].trim()).replace(
-    /\s+(?:(?:which|that)\s+is\s*)?(?:located|positioned|placed|situated)?$/i,
-    ''
-  );
+  // Strip trailing connector filler: "which is" / "that is [located]" always;
+  // a BARE participle only after a generic region noun ("the area located
+  // above X" → "area"). A bare participle after a real label is kept —
+  // "Order Placed below Filters" must NOT become "Order".
+  const target = trimPunct(m[1].trim())
+    .replace(/\s+(?:which|that)\s+is(?:\s+(?:located|positioned|placed|situated))?$/i, '')
+    .replace(
+      /^((?:the\s+)?(?:area|section|carousel|strip|list|row|region|scroll\s*(?:area|view|section)))\s+(?:located|positioned|placed|situated)$/i,
+      '$1'
+    );
   const relWord = m[2].toLowerCase().replace(/\s+/g, ' ');
   const anchorRest = trimPunct(m[3].trim());
   const relation = PROXIMITY_RELATIONS[relWord];

--- a/packages/core/src/flow/natural-line.ts
+++ b/packages/core/src/flow/natural-line.ts
@@ -251,15 +251,27 @@ export function tryParseNaturalFlowLine(line: string): FlowStep | null {
   }
 
   // scroll down until "X" is visible / scroll down 3 times to find "X"
+  // Anchored form: "swipe the FII/DII left until Goal calculator is visible" —
+  // the optional element between the verb and the direction anchors the gesture
+  // inside that element's container (a carousel/strip) instead of screen center.
   // MUST come before the simple swipe/scroll match to avoid premature matching
   const scrollAssertMatch = t.match(
-    /^scroll\s+(up|down|left|right)\s+(?:(\d+)\s+times?\s+)?(?:until|to\s+(?:find|see|check|verify))\s+["']?(.+?)["']?\s*(?:is\s+(?:visible|present|shown|displayed|seen|found|there))?$/i
+    /^(?:scroll|swipe)\s+(?:(?:the\s+)?(.+?)\s+)?(up|down|left|right)\s+(?:(\d+)\s+times?\s+)?(?:until|to\s+(?:find|see|check|verify))\s+["']?(.+?)["']?\s*(?:is\s+(?:visible|present|shown|displayed|seen|found|there))?$/i
   );
   if (scrollAssertMatch) {
-    const direction = scrollAssertMatch[1].toLowerCase() as 'up' | 'down' | 'left' | 'right';
-    const maxScrolls = scrollAssertMatch[2] ? Number(scrollAssertMatch[2]) : 3;
-    const text = stripTextPrefix(trimPunct(scrollAssertMatch[3].trim()));
-    if (text) return { kind: 'scrollAssert', text, direction, maxScrolls, verbatim };
+    const target = scrollAssertMatch[1] ? trimPunct(scrollAssertMatch[1].trim()) : undefined;
+    const direction = scrollAssertMatch[2].toLowerCase() as 'up' | 'down' | 'left' | 'right';
+    const maxScrolls = scrollAssertMatch[3] ? Number(scrollAssertMatch[3]) : 3;
+    const text = stripTextPrefix(trimPunct(scrollAssertMatch[4].trim()));
+    if (text)
+      return {
+        kind: 'scrollAssert',
+        text,
+        direction,
+        maxScrolls,
+        ...(target ? { target } : {}),
+        verbatim,
+      };
   }
 
   // "drag X to Y" / "slide X to Y" / "move X to Y"

--- a/packages/core/src/flow/parse-yaml-flow.ts
+++ b/packages/core/src/flow/parse-yaml-flow.ts
@@ -157,6 +157,7 @@ export function normalizeStructured(raw: unknown, index: number): FlowStep | nul
         text,
         direction: dir as 'up' | 'down' | 'left' | 'right',
         maxScrolls,
+        ...(o.target != null && o.target !== '' ? { target: String(o.target) } : {}),
       };
     }
 

--- a/packages/core/src/flow/run-yaml-flow.ts
+++ b/packages/core/src/flow/run-yaml-flow.ts
@@ -322,7 +322,7 @@ function stepLabel(step: FlowStep): string {
     case 'assert':
       return `assert "${step.text}"`;
     case 'scrollAssert':
-      return `scroll ${step.direction} until "${step.text}"`;
+      return `scroll ${step.direction} until "${step.text}"${step.target ? ` (on "${step.target}")` : ''}`;
     case 'getInfo':
       return `getInfo "${step.query.length > 50 ? `${step.query.slice(0, 47)}…` : step.query}"`;
     case 'done':
@@ -1784,11 +1784,32 @@ async function scrollUntilVisible(
   direction: 'up' | 'down' | 'left' | 'right',
   maxScrolls: number,
   poll: FlowTapPollOptions,
-  distance?: ScrollDistance
+  distance?: ScrollDistance,
+  target?: string
 ): Promise<ActionResult> {
-  const customCoords = distance ? scrollCoordsForDistance(mcp, direction, distance) : null;
   const visionFirst = isVisionMode();
   const useVision = isVisionLocateEnabled();
+
+  // Anchored form: swipe from the named element's position (a carousel/strip)
+  // instead of screen center. Resolved ONCE, before any swiping — the anchor
+  // element itself scrolls away with the strip's content, but the strip stays
+  // where it is on screen, so the first-seen coordinates remain the right
+  // place to keep swiping. Finger-motion semantics, same as anchored `swipe`.
+  let anchorCoords: { x: number; y: number; endX: number; endY: number } | null = null;
+  if (target) {
+    const center = await resolveTargetCenter(mcp, target);
+    if (center) {
+      anchorCoords = anchoredSwipeCoords(mcp, center, direction, distance);
+    } else {
+      ui.printAgentBullet(`"${target}" not found — scrolling ${direction} from screen center`);
+    }
+  }
+  const customCoords =
+    anchorCoords ?? (distance ? scrollCoordsForDistance(mcp, direction, distance) : null);
+  // Anchored horizontal drags use the swipe gesture, mirroring the anchored
+  // `swipe` step; the plain path keeps its historical scroll semantics.
+  const gestureAction =
+    anchorCoords && (direction === 'left' || direction === 'right') ? 'swipe' : 'scroll';
 
   // Helper: check if text is currently visible on screen
   const isVisible = async (): Promise<boolean> => {
@@ -1811,9 +1832,10 @@ async function scrollUntilVisible(
     };
   }
 
+  const onNote = anchorCoords ? ` on "${target}"` : '';
   for (let scroll = 0; scroll < maxScrolls; scroll++) {
     await mcp.callTool('appium_gesture', {
-      action: 'scroll',
+      action: gestureAction,
       ...(customCoords ? customCoords : { direction }),
     });
     await sleep(800);
@@ -1821,7 +1843,7 @@ async function scrollUntilVisible(
     if (await isVisible()) {
       return {
         success: true,
-        message: `Found "${text}" after ${scroll + 1} scroll(s) ${direction}`,
+        message: `Found "${text}" after ${scroll + 1} scroll(s) ${direction}${onNote}`,
       };
     }
   }
@@ -1841,7 +1863,7 @@ async function scrollUntilVisible(
 
   return {
     success: false,
-    message: `"${text}" not found after ${maxScrolls} scroll(s) ${direction}${screenSummary}`,
+    message: `"${text}" not found after ${maxScrolls} scroll(s) ${direction}${onNote}${screenSummary}`,
   };
 }
 
@@ -2326,7 +2348,8 @@ export async function executeStep(
         step.direction,
         scroll?.times ?? step.maxScrolls,
         tapPoll,
-        scroll?.distance
+        scroll?.distance,
+        step.target
       );
     case 'getInfo': {
       const infoApiKey = getStarkVisionApiKey();

--- a/packages/core/src/flow/run-yaml-flow.ts
+++ b/packages/core/src/flow/run-yaml-flow.ts
@@ -1778,6 +1778,39 @@ async function assertTextVisible(
  * Checks the current screen BEFORE the first scroll — if the target is already
  * visible, returns immediately without scrolling (avoids pushing it off screen).
  */
+/** Generic region nouns in phrases like "the area above View All" — no element
+ *  carries this text; the region is defined purely by the spatial qualifier. */
+const GENERIC_REGION_NOUN =
+  /^(?:area|section|carousel|strip|list|row|region|scroll\s*(?:area|view|section))$/i;
+
+/**
+ * Resolve where an anchored scroll-until-visible should swipe.
+ *
+ * - target only               → the element's center (same as anchored swipe)
+ * - target + qualifier        → the spatially-disambiguated instance's center
+ * - generic noun + qualifier  → the nearest element on that side of the
+ *   qualifier's anchor ("the area above View All" → whatever sits just above
+ *   "View All"), guaranteeing the point lands on real content in that region.
+ */
+async function resolveScrollAnchorCenter(
+  mcp: MCPClient,
+  target: string | undefined,
+  proximity: Proximity | undefined
+): Promise<[number, number] | null> {
+  if (!proximity) return target ? resolveTargetCenter(mcp, target) : null;
+  const pageSource = await getPageSource(mcp);
+  const platform = detectPlatform(pageSource);
+  const elements =
+    platform === 'android' ? parseAndroidPageSource(pageSource) : parseIOSPageSource(pageSource);
+  if (!target || GENERIC_REGION_NOUN.test(target)) {
+    const anchorEl = resolveAnchor(elements, proximity);
+    if (!anchorEl) return null;
+    const ranked = rankBySpatial(elements, anchorEl, proximity.relation);
+    return ranked[0]?.center ?? null;
+  }
+  return resolveTapTarget(elements, target, proximity).el?.center ?? null;
+}
+
 async function scrollUntilVisible(
   mcp: MCPClient,
   text: string,
@@ -1785,7 +1818,8 @@ async function scrollUntilVisible(
   maxScrolls: number,
   poll: FlowTapPollOptions,
   distance?: ScrollDistance,
-  target?: string
+  target?: string,
+  targetProximity?: Proximity
 ): Promise<ActionResult> {
   const visionFirst = isVisionMode();
   const useVision = isVisionLocateEnabled();
@@ -1796,12 +1830,15 @@ async function scrollUntilVisible(
   // where it is on screen, so the first-seen coordinates remain the right
   // place to keep swiping. Finger-motion semantics, same as anchored `swipe`.
   let anchorCoords: { x: number; y: number; endX: number; endY: number } | null = null;
-  if (target) {
-    const center = await resolveTargetCenter(mcp, target);
+  const targetDesc = targetProximity
+    ? `${target ?? 'area'} ${relationPhrase(targetProximity.relation)} ${describeAnchor(targetProximity)}`
+    : target;
+  if (target || targetProximity) {
+    const center = await resolveScrollAnchorCenter(mcp, target, targetProximity);
     if (center) {
       anchorCoords = anchoredSwipeCoords(mcp, center, direction, distance);
     } else {
-      ui.printAgentBullet(`"${target}" not found — scrolling ${direction} from screen center`);
+      ui.printAgentBullet(`"${targetDesc}" not found — scrolling ${direction} from screen center`);
     }
   }
   const customCoords =
@@ -1832,7 +1869,7 @@ async function scrollUntilVisible(
     };
   }
 
-  const onNote = anchorCoords ? ` on "${target}"` : '';
+  const onNote = anchorCoords ? ` on "${targetDesc}"` : '';
   for (let scroll = 0; scroll < maxScrolls; scroll++) {
     await mcp.callTool('appium_gesture', {
       action: gestureAction,
@@ -2349,7 +2386,8 @@ export async function executeStep(
         scroll?.times ?? step.maxScrolls,
         tapPoll,
         scroll?.distance,
-        step.target
+        step.target,
+        step.targetProximity
       );
     case 'getInfo': {
       const infoApiKey = getStarkVisionApiKey();

--- a/packages/core/src/flow/types.ts
+++ b/packages/core/src/flow/types.ts
@@ -128,6 +128,12 @@ export type FlowStep =
       text: string;
       direction: 'up' | 'down' | 'left' | 'right';
       maxScrolls: number;
+      /**
+       * Optional anchor element: the swipe gesture starts from this element's
+       * position (e.g. inside a horizontal carousel) instead of screen center.
+       * Resolved once — the anchor itself may scroll away; its coordinates stay.
+       */
+      target?: string;
     } & Verbatim)
   | ({ kind: 'getInfo'; query: string } & Verbatim)
   | ({ kind: 'done'; message?: string } & Verbatim);

--- a/packages/core/src/flow/types.ts
+++ b/packages/core/src/flow/types.ts
@@ -134,6 +134,13 @@ export type FlowStep =
        * Resolved once — the anchor itself may scroll away; its coordinates stay.
        */
       target?: string;
+      /**
+       * Spatial qualifier picking WHICH scroll area when several exist:
+       * "the FII/DII below Post-Market Insights" or a pure region phrase
+       * ("the area above View All") whose generic noun resolves to the
+       * nearest element on that side of the qualifier's anchor.
+       */
+      targetProximity?: Proximity;
     } & Verbatim)
   | ({ kind: 'getInfo'; query: string } & Verbatim)
   | ({ kind: 'done'; message?: string } & Verbatim);

--- a/packages/core/src/ui/step-printer.ts
+++ b/packages/core/src/ui/step-printer.ts
@@ -96,7 +96,7 @@ export function stepTarget(step: FlowStep): string {
     case 'assert':
       return `"${step.text}"`;
     case 'scrollAssert':
-      return `"${step.text}" ${step.direction} ×${step.maxScrolls}`;
+      return `"${step.text}" ${step.direction} ×${step.maxScrolls}${step.target ? ` on "${step.target}"` : ''}`;
     case 'drag':
       return `"${step.from}" → "${step.to}"`;
     case 'getInfo':

--- a/tests/flow/natural-line.test.ts
+++ b/tests/flow/natural-line.test.ts
@@ -583,3 +583,31 @@ describe('natural-line: spatially-qualified scroll areas', () => {
     expect(r && 'targetProximity' in r ? r.targetProximity : undefined).toBeUndefined();
   });
 });
+
+describe('natural-line: participle labels are not mangled by connector stripping', () => {
+  test('"Order Placed" survives as a proximity target', () => {
+    expect(tryParseNaturalFlowLine('tap Order Placed below Filters')).toMatchObject({
+      kind: 'tap',
+      label: 'Order Placed',
+      proximity: { relation: 'below', anchor: 'Filters' },
+    });
+  });
+  test('"Conveniently Located" survives too', () => {
+    expect(tryParseNaturalFlowLine('tap Conveniently Located near the map')).toMatchObject({
+      kind: 'tap',
+      label: 'Conveniently Located',
+      proximity: { relation: 'near', anchor: 'map' },
+    });
+  });
+  test('bare participle IS stripped after a generic region noun', () => {
+    expect(
+      tryParseNaturalFlowLine(
+        'swipe left inside the area located above View All until Goal calculator is visible'
+      )
+    ).toMatchObject({
+      kind: 'scrollAssert',
+      target: 'area',
+      targetProximity: { relation: 'above', anchor: 'View All' },
+    });
+  });
+});

--- a/tests/flow/natural-line.test.ts
+++ b/tests/flow/natural-line.test.ts
@@ -502,3 +502,39 @@ describe('natural-line: double tap', () => {
     expect(tryParseNaturalFlowLine('tap Photo')).toMatchObject({ kind: 'tap', label: 'Photo' });
   });
 });
+
+describe('natural-line: anchored scrollAssert', () => {
+  test('swipe the <anchor> left until <text> is visible', () => {
+    expect(
+      tryParseNaturalFlowLine('swipe the FII/DII left until Goal calculator is visible')
+    ).toMatchObject({
+      kind: 'scrollAssert',
+      target: 'FII/DII',
+      direction: 'left',
+      text: 'Goal calculator',
+      maxScrolls: 3,
+    });
+  });
+  test('anchored form with an explicit count', () => {
+    expect(
+      tryParseNaturalFlowLine('swipe the FII/DII left 5 times until Goal calculator is visible')
+    ).toMatchObject({ kind: 'scrollAssert', target: 'FII/DII', maxScrolls: 5 });
+  });
+  test('plain scroll-until keeps working without a target', () => {
+    const r = tryParseNaturalFlowLine('scroll down until Checkout is visible');
+    expect(r).toMatchObject({ kind: 'scrollAssert', direction: 'down', text: 'Checkout' });
+    expect(r && 'target' in r ? r.target : undefined).toBeUndefined();
+  });
+  test('swipe verb without a target parses too', () => {
+    const r = tryParseNaturalFlowLine('swipe left until Reviews is visible');
+    expect(r).toMatchObject({ kind: 'scrollAssert', direction: 'left', text: 'Reviews' });
+    expect(r && 'target' in r ? r.target : undefined).toBeUndefined();
+  });
+  test('anchored swipe WITHOUT until stays a plain swipe step', () => {
+    expect(tryParseNaturalFlowLine('swipe the FII/DII left')).toMatchObject({
+      kind: 'swipe',
+      direction: 'left',
+      target: 'FII/DII',
+    });
+  });
+});

--- a/tests/flow/natural-line.test.ts
+++ b/tests/flow/natural-line.test.ts
@@ -538,3 +538,48 @@ describe('natural-line: anchored scrollAssert', () => {
     });
   });
 });
+
+describe('natural-line: spatially-qualified scroll areas', () => {
+  test('direction-first region form: "swipe left inside the area above View All until …"', () => {
+    expect(
+      tryParseNaturalFlowLine(
+        'swipe left inside the area above View All until Goal calculator is visible'
+      )
+    ).toMatchObject({
+      kind: 'scrollAssert',
+      direction: 'left',
+      target: 'area',
+      targetProximity: { relation: 'above', anchor: 'View All' },
+      text: 'Goal calculator',
+    });
+  });
+  test('connector filler is stripped: "…the area that is located above View All…"', () => {
+    expect(
+      tryParseNaturalFlowLine(
+        'swipe left inside the area that is located above View All until Goal calculator is visible'
+      )
+    ).toMatchObject({
+      kind: 'scrollAssert',
+      target: 'area',
+      targetProximity: { relation: 'above', anchor: 'View All' },
+    });
+  });
+  test('qualified labeled target: "swipe the FII/DII below Post-Market Insights left until …"', () => {
+    expect(
+      tryParseNaturalFlowLine(
+        'swipe the FII/DII below Post-Market Insights left until Goal calculator is visible'
+      )
+    ).toMatchObject({
+      kind: 'scrollAssert',
+      direction: 'left',
+      target: 'FII/DII',
+      targetProximity: { relation: 'below', anchor: 'Post-Market Insights' },
+      text: 'Goal calculator',
+    });
+  });
+  test('unqualified anchored form still has no targetProximity', () => {
+    const r = tryParseNaturalFlowLine('swipe the FII/DII left until Goal calculator is visible');
+    expect(r).toMatchObject({ kind: 'scrollAssert', target: 'FII/DII' });
+    expect(r && 'targetProximity' in r ? r.targetProximity : undefined).toBeUndefined();
+  });
+});

--- a/tests/flow/run-instruction-proximity.test.ts
+++ b/tests/flow/run-instruction-proximity.test.ts
@@ -253,3 +253,71 @@ describe('runOneInstruction: double tap', () => {
     expect(doubleTaps()[0].args).toHaveProperty('elementUUID');
   });
 });
+
+// Anchored scroll-until-visible: a horizontal icon strip (FII/DII, Indices, …)
+// low on the screen. "Goal calculator" is off the right edge and only enters
+// the page source after two strip swipes. The gesture must be anchored at the
+// strip (the FII/DII icon's position), not the screen center — and must KEEP
+// using those coordinates even after the FII/DII icon itself scrolls away.
+describe('runOneInstruction: anchored scroll-until-visible', () => {
+  const stripXml = (icons: string[]) => `<?xml version='1.0' encoding='UTF-8' standalone='yes' ?>
+<hierarchy rotation="0">
+  <android.widget.FrameLayout class="android.widget.FrameLayout" bounds="[0,0][1080,2400]" clickable="false" enabled="true">
+    <android.widget.TextView class="android.widget.TextView" text="Post-Market Insights" clickable="false" enabled="true" bounds="[40,700][560,760]" />
+    ${icons
+      .map(
+        (label, i) =>
+          `<android.widget.TextView class="android.widget.TextView" text="${label}" clickable="true" enabled="true" bounds="[${40 + i * 210},1400][${210 + i * 210},1460]" />`
+      )
+      .join('\n    ')}
+  </android.widget.FrameLayout>
+</hierarchy>`;
+
+  function stripMcp(): MCPClient {
+    let swipes = 0;
+    return {
+      callTool: vi.fn(async (name: string, args: Record<string, unknown> = {}) => {
+        calls.push({ name, args });
+        if (name === 'appium_gesture' && (args.action === 'swipe' || args.action === 'scroll')) {
+          swipes++;
+        }
+        if (name === 'appium_get_page_source') {
+          const icons =
+            swipes >= 2
+              ? ['smallcase', 'Launchpad', 'Goal calculator']
+              : ['FII/DII', 'Indices', 'Trade Easy', 'smallcase'];
+          return { content: [{ type: 'text' as const, text: stripXml(icons) }] };
+        }
+        return { content: [{ type: 'text' as const, text: 'OK' }] };
+      }),
+      listTools: vi.fn(async () => []),
+      close: vi.fn(async () => {}),
+    } as unknown as MCPClient;
+  }
+
+  test('"swipe the FII/DII left until Goal calculator is visible" swipes at the strip', async () => {
+    const { step, result } = await runOneInstruction(
+      stripMcp(),
+      'swipe the FII/DII left until Goal calculator is visible'
+    );
+    expect(step).toMatchObject({
+      kind: 'scrollAssert',
+      target: 'FII/DII',
+      direction: 'left',
+      text: 'Goal calculator',
+    });
+    expect(result.success).toBe(true);
+    expect(result.message).toContain('Goal calculator');
+    expect(result.message).toContain('on "FII/DII"');
+
+    const swipes = calls.filter((c) => c.name === 'appium_gesture' && c.args.action === 'swipe');
+    expect(swipes).toHaveLength(2);
+    for (const s of swipes) {
+      // Anchored at the FII/DII icon center (125, 1430), finger moving left —
+      // both swipes, including the one AFTER the icon left the page source.
+      expect(s.args).toMatchObject({ x: 125, y: 1430 });
+      expect(s.args.endX as number).toBeLessThan(125 + 1);
+      expect(s.args.endY).toBe(1430);
+    }
+  }, 15000);
+});

--- a/tests/flow/run-instruction-proximity.test.ts
+++ b/tests/flow/run-instruction-proximity.test.ts
@@ -270,6 +270,7 @@ describe('runOneInstruction: anchored scroll-until-visible', () => {
           `<android.widget.TextView class="android.widget.TextView" text="${label}" clickable="true" enabled="true" bounds="[${40 + i * 210},1400][${210 + i * 210},1460]" />`
       )
       .join('\n    ')}
+    <android.widget.TextView class="android.widget.TextView" text="View All" clickable="true" enabled="true" bounds="[850,1600][1010,1650]" />
   </android.widget.FrameLayout>
 </hierarchy>`;
 
@@ -317,6 +318,33 @@ describe('runOneInstruction: anchored scroll-until-visible', () => {
       // both swipes, including the one AFTER the icon left the page source.
       expect(s.args).toMatchObject({ x: 125, y: 1430 });
       expect(s.args.endX as number).toBeLessThan(125 + 1);
+      expect(s.args.endY).toBe(1430);
+    }
+  }, 15000);
+
+  test('region form: "swipe left inside the area above View All until …" swipes at the strip', async () => {
+    // "area" is not a real element — the region is defined by the qualifier:
+    // resolve "View All", then swipe from the nearest element ABOVE it (the
+    // 'smallcase' icon at 755,1430 — inside the strip).
+    const { step, result } = await runOneInstruction(
+      stripMcp(),
+      'swipe left inside the area above View All until Goal calculator is visible'
+    );
+    expect(step).toMatchObject({
+      kind: 'scrollAssert',
+      direction: 'left',
+      target: 'area',
+      targetProximity: { relation: 'above', anchor: 'View All' },
+      text: 'Goal calculator',
+    });
+    expect(result.success).toBe(true);
+    expect(result.message).toContain('on "area above \"View All\""');
+
+    const swipes = calls.filter((c) => c.name === 'appium_gesture' && c.args.action === 'swipe');
+    expect(swipes).toHaveLength(2);
+    for (const s of swipes) {
+      expect(s.args).toMatchObject({ x: 755, y: 1430 });
+      expect(s.args.endX as number).toBeLessThan(755 + 1);
       expect(s.args.endY).toBe(1430);
     }
   }, 15000);


### PR DESCRIPTION
This pull request adds support for anchored and spatially-qualified scroll/swipe gestures, enabling more precise control when automating scrolling within carousels, strips, or specific regions of the UI. It introduces new parsing logic, schema fields, and execution behavior to handle gestures like "swipe the FII/DII left until Goal calculator is visible" or "swipe left inside the area above View All until Goal calculator is visible." Documentation and UI have been updated to describe and display these capabilities.

**Anchored and Qualified Scroll/Swipe Support**

* Parsing and Type System:
  - Extended the `FlowStep` type and schema to include optional `target` and `targetProximity` fields for `scrollAssert` steps, representing the anchor element and spatial qualifier. [[1]](diffhunk://#diff-37927d400f18249c8d39a47a880271aa86f34d8fd712f2de350297f8fda0c778R131-R143) [[2]](diffhunk://#diff-824aec1bf36b25f99a958fefb2f0c36299fa72435de3c681d71beaae32372e74R90-R108)
  - Enhanced natural language parsing to extract anchors and qualifiers from phrases like "swipe the FII/DII left until X is visible" and "swipe left inside the area above View All until X is visible."
  - Improved proximity parsing to better handle generic region nouns and trailing connectors.

* Execution and Behavior:
  - Updated scroll/swipe execution to resolve anchor coordinates based on the provided `target` and `targetProximity`, swiping from the correct location within a carousel or region. [[1]](diffhunk://#diff-c78af0efc0d69c859800abe271bbd702c1562be0da320123bd8b9da648471903R1781-R1850) [[2]](diffhunk://#diff-c78af0efc0d69c859800abe271bbd702c1562be0da320123bd8b9da648471903R1872-R1883)
  - Adjusted result messages and UI step labels to reflect anchored gestures. [[1]](diffhunk://#diff-c78af0efc0d69c859800abe271bbd702c1562be0da320123bd8b9da648471903L325-R325) [[2]](diffhunk://#diff-eb27af844e51aea7bb26e5a6cfb0dda2250459615f9138a15f56e7310292512cL99-R99)

**Documentation and Examples**

* Added new code blocks and examples to the usage documentation, illustrating anchored swipes, swiping until elements appear, and use of spatial qualifiers.
* Updated the full command reference and structured YAML examples to include the new fields and gesture forms. [[1]](diffhunk://#diff-c5d155887d229c46af04649f0ab0e7cac2c6562917ce8e8e3e600e39d13ed79aR2651-R2655) [[2]](diffhunk://#diff-c5d155887d229c46af04649f0ab0e7cac2c6562917ce8e8e3e600e39d13ed79aL2635-R2689) [[3]](diffhunk://#diff-c5d155887d229c46af04649f0ab0e7cac2c6562917ce8e8e3e600e39d13ed79aL2650-R2707)

**System Prompt and Schema**

* Clarified in the system prompt how anchored scroll/swipe gestures are mapped to the new fields, and updated the schema to describe the new parameters. [[1]](diffhunk://#diff-824aec1bf36b25f99a958fefb2f0c36299fa72435de3c681d71beaae32372e74L130-R150) [[2]](diffhunk://#diff-824aec1bf36b25f99a958fefb2f0c36299fa72435de3c681d71beaae32372e74R90-R108)

These changes collectively make scroll/swipe automation more robust, expressive, and aligned with real-world UI layouts.