### PR TITLE
feat(flow): add structured YAML selectors and property assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ You'll need **Node.js 22+**, a connected device / emulator / simulator, and an *
 ## What it can do
 
 - **Agent mode** — plain-English goals; the LLM drives the device (tap, type, swipe)
-- **YAML flows** — deterministic, zero-LLM automation
+- **YAML flows** — deterministic, zero-LLM automation with [structured selectors and state assertions](docs/structured-selectors.md)
 - **Test runner** — vitest-style specs across real devices; scaffold with `appclaw init`
 - **SDK** — drive AppClaw from your own vitest / jest / mocha
 - **Playground, cloud devices, record & replay, PRD explorer**, and more

--- a/docs/runner-architecture.md
+++ b/docs/runner-architecture.md
@@ -161,7 +161,6 @@ per-test platform/OS tags.
   "platformName": "Android",
   "appium:automationName": "UiAutomator2",
   "appium:deviceName": "Android Device",
-  "appium:settings[...]": 0,
   "appium:autoGrantPermissions": true,
   "appium:newCommandTimeout": 300,
 
@@ -181,6 +180,22 @@ instead of `systemPort`/`mjpeg`.
 Merge order (later wins): `appium-mcp defaults` < `CAPABILITIES_FILE` <
 `extraCaps` (ports + udid). Assembled in `sdk/mcp-session.ts` →
 `device/session.ts:createPlatformSession`.
+
+After an Android session is created, AppClaw calls `appium_driver_settings`
+for that session before probing the device:
+
+```json
+{
+  "actionAcknowledgmentTimeout": 0,
+  "waitForIdleTimeout": 0,
+  "waitForSelectorTimeout": 0
+}
+```
+
+These are UiAutomator2 session settings, not W3C capabilities. Applying them
+through the settings endpoint prevents dynamic pages from stalling page-source
+reads while waiting for an idle accessibility tree. If the settings update
+fails, session setup fails fast and deletes the just-created session.
 
 ---
 

--- a/docs/structured-selectors.md
+++ b/docs/structured-selectors.md
@@ -56,6 +56,18 @@ String shorthand is exact and case-insensitive. Use an explicit matcher for cont
 Action selectors must resolve to exactly one visible element. If several elements match, add an
 `index` or relation. AppClaw reports ambiguity instead of silently choosing the first match.
 
+On Android, an element with a stable `resource-id` remains selectable even when UiAutomator2
+reports `clickable=false` and exposes no `text` or `content-desc`. This pattern is common when a
+parent gesture layer handles the tap while a child container carries the ID and bounds. Structured
+tap actions use the uniquely resolved element's center coordinates, so no vision fallback is needed:
+
+```yaml
+- tap:
+    id: com.example:id/ask_ai_container
+```
+
+Empty, non-interactive Android layout nodes without a `resource-id` are still filtered out.
+
 ## Spatial and tree relations
 
 Relations accept text shorthand or a nested selector:

--- a/docs/structured-selectors.md
+++ b/docs/structured-selectors.md
@@ -1,0 +1,171 @@
+# Structured YAML selectors and assertions
+
+AppClaw YAML flows support a deterministic accessibility-tree lane alongside the existing
+natural-language and vision lanes. A structured selector never silently falls back to vision.
+This makes state checks and repeated CI runs predictable while preserving legacy flow syntax.
+
+## Actions
+
+Legacy string actions keep their existing fuzzy matching behavior:
+
+```yaml
+- tap: Login
+```
+
+Use an object to opt into exact structured matching:
+
+```yaml
+steps:
+  - tap:
+      target:
+        id: login_button
+        enabled: true
+
+  - type:
+      value: ${secrets.email}
+      into:
+        accessibilityId: email_input
+
+  - doubleTap:
+      text: Photo
+      index: 1
+
+  - longPress:
+      target:
+        accessibilityId: item_menu
+      duration: 1500
+```
+
+Structured selectors support these identity and state fields:
+
+- `text`, `id`, `accessibilityId`, `type`, `hint`, `value`
+- `enabled`, `checked`, `focused`, `selected`
+- `editable`, `clickable`, `scrollable`, `longClickable`
+- `index` (zero-based, applied after all other filters)
+
+String shorthand is exact and case-insensitive. Use an explicit matcher for contains or regex:
+
+```yaml
+- tap:
+    text:
+      value: '^Add to cart \\([0-9]+\\)$'
+      match: regex # exact | contains | regex
+      caseSensitive: false
+```
+
+Action selectors must resolve to exactly one visible element. If several elements match, add an
+`index` or relation. AppClaw reports ambiguity instead of silently choosing the first match.
+
+## Spatial and tree relations
+
+Relations accept text shorthand or a nested selector:
+
+```yaml
+- tap:
+    text: Submit
+    below:
+      id: password_input
+
+- tap:
+    accessibilityId: disclosure_icon
+    descendantOf:
+      id: account_row
+```
+
+Available relations:
+
+- Geometry: `above`, `below`, `leftOf`, `rightOf`, `near`, `within`
+- Accessibility hierarchy: `childOf`, `descendantOf`
+
+Relations can be nested to disambiguate the anchor itself.
+
+## Property and count assertions
+
+Keep target identity separate from expected state so failures can report expected and actual
+values:
+
+```yaml
+assertions:
+  - assert:
+      target:
+        id: remember_me
+      properties:
+        visible: true
+        checked: true
+        enabled: true
+
+  - assert:
+      target:
+        type: Cell
+      count:
+        gte: 1
+
+  - assert:
+      target:
+        id: checkout_card
+      properties:
+        width:
+          gte: 280
+          lte: 360
+        height:
+          equals: 180
+          tolerance: 4
+        x:
+          min: 0
+        y:
+          max: 1200
+```
+
+Property assertions support:
+
+- Presence: `exists`, `visible`
+- Content: `text`, `value`, `type`
+- State: `enabled`, `checked`, `focused`, `selected`, `editable`, `clickable`, `scrollable`,
+  `longClickable`
+- Geometry: `width`, `height`, `x`, `y`
+
+Numeric expectations accept a number or `equals`, `gte`/`lte`, `min`/`max`, and `tolerance`.
+Count assertions use the same numeric matcher.
+
+Convenience aliases are available for visibility checks:
+
+```yaml
+- assertVisible:
+    id: dashboard
+
+- assertNotVisible:
+    id: loading_spinner
+```
+
+`visible: false` passes when no matching visible node is present. `exists: false` is stricter and
+passes only when no matching node exists at all. When a platform does not expose a state such as
+`checked`, AppClaw reports it as unavailable instead of treating it as `false`.
+
+## Deterministic waits and scrolling
+
+```yaml
+- waitUntil:
+    visible:
+      id: dashboard
+    timeout: 15
+
+- waitUntil:
+    gone:
+      id: loading_spinner
+    timeout: 30
+
+- scrollAssert:
+    target:
+      id: legal_footer
+    direction: down
+    maxScrolls: 4
+```
+
+Structured waits and scroll assertions use only the current Android/iOS accessibility tree.
+Natural-language string assertions retain the existing DOM-first/vision-fallback behavior.
+
+## Reports
+
+Run manifests and HTML inspectors include the structured selector, matched count, matched element
+snapshots, expected properties/count, and individual failure reasons. Secure input values are
+masked in selector diagnostics.

--- a/openspec/changes/fix-android-structured-selector-device-stability/design.md
+++ b/openspec/changes/fix-android-structured-selector-device-stability/design.md
@@ -1,0 +1,45 @@
+# 设计：Android ID-only 节点与 session settings
+
+## 调用链
+
+### 结构化点击
+
+`appium_get_page_source` → `parseAndroidPageSource` → `resolveStructuredActionTarget` → `tapBySelector` → `appium_gesture(action=tap, x, y)`
+
+失败点位于 parser：`tapBySelector` 已支持对解析结果执行中心坐标点击，并不要求节点的 `clickable=true`。因此只需让 parser 保留可稳定寻址的 ID-only 节点，不需要改变执行器。
+
+### 页面树超时
+
+`createPlatformSession` → `appium_session_management(action=create)` → `SessionScopedMCPClient` → 页面树读取
+
+UiAutomator2 的三项等待参数是 session settings，而不是当前驱动接受的 W3C capabilities。session 创建后，使用带 sessionId 的 `appium_driver_settings(action=update)` 才能实际生效。settings 必须在 `detectScreenSize` 以及后续 page-source 调用之前写入。
+
+## 方案
+
+### Parser 纳入条件
+
+节点在 bounds 合法时，满足以下任一条件即可进入 `UIElement[]`：
+
+- 可交互：clickable / editable / long-clickable / scrollable
+- 有可读内容：text / content-desc
+- 有稳定标识：resource-id
+
+仍然过滤无标识、无内容、不可交互的纯布局节点，控制 DOM 元素量。
+
+### Android driver settings
+
+新增一个小型 helper，接收 session-scoped MCP client：
+
+1. 调用 `appium_driver_settings` 更新三项等待设置。
+2. 检查 MCP 返回文本；包含 error/failed 时抛错。
+3. 仅 Android 调用；iOS 保持现状。
+4. 本地与 cloud Android session 使用同一 helper，保证行为一致。
+
+选择 fail-fast 是因为静默降级会重新引入动态页面长时间挂起，而且当前依赖的 appium-mcp 已提供该工具。
+
+## 风险与控制
+
+- **元素数量增加**：仅增加带 `resource-id` 的节点，不纳入普通空布局节点。
+- **ID-only 节点并非自身 clickable**：结构化动作仍要求唯一且可见，点击使用其 bounds 中心；这与现有结构化坐标执行路径一致。
+- **旧版 MCP 不支持 settings 工具**：初始化明确失败并带上工具错误，避免难以定位的后续 page-source 超时。
+- **云设备差异**：Appium settings 是 session 级接口；若云厂商不支持，将在初始化阶段明确暴露，而不是产生间歇性执行失败。

--- a/openspec/changes/fix-android-structured-selector-device-stability/proposal.md
+++ b/openspec/changes/fix-android-structured-selector-device-stability/proposal.md
@@ -1,0 +1,40 @@
+# 变更提案：修复 Android 结构化选择器与页面树稳定性
+
+## 背景
+
+Android 应用的无障碍树中，部分可交互区域由父级或手势层处理点击，因此节点本身可能同时满足：
+
+- 有稳定的 `resource-id`
+- 没有 `text` / `content-desc`
+- `clickable=false`
+
+当前 Android parser 会丢弃这类节点，导致 YAML 结构化 selector 即使拿到了真实 ID，也无法解析目标。在快手首页中，底部“问 AI”入口的 `merchant_ai_container` 就属于这种节点。
+
+另外，appium-mcp 将 UiAutomator2 的 `waitForIdleTimeout`、`waitForSelectorTimeout` 等设置放进 session capabilities。当前 UiAutomator2 6.x 不识别这些 capability，动态页面上的 `getPageSource` 仍可能等待应用空闲并超时。
+
+## 目标
+
+1. Android parser 保留具有有效 `resource-id` 和有效 bounds 的节点，即使它没有文案且 `clickable=false`。
+2. 不扩大到所有无内容容器：没有 ID、没有内容、不可交互的节点仍不进入可选择元素集合。
+3. Android session 创建成功后，通过 Appium driver settings API 设置：
+   - `actionAcknowledgmentTimeout: 0`
+   - `waitForIdleTimeout: 0`
+   - `waitForSelectorTimeout: 0`
+4. settings 更新失败时终止 session 初始化，避免以“看似成功、实际仍会卡住”的配置继续执行。
+5. 用快手 Android 真机验证：从首页通过结构化 ID 点击“问 AI”，并在落地页完成结构化断言；连续执行两次以覆盖重复 page-source 读取。
+
+## 非目标
+
+- 不改变结构化 selector 的“动作必须唯一匹配”语义。
+- 不为该入口添加快手专用 selector 或坐标特例。
+- 不改变 iOS session settings。
+- 不引入 vision/LLM fallback。
+
+## 验收标准
+
+- parser 单测覆盖 ID-only、`clickable=false` 节点被保留。
+- parser 单测覆盖无 ID 的空容器仍被过滤。
+- runtime 单测证明该节点可被结构化 ID 解析并以中心坐标点击。
+- session 单测证明 Android settings 在屏幕探测前更新，iOS 不更新。
+- 类型检查、构建和相关测试通过。
+- 快手真机“首页 → 问 AI”结构化 flow 连续两次通过。

--- a/openspec/changes/fix-android-structured-selector-device-stability/specs/android-structured-automation/spec.md
+++ b/openspec/changes/fix-android-structured-selector-device-stability/specs/android-structured-automation/spec.md
@@ -1,0 +1,40 @@
+# Android 结构化自动化增量规范
+
+## ADDED Requirements
+
+### Requirement: 具有 resource-id 的 Android 节点必须可被结构化选择器观察
+
+系统 MUST（必须）把具有非空 `resource-id` 和有效 bounds 的 Android 无障碍节点暴露给结构化 selector，即使该节点没有文本、没有 content description 且声明为不可点击。
+
+#### Scenario: ID-only 容器可被点击
+
+- **GIVEN** 页面树包含一个具有唯一 `resource-id`、有效 bounds、`clickable=false` 且无文案的节点
+- **WHEN** YAML flow 使用该完整 ID 作为结构化 tap selector
+- **THEN** selector 必须唯一解析该节点
+- **AND** tap 必须落在该节点 bounds 的中心坐标
+
+#### Scenario: 纯布局节点仍被过滤
+
+- **GIVEN** 页面树包含一个没有 ID、没有文案、不可交互的布局节点
+- **WHEN** Android parser 构建可选择元素集合
+- **THEN** 该节点不得进入集合
+
+### Requirement: Android driver 等待设置必须在 session 创建后生效
+
+系统 MUST（必须）在 Android session 创建成功后、任何设备探测或页面树读取前，通过 Appium driver settings API 将 action acknowledgment、idle 和 selector wait timeout 设置为零。
+
+#### Scenario: Android session 配置成功
+
+- **WHEN** Android Appium session 创建成功
+- **THEN** 系统必须以该 sessionId 更新三项 driver settings
+- **AND** 更新完成后才可开始屏幕尺寸探测
+
+#### Scenario: settings 更新失败
+
+- **WHEN** driver settings API 返回失败
+- **THEN** session 初始化必须失败并暴露原始错误信息
+
+#### Scenario: iOS session 不受影响
+
+- **WHEN** iOS Appium session 创建成功
+- **THEN** 系统不得写入 Android 专属 driver settings

--- a/openspec/changes/fix-android-structured-selector-device-stability/tasks.md
+++ b/openspec/changes/fix-android-structured-selector-device-stability/tasks.md
@@ -1,0 +1,9 @@
+# 任务清单
+
+- [x] 记录两个真机问题、调用链和验收标准。
+- [x] 添加 Android parser 与结构化点击回归测试。
+- [x] 添加 Android session settings 回归测试。
+- [x] 实现 ID-only 节点保留与 session 后置 settings。
+- [x] 更新结构化 selector 与 runner 文档。
+- [x] 运行测试、类型检查、构建与 diff 检查。
+- [ ] 在快手 Android 真机连续执行两次“首页 → 问 AI”结构化 flow。

--- a/packages/core/src/agent-runtime/index.ts
+++ b/packages/core/src/agent-runtime/index.ts
@@ -48,8 +48,8 @@ export interface AgentElement {
   bounds: string;
   action: UIElement['action'];
   enabled: boolean;
-  checked: boolean;
-  focused: boolean;
+  checked?: boolean;
+  focused?: boolean;
   selector?: AgentSelector;
 }
 

--- a/packages/core/src/device/session.ts
+++ b/packages/core/src/device/session.ts
@@ -10,7 +10,7 @@ import { resolve } from 'node:path';
 import type { MCPClient } from '../mcp/types.js';
 import type { AppClawConfig } from '../config.js';
 import type { Platform, DeviceType } from '../sdk/types.js';
-import { extractText } from '../mcp/tools.js';
+import { extractText, isMCPError } from '../mcp/tools.js';
 import { setDeviceScreenSize, setDevicePlatform } from '../vision/window-size.js';
 import {
   extractIOSModelFromDeviceInfo,
@@ -26,6 +26,52 @@ export interface SessionResult {
   sessionId: string;
   /** Session-scoped MCP wrapper — injects sessionId into every tool call. */
   scopedMcp: MCPClient;
+}
+
+const ANDROID_DRIVER_SETTINGS = {
+  actionAcknowledgmentTimeout: 0,
+  waitForIdleTimeout: 0,
+  waitForSelectorTimeout: 0,
+} as const;
+
+/**
+ * UiAutomator2 exposes these as session settings, not capabilities. Applying
+ * them after session creation prevents dynamic apps from blocking page-source
+ * reads while waiting for a permanently busy accessibility tree to go idle.
+ */
+async function configureAndroidDriverSettings(mcp: MCPClient): Promise<void> {
+  const result = await mcp.callTool('appium_driver_settings', {
+    action: 'update',
+    settings: ANDROID_DRIVER_SETTINGS,
+  });
+  if (isMCPError(result)) {
+    throw new Error(extractText(result) || 'Failed to update Android driver settings');
+  }
+}
+
+async function configureSessionAfterCreate(
+  baseMcp: MCPClient,
+  scopedMcp: MCPClient,
+  platform: Platform,
+  sessionId: string
+): Promise<void> {
+  if (platform !== 'android') return;
+
+  try {
+    await configureAndroidDriverSettings(scopedMcp);
+  } catch (error) {
+    // The session already exists at this point. Best-effort deletion prevents
+    // a failed settings handshake from leaking UiAutomator2 ports/processes.
+    try {
+      await baseMcp.callTool('appium_session_management', {
+        action: 'delete',
+        sessionId,
+      });
+    } catch {
+      // Preserve the settings failure as the actionable root cause.
+    }
+    throw error;
+  }
 }
 
 /**
@@ -113,6 +159,7 @@ export async function createPlatformSession(
 
     // Wrap with a session-scoped client so all subsequent tool calls target this session
     const scopedMcp = new SessionScopedMCPClient(mcp, sessionId);
+    await configureSessionAfterCreate(mcp, scopedMcp, platform, sessionId);
 
     // Set platform + detect screen size via the scoped client (stores under scopedMcp in WeakMap)
     setDevicePlatform(scopedMcp, platform);
@@ -286,6 +333,7 @@ async function createCloudSession(
     const sessionId = sessionIdMatch?.[1] ?? 'session';
 
     const scopedMcp = new SessionScopedMCPClient(mcp, sessionId);
+    await configureSessionAfterCreate(mcp, scopedMcp, platform, sessionId);
     setDevicePlatform(scopedMcp, platform);
     await detectScreenSize(scopedMcp, platform);
 

--- a/packages/core/src/flow/parse-yaml-flow.ts
+++ b/packages/core/src/flow/parse-yaml-flow.ts
@@ -44,6 +44,7 @@ import type {
   PhasedStep,
   ParsedFlow,
   ParsedSuite,
+  ElementSelector,
 } from './types.js';
 import { tryParseNaturalFlowLine } from './natural-line.js';
 import { resolveNaturalStep } from './llm-parser.js';
@@ -57,8 +58,193 @@ import {
   loadInlineBindings,
   type VariableBindings,
 } from './variable-resolver.js';
+import {
+  describeElementSelector,
+  parseElementSelector,
+  parseNumericExpectation,
+  parsePropertyExpectations,
+} from './selector.js';
 
 // ── Step normalizer (unchanged logic, extracted for SRP) ───────────
+
+function structuredRecord(raw: unknown, context: string): Record<string, unknown> {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error(`${context} must be a YAML object`);
+  }
+  return raw as Record<string, unknown>;
+}
+
+function selectorWithout(
+  config: Record<string, unknown>,
+  reserved: readonly string[]
+): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(config).filter(([key]) => !reserved.includes(key)));
+}
+
+function rejectUnknownKeys(
+  config: Record<string, unknown>,
+  allowed: readonly string[],
+  context: string
+): void {
+  const allowedSet = new Set(allowed);
+  const unknown = Object.keys(config).filter((key) => !allowedSet.has(key));
+  if (unknown.length) throw new Error(`${context}: unknown key(s): ${unknown.join(', ')}`);
+}
+
+function rejectConflictingTargetKeys(config: Record<string, unknown>, context: string): void {
+  if (config.target != null && config.selector != null) {
+    throw new Error(`${context} cannot combine target and selector`);
+  }
+}
+
+function parseActionSelector(
+  raw: unknown,
+  context: string,
+  reserved: readonly string[] = []
+): ElementSelector {
+  if (typeof raw === 'string') return parseElementSelector(raw, context);
+  const config = structuredRecord(raw, context);
+  rejectConflictingTargetKeys(config, context);
+  const target = config.target ?? config.selector;
+  if (target != null) {
+    rejectUnknownKeys(config, ['target', 'selector', ...reserved], context);
+  }
+  return parseElementSelector(
+    target ?? selectorWithout(config, ['target', 'selector', ...reserved]),
+    `${context}.target`
+  );
+}
+
+function structuredTargetLabel(selector: ElementSelector): string {
+  return `selector(${describeElementSelector(selector)})`;
+}
+
+function parseWaitUntilStep(
+  raw: unknown,
+  index: number,
+  outerTimeout: unknown,
+  forceGone: boolean
+): FlowStep {
+  const context = `Step ${index + 1}: waitUntil`;
+  if (typeof raw !== 'object' || raw == null || Array.isArray(raw)) {
+    const text = String(raw).trim();
+    const timeout = Number(outerTimeout ?? 10);
+    if (!Number.isFinite(timeout) || timeout < 1) {
+      throw new Error(`${context} timeout must be a positive number`);
+    }
+    const lower = text.toLowerCase();
+    if (
+      !forceGone &&
+      ['screen loaded', 'screenloaded', 'screen ready', 'screen stable'].includes(lower)
+    ) {
+      return { kind: 'waitUntil', condition: 'screenLoaded', timeoutSeconds: timeout };
+    }
+    return {
+      kind: 'waitUntil',
+      condition: forceGone ? 'gone' : 'visible',
+      text,
+      timeoutSeconds: timeout,
+    };
+  }
+
+  const config = structuredRecord(raw, context);
+  rejectConflictingTargetKeys(config, context);
+  const explicitTargetKeys = ['target', 'selector', 'visible', 'gone', 'notVisible'].filter(
+    (key) => config[key] != null
+  );
+  if (explicitTargetKeys.length > 1) {
+    throw new Error(`${context} cannot combine ${explicitTargetKeys.join(' and ')}`);
+  }
+  if (explicitTargetKeys.length > 0) {
+    rejectUnknownKeys(
+      config,
+      ['target', 'selector', 'visible', 'gone', 'notVisible', 'condition', 'timeout'],
+      context
+    );
+  }
+  const timeout = Number(config.timeout ?? outerTimeout ?? 10);
+  if (!Number.isFinite(timeout) || timeout < 1) {
+    throw new Error(`${context} timeout must be a positive number`);
+  }
+  const conditionRaw = String(config.condition ?? (forceGone ? 'gone' : 'visible'));
+  let condition: 'visible' | 'gone' | 'screenLoaded';
+  if (conditionRaw === 'notVisible') condition = 'gone';
+  else if (['visible', 'gone', 'screenLoaded'].includes(conditionRaw)) {
+    condition = conditionRaw as typeof condition;
+  } else {
+    throw new Error(`${context}.condition must be visible, gone, notVisible, or screenLoaded`);
+  }
+  if (condition === 'screenLoaded') {
+    if (explicitTargetKeys.length > 0) {
+      throw new Error(`${context}.condition=screenLoaded cannot include a target selector`);
+    }
+    return { kind: 'waitUntil', condition, timeoutSeconds: timeout };
+  }
+
+  let selectorRaw: unknown = config.target ?? config.selector;
+  if (config.visible != null) {
+    selectorRaw = config.visible;
+    condition = 'visible';
+  } else if (config.gone != null || config.notVisible != null) {
+    selectorRaw = config.gone ?? config.notVisible;
+    condition = 'gone';
+  }
+  if (selectorRaw == null) {
+    selectorRaw = selectorWithout(config, [
+      'target',
+      'selector',
+      'visible',
+      'gone',
+      'notVisible',
+      'condition',
+      'timeout',
+    ]);
+  }
+  const selector = parseElementSelector(selectorRaw, `${context}.target`);
+  return { kind: 'waitUntil', condition, selector, timeoutSeconds: timeout };
+}
+
+function parseStructuredAssert(raw: unknown, index: number, mode: 'assert' | 'visible' | 'gone') {
+  if (typeof raw === 'string' && mode === 'assert') {
+    return { kind: 'assert', text: raw } as const;
+  }
+  const context = `Step ${index + 1}: assert`;
+  const config =
+    typeof raw === 'string' ? { target: { text: raw } } : structuredRecord(raw, context);
+  rejectConflictingTargetKeys(config, context);
+  if (config.target != null || config.selector != null) {
+    rejectUnknownKeys(config, ['target', 'selector', 'properties', 'count'], context);
+  }
+  const selectorRaw =
+    config.target ??
+    config.selector ??
+    selectorWithout(config, ['target', 'selector', 'properties', 'count']);
+  if (selectorRaw == null || Object.keys(selectorRaw as Record<string, unknown>).length === 0) {
+    throw new Error(`${context} structured form requires target or selector`);
+  }
+  const selector = parseElementSelector(selectorRaw, `${context}.target`);
+  let properties =
+    config.properties != null
+      ? parsePropertyExpectations(config.properties, `${context}.properties`)
+      : undefined;
+  if (mode !== 'assert') {
+    if (mode === 'gone' && (config.properties != null || config.count != null)) {
+      throw new Error(`${context} assertNotVisible cannot include properties or count`);
+    }
+    properties = { ...(properties ?? {}), visible: mode === 'visible' };
+  }
+  if (properties?.exists === false && Object.keys(properties).some((key) => key !== 'exists')) {
+    throw new Error(`${context}.properties.exists=false cannot be combined with other properties`);
+  }
+  const count =
+    config.count != null ? parseNumericExpectation(config.count, `${context}.count`) : undefined;
+  return {
+    kind: 'assert' as const,
+    selector,
+    ...(properties ? { properties } : {}),
+    ...(count != null ? { count } : {}),
+  };
+}
 
 export function normalizeStructured(raw: unknown, index: number): FlowStep | null {
   if (typeof raw === 'string') {
@@ -83,38 +269,33 @@ export function normalizeStructured(raw: unknown, index: number): FlowStep | nul
     if (keys.includes('waitUntil') || keys.includes('waitUntilGone')) {
       const isGone = keys.includes('waitUntilGone');
       const key = isGone ? 'waitUntilGone' : 'waitUntil';
-      const val = String(o[key]).trim();
-      const timeout = Number(o.timeout ?? 10);
-      if (!Number.isFinite(timeout) || timeout < 1) {
-        throw new Error(`Step ${index + 1}: waitUntil timeout must be a positive number`);
-      }
-      const valLower = val.toLowerCase();
-      if (
-        !isGone &&
-        (valLower === 'screen loaded' ||
-          valLower === 'screenloaded' ||
-          valLower === 'screen ready' ||
-          valLower === 'screen stable')
-      ) {
-        return { kind: 'waitUntil', condition: 'screenLoaded', timeoutSeconds: timeout };
-      }
-      return {
-        kind: 'waitUntil',
-        condition: isGone ? 'gone' : 'visible',
-        text: val,
-        timeoutSeconds: timeout,
-      };
+      return parseWaitUntilStep(o[key], index, o.timeout, isGone);
     }
 
     // ── Multi-key: zoom { scale, target? } ──
     if (keys.includes('zoom') || (keys.includes('scale') && !keys.includes('from'))) {
-      const scaleVal = o.zoom !== undefined ? Number(o.zoom) : Number(o.scale);
+      const zoomConfig =
+        o.zoom && typeof o.zoom === 'object' && !Array.isArray(o.zoom)
+          ? (o.zoom as Record<string, unknown>)
+          : keys.includes('scale')
+            ? o
+            : undefined;
+      const scaleVal = zoomConfig
+        ? Number(zoomConfig.scale ?? zoomConfig.zoom)
+        : o.zoom !== undefined
+          ? Number(o.zoom)
+          : Number(o.scale);
       if (!Number.isFinite(scaleVal) || scaleVal <= 0) {
         throw new Error(
           `Step ${index + 1}: zoom scale must be a positive number (e.g. 2.0 = zoom in 2x, 0.5 = zoom out)`
         );
       }
-      const target = o.target != null ? String(o.target).trim() : undefined;
+      const targetRaw = zoomConfig?.target ?? zoomConfig?.selector ?? o.target;
+      if (targetRaw && typeof targetRaw === 'object') {
+        const selector = parseElementSelector(targetRaw, `Step ${index + 1}: zoom.target`);
+        return { kind: 'zoom', scale: scaleVal, selector };
+      }
+      const target = targetRaw != null ? String(targetRaw).trim() : undefined;
       return { kind: 'zoom', scale: scaleVal, ...(target ? { target } : {}) };
     }
 
@@ -141,20 +322,36 @@ export function normalizeStructured(raw: unknown, index: number): FlowStep | nul
       const textKey = keys.find(
         (k) => k === 'scrollAssert' || k === 'scrollVerify' || k === 'scrollCheck'
       )!;
-      const text = String(o[textKey]);
-      const dir = String(o.direction ?? 'down').toLowerCase();
+      const rawTarget = o[textKey];
+      const config =
+        rawTarget && typeof rawTarget === 'object' && !Array.isArray(rawTarget)
+          ? (rawTarget as Record<string, unknown>)
+          : undefined;
+      const dir = String(config?.direction ?? o.direction ?? 'down').toLowerCase();
       if (!['up', 'down', 'left', 'right'].includes(dir)) {
         throw new Error(
           `Step ${index + 1}: scrollAssert direction must be up/down/left/right, got "${dir}"`
         );
       }
-      const maxScrolls = Number(o.maxScrolls ?? 3);
+      const maxScrolls = Number(config?.maxScrolls ?? o.maxScrolls ?? 3);
       if (!Number.isFinite(maxScrolls) || maxScrolls < 1) {
         throw new Error(`Step ${index + 1}: scrollAssert maxScrolls must be a positive number`);
       }
+      if (config) {
+        const selector = parseActionSelector(config, `Step ${index + 1}: scrollAssert`, [
+          'direction',
+          'maxScrolls',
+        ]);
+        return {
+          kind: 'scrollAssert',
+          selector,
+          direction: dir as 'up' | 'down' | 'left' | 'right',
+          maxScrolls,
+        };
+      }
       return {
         kind: 'scrollAssert',
-        text,
+        text: String(rawTarget),
         direction: dir as 'up' | 'down' | 'left' | 'right',
         maxScrolls,
         ...(o.target != null && o.target !== '' ? { target: String(o.target) } : {}),
@@ -206,8 +403,70 @@ export function normalizeStructured(raw: unknown, index: number): FlowStep | nul
         `Step ${index + 1}: drag requires "from to to" syntax, e.g. drag: "green dot to +100 mark"`
       );
     }
-    if (k === 'tap') return { kind: 'tap', label: String(v) };
-    if (k === 'doubleTap' || k === 'double_tap') return { kind: 'doubleTap', label: String(v) };
+    if (k === 'tap') {
+      if (v && typeof v === 'object') {
+        const selector = parseActionSelector(v, `Step ${index + 1}: tap`);
+        return { kind: 'tap', label: structuredTargetLabel(selector), selector };
+      }
+      return { kind: 'tap', label: String(v) };
+    }
+    if (k === 'doubleTap' || k === 'double_tap') {
+      if (v && typeof v === 'object') {
+        const selector = parseActionSelector(v, `Step ${index + 1}: doubleTap`);
+        return { kind: 'doubleTap', label: structuredTargetLabel(selector), selector };
+      }
+      return { kind: 'doubleTap', label: String(v) };
+    }
+    if (k === 'longPress' || k === 'long_press') {
+      if (v && typeof v === 'object') {
+        const config = structuredRecord(v, `Step ${index + 1}: longPress`);
+        const selector = parseActionSelector(config, `Step ${index + 1}: longPress`, ['duration']);
+        const duration = config.duration != null ? Number(config.duration) : undefined;
+        if (duration != null && (!Number.isFinite(duration) || duration <= 0)) {
+          throw new Error(`Step ${index + 1}: longPress.duration must be a positive number`);
+        }
+        return {
+          kind: 'longPress',
+          label: structuredTargetLabel(selector),
+          selector,
+          ...(duration != null ? { duration } : {}),
+        };
+      }
+      return { kind: 'longPress', label: String(v) };
+    }
+    if (k === 'swipe') {
+      const config = structuredRecord(v, `Step ${index + 1}: swipe`);
+      rejectUnknownKeys(
+        config,
+        ['direction', 'repeat', 'target', 'selector'],
+        `Step ${index + 1}: swipe`
+      );
+      rejectConflictingTargetKeys(config, `Step ${index + 1}: swipe`);
+      const direction = String(config.direction ?? '').toLowerCase();
+      if (!['up', 'down', 'left', 'right'].includes(direction)) {
+        throw new Error(`Step ${index + 1}: swipe.direction must be up/down/left/right`);
+      }
+      const repeat = config.repeat != null ? Number(config.repeat) : undefined;
+      if (repeat != null && (!Number.isInteger(repeat) || repeat < 1)) {
+        throw new Error(`Step ${index + 1}: swipe.repeat must be a positive integer`);
+      }
+      const targetRaw = config.target ?? config.selector;
+      if (targetRaw && typeof targetRaw === 'object') {
+        const selector = parseElementSelector(targetRaw, `Step ${index + 1}: swipe.target`);
+        return {
+          kind: 'swipe',
+          direction: direction as 'up' | 'down' | 'left' | 'right',
+          selector,
+          ...(repeat != null ? { repeat } : {}),
+        };
+      }
+      return {
+        kind: 'swipe',
+        direction: direction as 'up' | 'down' | 'left' | 'right',
+        ...(targetRaw != null ? { target: String(targetRaw) } : {}),
+        ...(repeat != null ? { repeat } : {}),
+      };
+    }
     if (k === 'zoom') {
       const scale = Number(v);
       if (!Number.isFinite(scale) || scale <= 0) {
@@ -217,9 +476,43 @@ export function normalizeStructured(raw: unknown, index: number): FlowStep | nul
       }
       return { kind: 'zoom', scale };
     }
-    if (k === 'type') return { kind: 'type', text: String(v) };
+    if (k === 'type') {
+      if (v && typeof v === 'object') {
+        const config = structuredRecord(v, `Step ${index + 1}: type`);
+        rejectUnknownKeys(
+          config,
+          ['value', 'text', 'into', 'target', 'selector'],
+          `Step ${index + 1}: type`
+        );
+        rejectConflictingTargetKeys(config, `Step ${index + 1}: type`);
+        const targetKeys = ['into', 'target', 'selector'].filter((key) => config[key] != null);
+        if (targetKeys.length > 1) {
+          throw new Error(`Step ${index + 1}: type cannot combine ${targetKeys.join(' and ')}`);
+        }
+        if (config.value != null && config.text != null) {
+          throw new Error(`Step ${index + 1}: type cannot combine value and text`);
+        }
+        const value = config.value ?? config.text;
+        if (value == null || typeof value === 'object') {
+          throw new Error(`Step ${index + 1}: type.value must be a string or scalar`);
+        }
+        const selectorRaw = config.into ?? config.target ?? config.selector;
+        if (selectorRaw != null) {
+          const selector = parseElementSelector(selectorRaw, `Step ${index + 1}: type.into`);
+          return { kind: 'type', text: String(value), selector };
+        }
+        return { kind: 'type', text: String(value) };
+      }
+      return { kind: 'type', text: String(v) };
+    }
     if (k === 'assert' || k === 'verify' || k === 'check') {
-      return { kind: 'assert', text: String(v) };
+      return parseStructuredAssert(v, index, 'assert');
+    }
+    if (k === 'assertVisible') {
+      return parseStructuredAssert(v, index, 'visible');
+    }
+    if (k === 'assertNotVisible') {
+      return parseStructuredAssert(v, index, 'gone');
     }
     if (k === 'getInfo') {
       return { kind: 'getInfo', query: String(v) };

--- a/packages/core/src/flow/run-yaml-flow.ts
+++ b/packages/core/src/flow/run-yaml-flow.ts
@@ -63,6 +63,10 @@ import type {
   PhaseResult,
   Proximity,
   ProximityRelation,
+  ElementSelector,
+  ElementPropertyExpectations,
+  NumericExpectation,
+  SelectorDiagnostics,
 } from './types.js';
 import type { AppResolver } from '../agent/app-resolver.js';
 import type { RunArtifactCollector } from '../report/writer.js';
@@ -78,6 +82,13 @@ import type { ScrollDistance } from '../sdk/types.js';
 import chalk from 'chalk';
 import * as ui from '../ui/terminal.js';
 import { resetVisionTokens, getVisionTokens } from '../vision/vision-token-tracker.js';
+import {
+  describeElementSelector,
+  evaluateStructuredAssertion,
+  resolveElementSelector,
+  snapshotElement,
+} from './selector.js';
+import { redactSensitiveData, redactSensitiveValues } from './variable-resolver.js';
 
 /** Extract [x, y] coordinates from an action result message like 'Tapped "X" via vision at [320, 540]' */
 function extractCoordinates(message?: string): { x: number; y: number } | undefined {
@@ -268,21 +279,7 @@ export interface RunYamlFlowResult {
   failedPhase?: FlowPhase;
 }
 
-/** Build the actual (non-redacted) label showing resolved values — for debug logging only. */
-function stepLabelResolved(step: FlowStep): string {
-  switch (step.kind) {
-    case 'type':
-      return `type "${step.text}"${step.target ? ` in "${step.target}"` : ''}`;
-    case 'assert':
-      return `assert "${step.text}"`;
-    case 'openApp':
-      return `open "${step.query}"`;
-    default:
-      return '';
-  }
-}
-
-function stepLabel(step: FlowStep): string {
+function rawStepLabel(step: FlowStep): string {
   if (step.verbatim) return step.verbatim;
   switch (step.kind) {
     case 'launchApp':
@@ -296,6 +293,8 @@ function stepLabel(step: FlowStep): string {
     case 'waitUntil':
       if (step.condition === 'screenLoaded')
         return `wait until screen is loaded (${step.timeoutSeconds}s timeout)`;
+      if (step.selector)
+        return `wait until selector(${describeElementSelector(step.selector)}) is ${step.condition === 'gone' ? 'gone' : 'visible'} (${step.timeoutSeconds}s timeout)`;
       if (step.condition === 'gone')
         return `wait until "${step.text}" is gone (${step.timeoutSeconds}s timeout)`;
       return `wait until "${step.text}" is visible (${step.timeoutSeconds}s timeout)`;
@@ -306,7 +305,7 @@ function stepLabel(step: FlowStep): string {
     case 'longPress':
       return `long-press "${step.label}"${step.duration != null ? ` (${step.duration}ms)` : ''}`;
     case 'type':
-      return `type "${step.text.length > 40 ? `${step.text.slice(0, 37)}…` : step.text}"`;
+      return `type "${step.sensitive ? '***' : step.text.length > 40 ? `${step.text.slice(0, 37)}…` : step.text}"${step.selector ? ` in selector(${describeElementSelector(step.selector)})` : ''}`;
     case 'enter':
       return 'enter';
     case 'back':
@@ -314,20 +313,30 @@ function stepLabel(step: FlowStep): string {
     case 'home':
       return 'goHome';
     case 'swipe':
-      return `swipe ${step.direction}`;
+      return `swipe ${step.direction}${step.selector ? ` from selector(${describeElementSelector(step.selector)})` : ''}`;
     case 'zoom':
-      return `zoom ${step.scale >= 1 ? 'in' : 'out'} (${step.scale}x)${step.target ? ` on "${step.target}"` : ''}`;
+      return `zoom ${step.scale >= 1 ? 'in' : 'out'} (${step.scale}x)${step.selector ? ` on selector(${describeElementSelector(step.selector)})` : step.target ? ` on "${step.target}"` : ''}`;
     case 'drag':
       return `drag "${step.from}" to "${step.to}"`;
     case 'assert':
-      return `assert "${step.text}"`;
+      return step.selector
+        ? `assert selector(${describeElementSelector(step.selector)})`
+        : `assert "${step.text ?? ''}"`;
     case 'scrollAssert':
-      return `scroll ${step.direction} until "${step.text}"${step.target ? ` (on "${step.target}")` : ''}`;
+      return `scroll ${step.direction} until ${
+        step.selector
+          ? `selector(${describeElementSelector(step.selector)})`
+          : `"${step.text ?? ''}"`
+      }${step.target ? ` (on "${step.target}")` : ''}`;
     case 'getInfo':
       return `getInfo "${step.query.length > 50 ? `${step.query.slice(0, 47)}…` : step.query}"`;
     case 'done':
       return step.message ? `done (${step.message})` : 'done';
   }
+}
+
+function stepLabel(step: FlowStep): string {
+  return redactSensitiveValues(rawStepLabel(step), step.sensitiveValues);
 }
 
 /**
@@ -1332,11 +1341,14 @@ async function flowTypeText(
   target?: string,
   deviceUdid?: string,
   poll: FlowTapPollOptions = { maxAttempts: 10, intervalMs: 300 },
-  proximity?: Proximity
+  proximity?: Proximity,
+  selector?: ElementSelector,
+  sensitive = false
 ): Promise<ActionResult> {
+  if (selector) return typeBySelector(mcp, text, selector, poll, deviceUdid);
   if (appclawDebug)
     ui.printAgentBullet(
-      `[type] text="${text}", target=${target ?? '(none)'}` +
+      `[type] text="${sensitive ? '***' : text}", target=${target ?? '(none)'}` +
         (proximity ? `, proximity=${proximity.relation}:"${proximity.anchor}"` : '')
     );
   // ── If a target field is specified, tap it first to focus (implicit wait) ──
@@ -1586,12 +1598,203 @@ function evaluateSpatialRelation(
 }
 
 /** Parse current page source into elements. */
-async function getScreenElements(mcp: MCPClient): Promise<UIElement[]> {
+async function getScreenElements(mcp: MCPClient, includeHidden = false): Promise<UIElement[]> {
   const pageSource = await getPageSource(mcp);
   const platform = detectPlatform(pageSource);
   return platform === 'android'
     ? parseAndroidPageSource(pageSource)
-    : parseIOSPageSource(pageSource);
+    : parseIOSPageSource(pageSource, { includeHidden });
+}
+
+function selectorDiagnostics(
+  selector: ElementSelector,
+  elements: UIElement[],
+  failures?: string[]
+): SelectorDiagnostics {
+  return {
+    selector,
+    matchedCount: elements.length,
+    // Keep reports useful but bounded on list-heavy screens.
+    matched: elements.slice(0, 20).map(snapshotElement),
+    ...(failures?.length ? { failures } : {}),
+  };
+}
+
+interface StructuredActionTarget {
+  element?: UIElement;
+  diagnostics: SelectorDiagnostics;
+  error?: string;
+}
+
+/**
+ * Resolve one deterministic action target with implicit waiting.
+ * Structured selectors never consult vision, and ambiguity is an explicit error.
+ */
+async function resolveStructuredActionTarget(
+  mcp: MCPClient,
+  selector: ElementSelector,
+  poll: FlowTapPollOptions
+): Promise<StructuredActionTarget> {
+  let lastCandidates: UIElement[] = [];
+  let lastError = `No visible element matched selector(${describeElementSelector(selector)})`;
+  for (let attempt = 0; attempt < poll.maxAttempts; attempt++) {
+    const elements = (await getScreenElements(mcp)).filter((element) => element.visible !== false);
+    const resolution = resolveElementSelector(elements, selector);
+    lastCandidates = resolution.matches;
+    if (selector.index == null && resolution.matches.length > 1) {
+      lastError =
+        `Structured selector is ambiguous: matched ${resolution.matches.length} elements; ` +
+        'add index or a relation selector';
+      return {
+        diagnostics: selectorDiagnostics(selector, resolution.matches, [lastError]),
+        error: lastError,
+      };
+    }
+    if (resolution.matches.length === 1) {
+      return {
+        element: resolution.matches[0],
+        diagnostics: selectorDiagnostics(selector, resolution.matches),
+      };
+    }
+    if (resolution.indexOutOfRange) {
+      lastError = `Selector index ${selector.index} is out of range (${resolution.allMatches.length} candidate(s))`;
+    }
+    if (attempt + 1 < poll.maxAttempts) await sleep(poll.intervalMs);
+  }
+  return {
+    diagnostics: selectorDiagnostics(selector, lastCandidates, [lastError]),
+    error: lastError,
+  };
+}
+
+async function tapBySelector(
+  mcp: MCPClient,
+  selector: ElementSelector,
+  poll: FlowTapPollOptions,
+  gesture: TapGesture = 'tap'
+): Promise<ActionResult> {
+  const target = await resolveStructuredActionTarget(mcp, selector, poll);
+  if (!target.element) {
+    return {
+      success: false,
+      message: target.error ?? 'Structured selector did not resolve',
+      selectorDiagnostics: target.diagnostics,
+    };
+  }
+  const beforeScreenshot = await capturePreAction(mcp);
+  const [x, y] = target.element.center;
+  const success = await gestureAtCoordinates(mcp, x, y, gesture);
+  return {
+    success,
+    message: success
+      ? `${gestureVerb(gesture)} selector(${describeElementSelector(selector)}) at [${x}, ${y}]`
+      : `Could not ${gesture === 'tap' ? 'tap' : 'double-tap'} selector(${describeElementSelector(selector)})`,
+    beforeScreenshot,
+    selectorDiagnostics: target.diagnostics,
+  };
+}
+
+async function longPressBySelector(
+  mcp: MCPClient,
+  selector: ElementSelector,
+  poll: FlowTapPollOptions,
+  duration = 2000
+): Promise<ActionResult> {
+  const target = await resolveStructuredActionTarget(mcp, selector, poll);
+  if (!target.element) {
+    return {
+      success: false,
+      message: target.error ?? 'Structured selector did not resolve',
+      selectorDiagnostics: target.diagnostics,
+    };
+  }
+  const [x, y] = target.element.center;
+  const result = await mcp.callTool('appium_gesture', {
+    action: 'long_press',
+    x,
+    y,
+    duration,
+  });
+  const response =
+    result.content?.map((content: any) => (content.type === 'text' ? content.text : '')).join('') ??
+    '';
+  const success =
+    !response.toLowerCase().includes('error') && !response.toLowerCase().includes('failed');
+  return {
+    success,
+    message: success
+      ? `Long-pressed selector(${describeElementSelector(selector)}) at [${x}, ${y}] (${duration}ms)`
+      : `Long-press failed: ${response.slice(0, 200)}`,
+    selectorDiagnostics: target.diagnostics,
+  };
+}
+
+async function typeBySelector(
+  mcp: MCPClient,
+  text: string,
+  selector: ElementSelector,
+  poll: FlowTapPollOptions,
+  deviceUdid?: string
+): Promise<ActionResult> {
+  const target = await resolveStructuredActionTarget(mcp, selector, poll);
+  if (!target.element) {
+    return {
+      success: false,
+      message: target.error ?? 'Structured selector did not resolve',
+      selectorDiagnostics: target.diagnostics,
+    };
+  }
+  if (!target.element.editable) {
+    const error = `Matched element is not editable (${target.element.type || 'unknown type'})`;
+    target.diagnostics.failures = [error];
+    return { success: false, message: error, selectorDiagnostics: target.diagnostics };
+  }
+  const [x, y] = target.element.center;
+  const focused = await tapAtCoordinates(mcp, x, y);
+  if (!focused) {
+    const error = 'Could not focus structured selector target';
+    target.diagnostics.failures = [error];
+    return { success: false, message: error, selectorDiagnostics: target.diagnostics };
+  }
+  await sleep(Config.CLOUD_PROVIDER ? 1200 : 300);
+  let typed = await typeViaSetValue(mcp, text);
+  if (!typed.success && target.element.platform === 'android') {
+    typed = await typeViaKeyboard(text, deviceUdid);
+  }
+  return {
+    success: typed.success,
+    message: typed.success
+      ? `Typed "${text}" in selector(${describeElementSelector(selector)}) at [${x}, ${y}]`
+      : typed.message,
+    selectorDiagnostics: target.diagnostics,
+  };
+}
+
+async function assertStructuredSelector(
+  mcp: MCPClient,
+  selector: ElementSelector,
+  properties: ElementPropertyExpectations | undefined,
+  count: NumericExpectation | undefined,
+  poll: FlowTapPollOptions
+): Promise<ActionResult> {
+  let last = evaluateStructuredAssertion([], selector, properties, count);
+  for (let attempt = 0; attempt < poll.maxAttempts; attempt++) {
+    const elements = await getScreenElements(mcp, true);
+    last = evaluateStructuredAssertion(elements, selector, properties, count);
+    if (last.success) {
+      return {
+        success: true,
+        message: last.message,
+        selectorDiagnostics: last.diagnostics,
+      };
+    }
+    if (attempt + 1 < poll.maxAttempts) await sleep(poll.intervalMs);
+  }
+  return {
+    success: false,
+    message: last.message,
+    selectorDiagnostics: last.diagnostics,
+  };
 }
 
 const ASSERT_DOM_POLLS_BEFORE_VISION = 3;
@@ -1708,10 +1911,11 @@ async function visionAssert(mcp: MCPClient, text: string): Promise<boolean> {
 async function assertTextVisible(
   mcp: MCPClient,
   text: string,
-  poll: FlowTapPollOptions
+  poll: FlowTapPollOptions,
+  allowVision = true
 ): Promise<ActionResult> {
-  const visionFirst = isVisionMode();
-  const useVision = isVisionLocateEnabled();
+  const visionFirst = allowVision && isVisionMode();
+  const useVision = allowVision && isVisionLocateEnabled();
   let lastElements: UIElement[] = [];
 
   // ── Check for spatial/relational assertions (e.g. "Jest is below Jasmine") ──
@@ -1813,13 +2017,14 @@ async function resolveScrollAnchorCenter(
 
 async function scrollUntilVisible(
   mcp: MCPClient,
-  text: string,
+  text: string | undefined,
   direction: 'up' | 'down' | 'left' | 'right',
   maxScrolls: number,
   poll: FlowTapPollOptions,
   distance?: ScrollDistance,
   target?: string,
-  targetProximity?: Proximity
+  targetProximity?: Proximity,
+  selector?: ElementSelector
 ): Promise<ActionResult> {
   const visionFirst = isVisionMode();
   const useVision = isVisionLocateEnabled();
@@ -1849,7 +2054,16 @@ async function scrollUntilVisible(
     anchorCoords && (direction === 'left' || direction === 'right') ? 'swipe' : 'scroll';
 
   // Helper: check if text is currently visible on screen
+  let selectorMatches: UIElement[] = [];
   const isVisible = async (): Promise<boolean> => {
+    if (selector) {
+      const elements = await getScreenElements(mcp);
+      selectorMatches = resolveElementSelector(elements, selector).matches.filter(
+        (element) => element.visible !== false
+      );
+      return selectorMatches.length > 0;
+    }
+    if (!text) return false;
     if (visionFirst) {
       return visionAssert(mcp, text);
     }
@@ -1865,7 +2079,10 @@ async function scrollUntilVisible(
   if (await isVisible()) {
     return {
       success: true,
-      message: `"${text}" already visible on screen (no scroll needed)`,
+      message: selector
+        ? `selector(${describeElementSelector(selector)}) already visible on screen (no scroll needed)`
+        : `"${text}" already visible on screen (no scroll needed)`,
+      ...(selector ? { selectorDiagnostics: selectorDiagnostics(selector, selectorMatches) } : {}),
     };
   }
 
@@ -1880,7 +2097,12 @@ async function scrollUntilVisible(
     if (await isVisible()) {
       return {
         success: true,
-        message: `Found "${text}" after ${scroll + 1} scroll(s) ${direction}${onNote}`,
+        message: selector
+          ? `Found selector(${describeElementSelector(selector)}) after ${scroll + 1} scroll(s) ${direction}${onNote}`
+          : `Found "${text}" after ${scroll + 1} scroll(s) ${direction}${onNote}`,
+        ...(selector
+          ? { selectorDiagnostics: selectorDiagnostics(selector, selectorMatches) }
+          : {}),
       };
     }
   }
@@ -1898,9 +2120,15 @@ async function scrollUntilVisible(
     /* ignore */
   }
 
+  const failure = selector
+    ? `selector(${describeElementSelector(selector)}) not found after ${maxScrolls} scroll(s) ${direction}${onNote}`
+    : `"${text}" not found after ${maxScrolls} scroll(s) ${direction}${onNote}${screenSummary}`;
   return {
     success: false,
-    message: `"${text}" not found after ${maxScrolls} scroll(s) ${direction}${onNote}${screenSummary}`,
+    message: failure,
+    ...(selector
+      ? { selectorDiagnostics: selectorDiagnostics(selector, selectorMatches, [failure]) }
+      : {}),
   };
 }
 
@@ -1913,7 +2141,8 @@ async function waitUntilCondition(
   condition: 'visible' | 'gone' | 'screenLoaded',
   text: string | undefined,
   timeoutSeconds: number,
-  poll: FlowTapPollOptions
+  poll: FlowTapPollOptions,
+  selector?: ElementSelector
 ): Promise<ActionResult> {
   const pollMs = 500;
   const deadline = Date.now() + timeoutSeconds * 1000;
@@ -1959,6 +2188,39 @@ async function waitUntilCondition(
     return { success: false, message: `Screen did not stabilize within ${timeoutSeconds}s` };
   }
 
+  if (selector) {
+    let lastMatches: UIElement[] = [];
+    while (Date.now() < deadline) {
+      const elements = await getScreenElements(mcp);
+      const resolution = resolveElementSelector(elements, selector);
+      lastMatches = resolution.matches.filter((element) => element.visible !== false);
+      if (condition === 'visible' && lastMatches.length > 0) {
+        return {
+          success: true,
+          message: `selector(${describeElementSelector(selector)}) appeared on screen`,
+          selectorDiagnostics: selectorDiagnostics(selector, lastMatches),
+        };
+      }
+      if (condition === 'gone' && lastMatches.length === 0) {
+        return {
+          success: true,
+          message: `selector(${describeElementSelector(selector)}) is no longer on screen`,
+          selectorDiagnostics: selectorDiagnostics(selector, []),
+        };
+      }
+      await sleep(pollMs);
+    }
+    const failure =
+      condition === 'visible'
+        ? `selector(${describeElementSelector(selector)}) did not appear within ${timeoutSeconds}s`
+        : `selector(${describeElementSelector(selector)}) did not disappear within ${timeoutSeconds}s`;
+    return {
+      success: false,
+      message: failure,
+      selectorDiagnostics: selectorDiagnostics(selector, lastMatches, [failure]),
+    };
+  }
+
   if (!text) {
     return { success: false, message: `waitUntil "${condition}" requires a text/element target` };
   }
@@ -1995,7 +2257,7 @@ async function waitUntilCondition(
   return { success: false, message: `"${text}" did not disappear within ${timeoutSeconds}s` };
 }
 
-export async function executeStep(
+async function executeStepUnredacted(
   mcp: MCPClient,
   step: FlowStep,
   meta: FlowMeta,
@@ -2010,6 +2272,9 @@ export async function executeStep(
   if (
     isVisionMode() &&
     step.verbatim &&
+    // Secret-bearing type steps stay on the focused-field + local keyboard path;
+    // never put resolved credentials into a vision instruction.
+    !step.sensitive &&
     (step.kind === 'tap' || step.kind === 'type' || step.kind === 'assert')
   ) {
     const { visionExecute } = await import('./vision-execute.js');
@@ -2137,15 +2402,38 @@ export async function executeStep(
       await sleep(Math.round(step.seconds * 1000));
       return { success: true, message: `Waited ${step.seconds}s` };
     case 'waitUntil':
-      return waitUntilCondition(mcp, step.condition, step.text, step.timeoutSeconds, tapPoll);
+      return waitUntilCondition(
+        mcp,
+        step.condition,
+        step.text,
+        step.timeoutSeconds,
+        tapPoll,
+        step.selector
+      );
     case 'tap':
-      return tapByLabel(mcp, step.label, tapPoll, step.proximity);
+      return step.selector
+        ? tapBySelector(mcp, step.selector, tapPoll)
+        : tapByLabel(mcp, step.label, tapPoll, step.proximity);
     case 'doubleTap':
-      return tapByLabel(mcp, step.label, tapPoll, step.proximity, 'double_tap');
+      return step.selector
+        ? tapBySelector(mcp, step.selector, tapPoll, 'double_tap')
+        : tapByLabel(mcp, step.label, tapPoll, step.proximity, 'double_tap');
     case 'longPress':
-      return longPressByLabel(mcp, step.label, step.duration);
-    case 'type':
-      return flowTypeText(mcp, step.text, step.target, deviceUdid, tapPoll, step.proximity);
+      return step.selector
+        ? longPressBySelector(mcp, step.selector, tapPoll, step.duration)
+        : longPressByLabel(mcp, step.label, step.duration);
+    case 'type': {
+      return flowTypeText(
+        mcp,
+        step.text,
+        step.target,
+        deviceUdid,
+        tapPoll,
+        step.proximity,
+        step.selector,
+        step.sensitive
+      );
+    }
     case 'enter':
       return pressEnterKey(mcp);
     case 'back':
@@ -2164,7 +2452,19 @@ export async function executeStep(
       // screen-center swipe if the element can't be located.
       let anchorCoords: { x: number; y: number; endX: number; endY: number } | null = null;
       let anchored = false;
-      if (step.target) {
+      if (step.selector) {
+        const resolved = await resolveStructuredActionTarget(mcp, step.selector, tapPoll);
+        if (!resolved.element) {
+          return {
+            success: false,
+            message: resolved.error ?? 'Structured swipe target did not resolve',
+            selectorDiagnostics: resolved.diagnostics,
+          };
+        }
+        const center = resolved.element.center;
+        anchorCoords = anchoredSwipeCoords(mcp, center, dir, scroll?.distance);
+        anchored = true;
+      } else if (step.target) {
         const center = await resolveTargetCenter(mcp, step.target);
         if (center) {
           anchorCoords = anchoredSwipeCoords(mcp, center, dir, scroll?.distance);
@@ -2211,6 +2511,38 @@ export async function executeStep(
       // Vision mode: use df-vision to locate the element by description.
       // DOM mode: parse page source and find element UUID.
       let elementUUID: string | undefined;
+      if (step.selector) {
+        const resolved = await resolveStructuredActionTarget(mcp, step.selector, tapPoll);
+        if (!resolved.element) {
+          return {
+            success: false,
+            message: resolved.error ?? 'Structured zoom target did not resolve',
+            selectorDiagnostics: resolved.diagnostics,
+          };
+        }
+        const [x, y] = resolved.element.center;
+        const pinchResult = await mcp.callTool('appium_gesture', {
+          action: 'pinch_zoom',
+          scale: step.scale,
+          x,
+          y,
+        });
+        const pinchText =
+          pinchResult.content
+            ?.map((content: { type: string; text?: string }) =>
+              content.type === 'text' ? content.text : ''
+            )
+            .join('') ?? '';
+        const failed =
+          pinchText.toLowerCase().includes('failed') || pinchText.toLowerCase().includes('error');
+        return {
+          success: !failed,
+          message: failed
+            ? pinchText.slice(0, 200)
+            : `Zoomed ${step.scale >= 1 ? 'in' : 'out'} on selector(${describeElementSelector(step.selector)}) at [${x}, ${y}]`,
+          selectorDiagnostics: resolved.diagnostics,
+        };
+      }
       if (step.target) {
         try {
           if (isVisionMode() || isVisionLocateEnabled()) {
@@ -2377,7 +2709,9 @@ export async function executeStep(
       };
     }
     case 'assert':
-      return assertTextVisible(mcp, step.text, tapPoll);
+      return step.selector
+        ? assertStructuredSelector(mcp, step.selector, step.properties, step.count, tapPoll)
+        : assertTextVisible(mcp, step.text ?? '', tapPoll, !step.sensitive);
     case 'scrollAssert':
       return scrollUntilVisible(
         mcp,
@@ -2387,7 +2721,8 @@ export async function executeStep(
         tapPoll,
         scroll?.distance,
         step.target,
-        step.targetProximity
+        step.targetProximity,
+        step.selector
       );
     case 'getInfo': {
       const infoApiKey = getStarkVisionApiKey();
@@ -2437,6 +2772,35 @@ export async function executeStep(
   }
 }
 
+/** Execute one step while ensuring resolved secrets cannot reach logs or reports. */
+export async function executeStep(
+  mcp: MCPClient,
+  step: FlowStep,
+  meta: FlowMeta,
+  appResolver: AppResolver | undefined,
+  tapPoll: FlowTapPollOptions,
+  deviceUdid?: string,
+  scroll?: ScrollControl
+): Promise<ActionResult> {
+  const result = await executeStepUnredacted(
+    mcp,
+    step,
+    meta,
+    appResolver,
+    tapPoll,
+    deviceUdid,
+    scroll
+  );
+  if (!step.sensitiveValues?.length) return result;
+  // Screenshot payloads are base64/binary-like and cannot contain the plain
+  // resolved value; keep them out of the recursive string-redaction pass.
+  const { beforeScreenshot, ...redactable } = result;
+  return {
+    ...redactSensitiveData(redactable, step.sensitiveValues),
+    ...(beforeScreenshot ? { beforeScreenshot } : {}),
+  };
+}
+
 /**
  * Execute a single phase (setup / test / assertion) and return its result.
  * Extracted for SRP: the runner orchestrates phases, this handles one.
@@ -2469,10 +2833,9 @@ async function executePhase(
     const label = stepLabel(step);
     const globalN = globalStepOffset + i + 1;
 
-    // Debug: show resolved value when secrets are redacted
+    // Confirm interpolation in debug mode without ever printing resolved secrets.
     if (appclawDebug && step.verbatim?.includes('***')) {
-      const resolved = stepLabelResolved(step);
-      if (resolved) ui.printAgentBullet(`[debug] resolved → ${resolved}`);
+      ui.printAgentBullet('[debug] secret placeholders resolved (values redacted)');
     }
 
     const globalIdx = globalStepOffset + i;
@@ -2534,6 +2897,7 @@ async function executePhase(
         message: result.message,
         tapCoordinates: tapCoords,
         deviceScreenSize: getCachedScreenSize(mcp) ?? undefined,
+        selectorDiagnostics: result.selectorDiagnostics,
       });
       // In vision mode, visionExecute already captured the pre-action screenshot.
       // - Tap actions: attach as "before" so the tap dot overlay is rendered.
@@ -2702,8 +3066,7 @@ export async function runYamlFlow(
     const n = i + 1;
 
     if (appclawDebug && step.verbatim?.includes('***')) {
-      const resolved = stepLabelResolved(step);
-      if (resolved) ui.printAgentBullet(`[debug] resolved → ${resolved}`);
+      ui.printAgentBullet('[debug] secret placeholders resolved (values redacted)');
     }
 
     options.artifactCollector?.startStep(i);
@@ -2764,6 +3127,7 @@ export async function runYamlFlow(
         message: result.message,
         tapCoordinates: tapCoords,
         deviceScreenSize: getCachedScreenSize(mcp) ?? undefined,
+        selectorDiagnostics: result.selectorDiagnostics,
       });
       // In vision mode, visionExecute already captured the pre-action screenshot.
       // - Tap actions: attach as "before" so the tap dot overlay is rendered.

--- a/packages/core/src/flow/selector.ts
+++ b/packages/core/src/flow/selector.ts
@@ -1,0 +1,580 @@
+import type { UIElement } from '../perception/types.js';
+import type {
+  ElementPropertyExpectations,
+  ElementSelector,
+  MatchedElementSnapshot,
+  NumericExpectation,
+  NumericMatcher,
+  SelectorDiagnostics,
+  SelectorReference,
+  StringMatcher,
+  StringSelector,
+} from './types.js';
+
+const STRING_FIELDS = ['text', 'id', 'accessibilityId', 'type', 'hint', 'value'] as const;
+const BOOLEAN_FIELDS = [
+  'enabled',
+  'checked',
+  'focused',
+  'selected',
+  'editable',
+  'clickable',
+  'scrollable',
+  'longClickable',
+] as const;
+const RELATION_FIELDS = [
+  'above',
+  'below',
+  'leftOf',
+  'rightOf',
+  'near',
+  'within',
+  'childOf',
+  'descendantOf',
+] as const;
+
+const SELECTOR_KEYS = new Set<string>([
+  ...STRING_FIELDS,
+  ...BOOLEAN_FIELDS,
+  ...RELATION_FIELDS,
+  'index',
+]);
+const PROPERTY_KEYS = new Set<string>([
+  'exists',
+  'visible',
+  'text',
+  'value',
+  'type',
+  ...BOOLEAN_FIELDS,
+  'width',
+  'height',
+  'x',
+  'y',
+]);
+
+function objectValue(raw: unknown, context: string): Record<string, unknown> {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error(`${context} must be a YAML object`);
+  }
+  return raw as Record<string, unknown>;
+}
+
+function parseStringSelector(raw: unknown, context: string): StringSelector {
+  if (typeof raw === 'string') return raw;
+  const obj = objectValue(raw, context);
+  const unknown = Object.keys(obj).filter(
+    (key) => !['value', 'match', 'caseSensitive'].includes(key)
+  );
+  if (unknown.length) throw new Error(`${context}: unknown key(s): ${unknown.join(', ')}`);
+  if (typeof obj.value !== 'string') throw new Error(`${context}.value must be a string`);
+  const match = obj.match ?? 'exact';
+  if (!['exact', 'contains', 'regex'].includes(String(match))) {
+    throw new Error(`${context}.match must be exact, contains, or regex`);
+  }
+  if (obj.caseSensitive != null && typeof obj.caseSensitive !== 'boolean') {
+    throw new Error(`${context}.caseSensitive must be true or false`);
+  }
+  if (match === 'regex') {
+    try {
+      new RegExp(obj.value, obj.caseSensitive ? '' : 'i');
+    } catch (error) {
+      throw new Error(
+        `${context}.value is not a valid regular expression: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+  return {
+    value: obj.value,
+    match: match as StringMatcher['match'],
+    ...(obj.caseSensitive != null ? { caseSensitive: obj.caseSensitive } : {}),
+  };
+}
+
+export function parseNumericExpectation(raw: unknown, context: string): NumericExpectation {
+  if (typeof raw === 'number' && Number.isFinite(raw)) return raw;
+  const obj = objectValue(raw, context);
+  const allowed = new Set(['equals', 'gte', 'lte', 'min', 'max', 'tolerance']);
+  const unknown = Object.keys(obj).filter((key) => !allowed.has(key));
+  if (unknown.length) throw new Error(`${context}: unknown key(s): ${unknown.join(', ')}`);
+  const parsed: NumericMatcher = {};
+  for (const key of allowed) {
+    const value = obj[key];
+    if (value == null) continue;
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+      throw new Error(`${context}.${key} must be a finite number`);
+    }
+    parsed[key as keyof NumericMatcher] = value;
+  }
+  if (Object.keys(parsed).length === 0) {
+    throw new Error(`${context} needs equals, gte/lte, or min/max`);
+  }
+  if (
+    parsed.equals == null &&
+    parsed.gte == null &&
+    parsed.lte == null &&
+    parsed.min == null &&
+    parsed.max == null
+  ) {
+    throw new Error(`${context}.tolerance requires equals`);
+  }
+  if (parsed.gte != null && parsed.min != null) {
+    throw new Error(`${context} cannot combine gte and min`);
+  }
+  if (parsed.lte != null && parsed.max != null) {
+    throw new Error(`${context} cannot combine lte and max`);
+  }
+  if (parsed.tolerance != null && parsed.tolerance < 0) {
+    throw new Error(`${context}.tolerance must be non-negative`);
+  }
+  return parsed;
+}
+
+/** Parse and strictly validate a structured selector from YAML. */
+export function parseElementSelector(raw: unknown, context: string): ElementSelector {
+  if (typeof raw === 'string') return { text: raw };
+  const obj = objectValue(raw, context);
+  const unknown = Object.keys(obj).filter((key) => !SELECTOR_KEYS.has(key));
+  if (unknown.length) throw new Error(`${context}: unknown selector key(s): ${unknown.join(', ')}`);
+  if (Object.keys(obj).length === 0) throw new Error(`${context} must not be empty`);
+
+  const selector: ElementSelector = {};
+  for (const key of STRING_FIELDS) {
+    if (obj[key] != null) selector[key] = parseStringSelector(obj[key], `${context}.${key}`);
+  }
+  for (const key of BOOLEAN_FIELDS) {
+    if (obj[key] == null) continue;
+    if (typeof obj[key] !== 'boolean') throw new Error(`${context}.${key} must be true or false`);
+    selector[key] = obj[key] as never;
+  }
+  if (obj.index != null) {
+    if (!Number.isInteger(obj.index) || Number(obj.index) < 0) {
+      throw new Error(`${context}.index must be a non-negative integer`);
+    }
+    selector.index = Number(obj.index);
+  }
+  for (const key of RELATION_FIELDS) {
+    if (obj[key] == null) continue;
+    selector[key] =
+      typeof obj[key] === 'string'
+        ? String(obj[key])
+        : parseElementSelector(obj[key], `${context}.${key}`);
+  }
+  return selector;
+}
+
+/** Parse properties used by a structured assert step. */
+export function parsePropertyExpectations(
+  raw: unknown,
+  context: string
+): ElementPropertyExpectations {
+  const obj = objectValue(raw, context);
+  const unknown = Object.keys(obj).filter((key) => !PROPERTY_KEYS.has(key));
+  if (unknown.length) throw new Error(`${context}: unknown property key(s): ${unknown.join(', ')}`);
+  const result: ElementPropertyExpectations = {};
+  for (const key of ['exists', 'visible', ...BOOLEAN_FIELDS] as const) {
+    if (obj[key] == null) continue;
+    if (typeof obj[key] !== 'boolean') throw new Error(`${context}.${key} must be true or false`);
+    result[key] = obj[key] as never;
+  }
+  for (const key of ['text', 'value', 'type'] as const) {
+    if (obj[key] != null) result[key] = parseStringSelector(obj[key], `${context}.${key}`);
+  }
+  for (const key of ['width', 'height', 'x', 'y'] as const) {
+    if (obj[key] != null) result[key] = parseNumericExpectation(obj[key], `${context}.${key}`);
+  }
+  if (Object.keys(result).length === 0) throw new Error(`${context} must not be empty`);
+  if (result.exists === false && Object.keys(result).some((key) => key !== 'exists')) {
+    throw new Error(`${context}.exists=false cannot be combined with other property expectations`);
+  }
+  return result;
+}
+
+export function isStructuredSelectorObject(raw: unknown): boolean {
+  return !!raw && typeof raw === 'object' && !Array.isArray(raw);
+}
+
+function matcherParts(expected: StringSelector): Required<StringMatcher> {
+  if (typeof expected === 'string') {
+    return { value: expected, match: 'exact', caseSensitive: false };
+  }
+  return {
+    value: expected.value,
+    match: expected.match ?? 'exact',
+    caseSensitive: expected.caseSensitive ?? false,
+  };
+}
+
+export function matchesString(actual: string | undefined, expected: StringSelector): boolean {
+  if (actual == null) return false;
+  const matcher = matcherParts(expected);
+  const lhs = matcher.caseSensitive ? actual : actual.toLowerCase();
+  const rhs = matcher.caseSensitive ? matcher.value : matcher.value.toLowerCase();
+  if (matcher.match === 'exact') return lhs === rhs;
+  if (matcher.match === 'contains') return lhs.includes(rhs);
+  return new RegExp(matcher.value, matcher.caseSensitive ? '' : 'i').test(actual);
+}
+
+export function matchesNumber(actual: number, expected: NumericExpectation): boolean {
+  if (typeof expected === 'number') return actual === expected;
+  const tolerance = expected.tolerance ?? 0;
+  if (expected.equals != null && Math.abs(actual - expected.equals) > tolerance) return false;
+  const lower = expected.gte ?? expected.min;
+  const upper = expected.lte ?? expected.max;
+  if (lower != null && actual < lower) return false;
+  if (upper != null && actual > upper) return false;
+  return true;
+}
+
+interface Rect {
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+}
+
+function rectOf(el: UIElement): Rect {
+  const [x, y] = el.center;
+  const [width, height] = el.size;
+  return {
+    left: x - width / 2,
+    right: x + width / 2,
+    top: y - height / 2,
+    bottom: y + height / 2,
+  };
+}
+
+function bboxDistance(a: Rect, b: Rect): number {
+  return (
+    Math.abs(a.left - b.left) +
+    Math.abs(a.right - b.right) +
+    Math.abs(a.top - b.top) +
+    Math.abs(a.bottom - b.bottom)
+  );
+}
+
+function referenceSelector(reference: SelectorReference): ElementSelector {
+  return typeof reference === 'string' ? { text: reference } : reference;
+}
+
+function baseMatches(el: UIElement, selector: ElementSelector): boolean {
+  for (const key of STRING_FIELDS) {
+    const expected = selector[key];
+    if (expected != null && !matchesString(el[key], expected)) return false;
+  }
+  for (const key of BOOLEAN_FIELDS) {
+    const expected = selector[key];
+    if (expected == null) continue;
+    const actual = el[key];
+    // An unavailable state must not be confused with an explicit false.
+    if (actual == null || actual !== expected) return false;
+  }
+  return true;
+}
+
+function sortByAnchorDistance(candidates: UIElement[], anchors: UIElement[]): UIElement[] {
+  return [...candidates].sort((a, b) => {
+    const ar = rectOf(a);
+    const br = rectOf(b);
+    const ad = Math.min(...anchors.map((anchor) => bboxDistance(ar, rectOf(anchor))));
+    const bd = Math.min(...anchors.map((anchor) => bboxDistance(br, rectOf(anchor))));
+    return ad - bd;
+  });
+}
+
+function geometricMatch(
+  candidate: UIElement,
+  anchor: UIElement,
+  relation: string,
+  tol = 0
+): boolean {
+  if (candidate === anchor) return false;
+  const c = rectOf(candidate);
+  const a = rectOf(anchor);
+  if (candidate.treeId && candidate.treeId === anchor.treeId) return false;
+  switch (relation) {
+    case 'above':
+      return c.bottom <= a.top;
+    case 'below':
+      return c.top >= a.bottom;
+    case 'leftOf':
+      return c.right <= a.left;
+    case 'rightOf':
+      return c.left >= a.right;
+    case 'within':
+      return c.left >= a.left && c.right <= a.right && c.top >= a.top && c.bottom <= a.bottom;
+    case 'near':
+      return (
+        c.left <= a.right + tol &&
+        c.right >= a.left - tol &&
+        c.top <= a.bottom + tol &&
+        c.bottom >= a.top - tol
+      );
+    default:
+      return false;
+  }
+}
+
+function applyRelation(
+  elements: UIElement[],
+  candidates: UIElement[],
+  relation: (typeof RELATION_FIELDS)[number],
+  reference: SelectorReference,
+  depth: number
+): UIElement[] {
+  const anchorResolution = resolveElementSelector(
+    elements,
+    referenceSelector(reference),
+    depth + 1
+  );
+  const anchors = anchorResolution.matches;
+  if (anchors.length === 0) return [];
+
+  if (relation === 'childOf') {
+    const ids = new Set(anchors.map((anchor) => anchor.treeId).filter(Boolean));
+    return candidates.filter(
+      (candidate) => !!candidate.parentTreeId && ids.has(candidate.parentTreeId)
+    );
+  }
+  if (relation === 'descendantOf') {
+    const ids = new Set(anchors.map((anchor) => anchor.treeId).filter(Boolean));
+    return candidates.filter((candidate) =>
+      (candidate.ancestorTreeIds ?? []).some((id) => ids.has(id))
+    );
+  }
+
+  if (relation === 'near') {
+    let scale = 1;
+    for (let attempt = 0; attempt < 6; attempt++) {
+      const hits = candidates.filter((candidate) =>
+        anchors.some((anchor) => {
+          const [width, height] = anchor.size;
+          return geometricMatch(candidate, anchor, relation, Math.max(width, height, 1) * scale);
+        })
+      );
+      if (hits.length > 0) return sortByAnchorDistance(hits, anchors);
+      scale *= 1.6;
+    }
+    return [];
+  }
+
+  const hits = candidates.filter((candidate) =>
+    anchors.some((anchor) => geometricMatch(candidate, anchor, relation))
+  );
+  return sortByAnchorDistance(hits, anchors);
+}
+
+export interface SelectorResolution {
+  /** Matches before applying index. Useful for ambiguity/count diagnostics. */
+  allMatches: UIElement[];
+  /** Final matches after applying index. */
+  matches: UIElement[];
+  indexOutOfRange: boolean;
+}
+
+/** Resolve a structured selector without using vision or fuzzy label scoring. */
+export function resolveElementSelector(
+  elements: UIElement[],
+  selector: ElementSelector,
+  depth = 0
+): SelectorResolution {
+  if (depth > 12) throw new Error('Structured selector relation nesting exceeds 12 levels');
+  let candidates = elements.filter((element) => baseMatches(element, selector));
+  for (const relation of RELATION_FIELDS) {
+    const reference = selector[relation];
+    if (reference != null) {
+      candidates = applyRelation(elements, candidates, relation, reference, depth);
+    }
+  }
+  if (selector.index == null) {
+    return { allMatches: candidates, matches: candidates, indexOutOfRange: false };
+  }
+  const selected = candidates[selector.index];
+  return {
+    allMatches: candidates,
+    matches: selected ? [selected] : [],
+    indexOutOfRange: !selected,
+  };
+}
+
+function printableStringSelector(value: StringSelector): string {
+  if (typeof value === 'string') return JSON.stringify(value);
+  const suffix = value.match && value.match !== 'exact' ? `/${value.match}` : '';
+  return `${JSON.stringify(value.value)}${suffix}`;
+}
+
+/** Compact, stable description for terminal output and report step labels. */
+export function describeElementSelector(selector: ElementSelector): string {
+  const parts: string[] = [];
+  for (const key of STRING_FIELDS) {
+    if (selector[key] != null) parts.push(`${key}=${printableStringSelector(selector[key]!)}`);
+  }
+  for (const key of BOOLEAN_FIELDS) {
+    if (selector[key] != null) parts.push(`${key}=${selector[key]}`);
+  }
+  if (selector.index != null) parts.push(`index=${selector.index}`);
+  for (const key of RELATION_FIELDS) {
+    const value = selector[key];
+    if (value == null) continue;
+    parts.push(
+      `${key}=(${typeof value === 'string' ? `text=${JSON.stringify(value)}` : describeElementSelector(value)})`
+    );
+  }
+  return parts.join(', ');
+}
+
+export function snapshotElement(element: UIElement): MatchedElementSnapshot {
+  return {
+    text: element.text,
+    id: element.id,
+    accessibilityId: element.accessibilityId,
+    type: element.type,
+    ...(element.value != null ? { value: element.password ? '***' : element.value } : {}),
+    bounds: element.bounds,
+    center: element.center,
+    size: element.size,
+    enabled: element.enabled,
+    ...(element.checked != null ? { checked: element.checked } : {}),
+    ...(element.focused != null ? { focused: element.focused } : {}),
+    ...(element.selected != null ? { selected: element.selected } : {}),
+    editable: element.editable,
+    clickable: element.clickable,
+    ...(element.visible != null ? { visible: element.visible } : {}),
+  };
+}
+
+function expectedLabel(expected: unknown): string {
+  return typeof expected === 'string' ? JSON.stringify(expected) : JSON.stringify(expected);
+}
+
+function actualFor(element: UIElement, key: keyof ElementPropertyExpectations): unknown {
+  switch (key) {
+    case 'width':
+      return element.size[0];
+    case 'height':
+      return element.size[1];
+    case 'x':
+      return element.center[0];
+    case 'y':
+      return element.center[1];
+    default:
+      return element[key as keyof UIElement];
+  }
+}
+
+function elementIdentity(element: UIElement, index: number): string {
+  const name = element.id || element.accessibilityId || element.text || element.type || 'element';
+  return `match #${index + 1} (${JSON.stringify(name)})`;
+}
+
+function redactDiagnosticsSelector(
+  selector: ElementSelector,
+  elements: UIElement[]
+): ElementSelector {
+  if (!elements.some((element) => element.password) || selector.value == null) return selector;
+  return { ...selector, value: '***' };
+}
+
+function redactExpectedProperties(
+  properties: ElementPropertyExpectations | undefined,
+  elements: UIElement[]
+): ElementPropertyExpectations | undefined {
+  if (!properties || !elements.some((element) => element.password) || properties.value == null) {
+    return properties;
+  }
+  return { ...properties, value: '***' };
+}
+
+export interface StructuredAssertionResult {
+  success: boolean;
+  message: string;
+  diagnostics: SelectorDiagnostics;
+}
+
+/** Evaluate count and property expectations against a selector resolution. */
+export function evaluateStructuredAssertion(
+  elements: UIElement[],
+  selector: ElementSelector,
+  properties?: ElementPropertyExpectations,
+  count?: NumericExpectation
+): StructuredAssertionResult {
+  const resolution = resolveElementSelector(elements, selector);
+  const matches = resolution.matches;
+  const failures: string[] = [];
+  const effectiveProperties = properties ?? (count == null ? { visible: true } : undefined);
+
+  if (count != null && !matchesNumber(matches.length, count)) {
+    failures.push(`count expected ${expectedLabel(count)}, actual ${matches.length}`);
+  }
+
+  const expectsAbsent =
+    effectiveProperties?.exists === false || effectiveProperties?.visible === false;
+  if (effectiveProperties?.exists === false) {
+    if (matches.length > 0)
+      failures.push(`expected target not to exist, but found ${matches.length}`);
+  } else if (effectiveProperties?.visible === false && matches.length === 0) {
+    // Absence satisfies not-visible.
+  } else if (effectiveProperties && matches.length === 0) {
+    failures.push(
+      resolution.indexOutOfRange
+        ? `selector index ${selector.index} is out of range (${resolution.allMatches.length} candidate(s))`
+        : 'target did not match any element'
+    );
+  }
+
+  if (effectiveProperties && matches.length > 0 && !expectsAbsent) {
+    for (let index = 0; index < matches.length; index++) {
+      const element = matches[index];
+      for (const [rawKey, expected] of Object.entries(effectiveProperties)) {
+        const key = rawKey as keyof ElementPropertyExpectations;
+        if (key === 'exists') continue;
+        const actual = actualFor(element, key);
+        let satisfied: boolean;
+        if (key === 'visible') {
+          satisfied = (actual !== false) === expected;
+        } else if (['text', 'value', 'type'].includes(key)) {
+          satisfied = matchesString(actual as string | undefined, expected as StringSelector);
+        } else if (['width', 'height', 'x', 'y'].includes(key)) {
+          satisfied = matchesNumber(actual as number, expected as NumericExpectation);
+        } else {
+          satisfied = actual != null && actual === expected;
+        }
+        if (!satisfied) {
+          const shownActual =
+            element.password && key === 'value' && actual != null ? '***' : actual;
+          const unavailable = actual == null ? 'unavailable' : JSON.stringify(shownActual);
+          failures.push(
+            `${elementIdentity(element, index)}.${key} expected ${expectedLabel(
+              element.password && key === 'value' ? '***' : expected
+            )}, actual ${unavailable}`
+          );
+        }
+      }
+    }
+  } else if (effectiveProperties?.visible === false && matches.length > 0) {
+    const visible = matches.filter((element) => element.visible !== false);
+    if (visible.length > 0)
+      failures.push(
+        `expected target not to be visible, but ${visible.length} visible match(es) remain`
+      );
+  }
+
+  const diagnostics: SelectorDiagnostics = {
+    selector: redactDiagnosticsSelector(selector, matches),
+    matchedCount: matches.length,
+    matched: matches.map(snapshotElement),
+    ...(effectiveProperties
+      ? { expectedProperties: redactExpectedProperties(effectiveProperties, matches) }
+      : {}),
+    ...(count != null ? { expectedCount: count } : {}),
+    ...(failures.length ? { failures } : {}),
+  };
+  const selectorText = describeElementSelector(diagnostics.selector);
+  return {
+    success: failures.length === 0,
+    message:
+      failures.length === 0
+        ? `Structured assertion passed: ${selectorText} (${matches.length} match${matches.length === 1 ? '' : 'es'})`
+        : `Structured assertion failed: ${selectorText} — ${failures.join('; ')}`,
+    diagnostics,
+  };
+}

--- a/packages/core/src/flow/types.ts
+++ b/packages/core/src/flow/types.ts
@@ -52,7 +52,128 @@ export interface ParsedSuite {
 }
 
 /** Set when the step was parsed from a natural-language YAML string (shown in CLI). */
-type Verbatim = { verbatim?: string };
+type Verbatim = {
+  verbatim?: string;
+  /** Internal marker: at least one resolved field originated from `${secrets.*}`. */
+  sensitive?: boolean;
+  /** Resolved secret values used to redact logs, labels, diagnostics, and reports. */
+  sensitiveValues?: string[];
+};
+
+/** How a structured selector compares a string-valued UI attribute. */
+export type StringMatchMode = 'exact' | 'contains' | 'regex';
+
+export interface StringMatcher {
+  value: string;
+  /** Structured selectors default to exact matching. */
+  match?: StringMatchMode;
+  /** Matching is case-insensitive unless explicitly enabled. */
+  caseSensitive?: boolean;
+}
+
+export type StringSelector = string | StringMatcher;
+
+/** Numeric matcher used by count, position, and dimension assertions. */
+export interface NumericMatcher {
+  equals?: number;
+  gte?: number;
+  lte?: number;
+  /** Friendly aliases for gte/lte. */
+  min?: number;
+  max?: number;
+  /** Applied to `equals` (default 0). */
+  tolerance?: number;
+}
+
+export type NumericExpectation = number | NumericMatcher;
+
+/**
+ * Cross-platform selector evaluated against the normalized accessibility tree.
+ *
+ * String shorthand is exact and case-insensitive. Legacy YAML string actions
+ * retain their existing fuzzy matching behavior and do not use this type.
+ */
+export interface ElementSelector {
+  text?: StringSelector;
+  id?: StringSelector;
+  accessibilityId?: StringSelector;
+  type?: StringSelector;
+  hint?: StringSelector;
+  value?: StringSelector;
+  /** Select one occurrence after all other filters and relations (0-based). */
+  index?: number;
+
+  enabled?: boolean;
+  checked?: boolean;
+  focused?: boolean;
+  selected?: boolean;
+  editable?: boolean;
+  clickable?: boolean;
+  scrollable?: boolean;
+  longClickable?: boolean;
+
+  above?: SelectorReference;
+  below?: SelectorReference;
+  leftOf?: SelectorReference;
+  rightOf?: SelectorReference;
+  near?: SelectorReference;
+  within?: SelectorReference;
+  childOf?: SelectorReference;
+  descendantOf?: SelectorReference;
+}
+
+/** A relation anchor may use text shorthand or another structured selector. */
+export type SelectorReference = string | ElementSelector;
+
+/** Properties checked after the target element(s) have been located. */
+export interface ElementPropertyExpectations {
+  exists?: boolean;
+  visible?: boolean;
+  text?: StringSelector;
+  value?: StringSelector;
+  type?: StringSelector;
+  enabled?: boolean;
+  checked?: boolean;
+  focused?: boolean;
+  selected?: boolean;
+  editable?: boolean;
+  clickable?: boolean;
+  scrollable?: boolean;
+  longClickable?: boolean;
+  width?: NumericExpectation;
+  height?: NumericExpectation;
+  x?: NumericExpectation;
+  y?: NumericExpectation;
+}
+
+/** Serializable element details attached to structured-selector reports. */
+export interface MatchedElementSnapshot {
+  text: string;
+  id: string;
+  accessibilityId: string;
+  type: string;
+  value?: string;
+  bounds: string;
+  center: [number, number];
+  size: [number, number];
+  enabled: boolean;
+  checked?: boolean;
+  focused?: boolean;
+  selected?: boolean;
+  editable: boolean;
+  clickable: boolean;
+  visible?: boolean;
+}
+
+/** Structured diagnostics persisted in run manifests and rendered in reports. */
+export interface SelectorDiagnostics {
+  selector: ElementSelector;
+  matchedCount: number;
+  matched: MatchedElementSnapshot[];
+  expectedProperties?: ElementPropertyExpectations;
+  expectedCount?: NumericExpectation;
+  failures?: string[];
+}
 
 /**
  * Spatial selectors for disambiguating which matching element to act on, modeled
@@ -86,12 +207,25 @@ export type FlowStep =
       kind: 'waitUntil';
       condition: 'visible' | 'gone' | 'screenLoaded';
       text?: string;
+      /** Structured targets are deterministic DOM/accessibility-tree only. */
+      selector?: ElementSelector;
       timeoutSeconds: number;
     } & Verbatim)
-  | ({ kind: 'tap'; label: string; proximity?: Proximity } & Verbatim)
-  | ({ kind: 'doubleTap'; label: string; proximity?: Proximity } & Verbatim)
-  | ({ kind: 'longPress'; label: string; duration?: number } & Verbatim)
-  | ({ kind: 'type'; text: string; target?: string; proximity?: Proximity } & Verbatim)
+  | ({ kind: 'tap'; label: string; selector?: ElementSelector; proximity?: Proximity } & Verbatim)
+  | ({
+      kind: 'doubleTap';
+      label: string;
+      selector?: ElementSelector;
+      proximity?: Proximity;
+    } & Verbatim)
+  | ({ kind: 'longPress'; label: string; selector?: ElementSelector; duration?: number } & Verbatim)
+  | ({
+      kind: 'type';
+      text: string;
+      target?: string;
+      selector?: ElementSelector;
+      proximity?: Proximity;
+    } & Verbatim)
   | ({ kind: 'enter' } & Verbatim)
   | ({ kind: 'back' } & Verbatim)
   | ({ kind: 'home' } & Verbatim)
@@ -105,6 +239,7 @@ export type FlowStep =
        * moves in `direction`. When omitted, swipes from the screen center.
        */
       target?: string;
+      selector?: ElementSelector;
     } & Verbatim)
   | ({
       kind: 'zoom';
@@ -112,6 +247,7 @@ export type FlowStep =
       scale: number;
       /** Optional label of the element to zoom on. If omitted, zooms on the center of the screen. */
       target?: string;
+      selector?: ElementSelector;
     } & Verbatim)
   | ({
       kind: 'drag';
@@ -122,10 +258,19 @@ export type FlowStep =
       /** Hold duration before dragging in ms. Default: 400 */
       longPressDuration?: number;
     } & Verbatim)
-  | ({ kind: 'assert'; text: string } & Verbatim)
+  | ({
+      kind: 'assert';
+      /** Legacy semantic/text assertion. */
+      text?: string;
+      /** Structured target; never silently falls back to vision. */
+      selector?: ElementSelector;
+      properties?: ElementPropertyExpectations;
+      count?: NumericExpectation;
+    } & Verbatim)
   | ({
       kind: 'scrollAssert';
-      text: string;
+      text?: string;
+      selector?: ElementSelector;
       direction: 'up' | 'down' | 'left' | 'right';
       maxScrolls: number;
       /**

--- a/packages/core/src/flow/variable-resolver.ts
+++ b/packages/core/src/flow/variable-resolver.ts
@@ -21,6 +21,7 @@ export interface VariableBindings {
 export interface ResolveResult {
   resolved: string;
   redacted: string;
+  sensitiveValues: string[];
 }
 
 // ── Loading ────────────────────────────────────────────────────────
@@ -109,6 +110,7 @@ const PLACEHOLDER_RE = /\$\{(secrets|variables)\.([^}]+)\}/g;
 export function interpolate(template: string, bindings: VariableBindings): ResolveResult {
   let resolved = template;
   let redacted = template;
+  const sensitiveValues = new Set<string>();
 
   resolved = resolved.replace(PLACEHOLDER_RE, (_match, scope: string, key: string) => {
     if (scope === 'secrets') {
@@ -119,6 +121,7 @@ export function interpolate(template: string, bindings: VariableBindings): Resol
             `Set the environment variable "${key}" in your shell or .env file.`
         );
       }
+      if (value) sensitiveValues.add(value);
       return value;
     }
     if (!(key in bindings.variables)) {
@@ -137,7 +140,36 @@ export function interpolate(template: string, bindings: VariableBindings): Resol
     return _match;
   });
 
-  return { resolved, redacted };
+  return { resolved, redacted, sensitiveValues: [...sensitiveValues] };
+}
+
+/** Replace resolved secret values in any user-visible string. */
+export function redactSensitiveValues(text: string, sensitiveValues?: string[]): string {
+  if (!sensitiveValues?.length) return text;
+  return [...new Set(sensitiveValues)]
+    .filter(Boolean)
+    .sort((a, b) => b.length - a.length)
+    .reduce((redacted, value) => redacted.split(value).join('***'), text);
+}
+
+/** Recursively redact resolved secrets from report- or log-shaped data. */
+export function redactSensitiveData<T>(value: T, sensitiveValues?: string[]): T {
+  if (!sensitiveValues?.length) return value;
+  if (typeof value === 'string') {
+    return redactSensitiveValues(value, sensitiveValues) as T;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => redactSensitiveData(item, sensitiveValues)) as T;
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([key, nested]) => [
+        key,
+        redactSensitiveData(nested, sensitiveValues),
+      ])
+    ) as T;
+  }
+  return value;
 }
 
 /**
@@ -155,33 +187,53 @@ export function hasPlaceholders(text: string): boolean {
 export function interpolateStep<T extends Record<string, unknown>>(
   step: T,
   bindings: VariableBindings
-): T {
-  // Check if any interpolation is needed (variables in bindings or secrets in step strings)
-  const hasVars = Object.keys(bindings.variables).length > 0;
-  const hasSecretPlaceholders = Object.values(step).some(
-    (v) => typeof v === 'string' && /\$\{secrets\.[^}]+\}/.test(v)
-  );
-  if (!hasVars && !hasSecretPlaceholders) {
+): T & { sensitive?: boolean; sensitiveValues?: string[] } {
+  const containsPlaceholder = (value: unknown): boolean => {
+    if (typeof value === 'string') return hasPlaceholders(value);
+    if (Array.isArray(value)) return value.some(containsPlaceholder);
+    if (value && typeof value === 'object') return Object.values(value).some(containsPlaceholder);
+    return false;
+  };
+  if (!containsPlaceholder(step)) {
     return step;
   }
+  const containsSecret = (value: unknown): boolean => {
+    if (typeof value === 'string') return /\$\{secrets\.[^}]+\}/.test(value);
+    if (Array.isArray(value)) return value.some(containsSecret);
+    if (value && typeof value === 'object') return Object.values(value).some(containsSecret);
+    return false;
+  };
+  const sensitive = containsSecret(step);
+  const sensitiveValues = new Set<string>();
 
-  const result = { ...step };
-
-  // First pass: resolve all string fields (except verbatim)
-  for (const [key, val] of Object.entries(result)) {
-    if (key === 'verbatim') continue;
-    if (typeof val === 'string' && hasPlaceholders(val)) {
-      const { resolved } = interpolate(val, bindings);
-      (result as Record<string, unknown>)[key] = resolved;
+  const resolveNested = (value: unknown): unknown => {
+    if (typeof value === 'string') {
+      if (!hasPlaceholders(value)) return value;
+      const result = interpolate(value, bindings);
+      for (const secretValue of result.sensitiveValues) sensitiveValues.add(secretValue);
+      return result.resolved;
     }
+    if (Array.isArray(value)) return value.map(resolveNested);
+    if (value && typeof value === 'object') {
+      return Object.fromEntries(
+        Object.entries(value as Record<string, unknown>).map(([key, nested]) => [
+          key,
+          resolveNested(nested),
+        ])
+      );
+    }
+    return value;
+  };
+
+  const result = resolveNested(step) as T;
+  if (sensitive) {
+    (result as Record<string, unknown>).sensitive = true;
+    (result as Record<string, unknown>).sensitiveValues = [...sensitiveValues];
   }
 
-  // Second pass: set verbatim to redacted form (secrets hidden, variables shown)
-  if (typeof result.verbatim === 'string' && hasPlaceholders(result.verbatim)) {
-    (result as Record<string, unknown>).verbatim = interpolate(
-      result.verbatim as string,
-      bindings
-    ).redacted;
+  // Keep the user-facing natural-language instruction redacted.
+  if (typeof step.verbatim === 'string' && hasPlaceholders(step.verbatim)) {
+    (result as Record<string, unknown>).verbatim = interpolate(step.verbatim, bindings).redacted;
   }
 
   return result;

--- a/packages/core/src/llm/schemas.ts
+++ b/packages/core/src/llm/schemas.ts
@@ -26,4 +26,6 @@ export interface ActionResult {
    * Undefined unless the report collector enabled capture.
    */
   beforeScreenshot?: string;
+  /** Deterministic selector resolution/assertion details for reports and CI diagnostics. */
+  selectorDiagnostics?: import('../flow/types.js').SelectorDiagnostics;
 }

--- a/packages/core/src/perception/android-parser.ts
+++ b/packages/core/src/perception/android-parser.ts
@@ -22,18 +22,30 @@ export function parseAndroidPageSource(xmlContent: string): UIElement[] {
   }
 
   const elements: UIElement[] = [];
+  let treeSequence = 0;
 
-  function walk(node: any, parentLabel: string, depth: number): void {
+  function walk(
+    node: any,
+    parentLabel: string,
+    depth: number,
+    parentTreeId?: string,
+    ancestorTreeIds: string[] = []
+  ): void {
     if (!node || typeof node !== 'object') return;
 
     if (node['@_bounds']) {
+      const treeId = `android-${treeSequence++}`;
       const isClickable = node['@_clickable'] === 'true';
       const isLongClickable = node['@_long-clickable'] === 'true';
       const isScrollable = node['@_scrollable'] === 'true';
       const isEnabled = node['@_enabled'] !== 'false';
-      const isChecked = node['@_checked'] === 'true';
-      const isFocused = node['@_focused'] === 'true';
-      const isSelected = node['@_selected'] === 'true';
+      const isCheckable =
+        node['@_checkable'] === 'true' ||
+        /Switch|CheckBox|RadioButton/i.test(node['@_class'] ?? '');
+      const isChecked = isCheckable ? node['@_checked'] === 'true' : undefined;
+      const isFocused = node['@_focused'] == null ? undefined : node['@_focused'] === 'true';
+      const isSelected = node['@_selected'] == null ? undefined : node['@_selected'] === 'true';
+      const isVisible = node['@_displayed'] == null ? true : node['@_displayed'] !== 'false';
 
       const elementClass: string = node['@_class'] ?? '';
       const isEditable =
@@ -45,6 +57,7 @@ export function parseAndroidPageSource(xmlContent: string): UIElement[] {
       const desc: string = node['@_content-desc'] ?? '';
       const resourceId: string = node['@_resource-id'] ?? '';
       const hint: string = node['@_hint'] ?? '';
+      const isPassword = node['@_password'] === 'true';
 
       const typeName = elementClass.split('.').pop() ?? '';
       const nodeLabel = text || desc || resourceId.split('/').pop() || typeName;
@@ -81,6 +94,7 @@ export function parseAndroidPageSource(xmlContent: string): UIElement[] {
               id: resourceId,
               accessibilityId: desc || resourceId.split('/').pop() || '',
               text: text || desc,
+              ...(isEditable && text ? { value: text } : {}),
               type: typeName,
               bounds,
               center: [centerX, centerY],
@@ -91,12 +105,17 @@ export function parseAndroidPageSource(xmlContent: string): UIElement[] {
               checked: isChecked,
               focused: isFocused,
               selected: isSelected,
+              visible: isVisible,
+              password: isPassword,
               scrollable: isScrollable,
               longClickable: isLongClickable,
               hint,
               action: suggestedAction,
               parent: parentLabel,
               depth,
+              treeId,
+              ...(parentTreeId ? { parentTreeId } : {}),
+              ancestorTreeIds,
               platform: 'android',
             });
           }
@@ -105,22 +124,28 @@ export function parseAndroidPageSource(xmlContent: string): UIElement[] {
         }
       }
 
-      walkChildren(node, nodeLabel, depth + 1);
+      walkChildren(node, nodeLabel, depth + 1, treeId, [...ancestorTreeIds, treeId]);
       return;
     }
 
-    walkChildren(node, parentLabel, depth);
+    walkChildren(node, parentLabel, depth, parentTreeId, ancestorTreeIds);
   }
 
-  function walkChildren(node: any, parentLabel: string, depth: number): void {
+  function walkChildren(
+    node: any,
+    parentLabel: string,
+    depth: number,
+    parentTreeId?: string,
+    ancestorTreeIds: string[] = []
+  ): void {
     // Appium page source nests children directly as element type keys
     for (const key of Object.keys(node)) {
       if (key.startsWith('@_')) continue; // skip attributes
       const child = node[key];
       if (Array.isArray(child)) {
-        for (const item of child) walk(item, parentLabel, depth);
+        for (const item of child) walk(item, parentLabel, depth, parentTreeId, ancestorTreeIds);
       } else if (typeof child === 'object' && child !== null) {
-        walk(child, parentLabel, depth);
+        walk(child, parentLabel, depth, parentTreeId, ancestorTreeIds);
       }
     }
   }

--- a/packages/core/src/perception/android-parser.ts
+++ b/packages/core/src/perception/android-parser.ts
@@ -64,8 +64,13 @@ export function parseAndroidPageSource(xmlContent: string): UIElement[] {
 
       const isInteractive = isClickable || isEditable || isLongClickable || isScrollable;
       const hasContent = !!(text || desc);
+      // Some Android apps attach the gesture to an ancestor while exposing a
+      // stable resource-id and bounds on a child container. Keeping id-bearing
+      // nodes makes those targets addressable by deterministic selectors even
+      // when UiAutomator2 reports clickable=false and no accessible label.
+      const hasStableId = !!resourceId;
 
-      if (isInteractive || hasContent) {
+      if (isInteractive || hasContent || hasStableId) {
         const bounds: string = node['@_bounds'];
         try {
           const coords = bounds

--- a/packages/core/src/perception/ios-parser.ts
+++ b/packages/core/src/perception/ios-parser.ts
@@ -22,7 +22,10 @@ function isEditableType(typeName: string): boolean {
   return editableTypes.some((t) => typeName.includes(t));
 }
 
-export function parseIOSPageSource(xmlContent: string): UIElement[] {
+export function parseIOSPageSource(
+  xmlContent: string,
+  options: { includeHidden?: boolean } = {}
+): UIElement[] {
   const parser = new XMLParser({
     ignoreAttributes: false,
     attributeNamePrefix: '@_',
@@ -38,14 +41,22 @@ export function parseIOSPageSource(xmlContent: string): UIElement[] {
   }
 
   const elements: UIElement[] = [];
+  let treeSequence = 0;
 
-  function walk(node: any, parentLabel: string, depth: number): void {
+  function walk(
+    node: any,
+    parentLabel: string,
+    depth: number,
+    parentTreeId?: string,
+    ancestorTreeIds: string[] = []
+  ): void {
     if (!node || typeof node !== 'object') return;
 
     // iOS elements have x, y, width, height attributes
     const hasPosition = node['@_x'] !== undefined && node['@_y'] !== undefined;
 
     if (hasPosition) {
+      const treeId = `ios-${treeSequence++}`;
       const x = parseInt(node['@_x'] ?? '0', 10);
       const y = parseInt(node['@_y'] ?? '0', 10);
       const width = parseInt(node['@_width'] ?? '0', 10);
@@ -71,9 +82,14 @@ export function parseIOSPageSource(xmlContent: string): UIElement[] {
         typeName === 'Slider';
       const isScrollable =
         typeName === 'ScrollView' || typeName === 'Table' || typeName === 'CollectionView';
-      const isChecked = value === '1' && (typeName === 'Switch' || typeName === 'CheckBox');
-      const isFocused = node['@_hasFocus'] === 'true';
-      const isSelected = node['@_selected'] === 'true';
+      const isCheckable =
+        typeName === 'Switch' || typeName === 'CheckBox' || typeName === 'RadioButton';
+      const isChecked = isCheckable
+        ? ['1', 'true', 'on', 'checked'].includes(value.toLowerCase())
+        : undefined;
+      const isFocused = node['@_hasFocus'] == null ? undefined : node['@_hasFocus'] === 'true';
+      const isSelected = node['@_selected'] == null ? undefined : node['@_selected'] === 'true';
+      const isPassword = typeName.includes('SecureTextField');
 
       const displayText = label || name || value;
       const nodeLabel = displayText || typeName;
@@ -81,7 +97,12 @@ export function parseIOSPageSource(xmlContent: string): UIElement[] {
       const isInteractive = isClickable || isEditable || isScrollable;
       const hasContent = !!displayText;
 
-      if ((isInteractive || hasContent) && width > 0 && height > 0 && isVisible) {
+      if (
+        (isInteractive || hasContent) &&
+        width > 0 &&
+        height > 0 &&
+        (isVisible || options.includeHidden)
+      ) {
         const centerX = Math.floor(x + width / 2);
         const centerY = Math.floor(y + height / 2);
 
@@ -95,6 +116,7 @@ export function parseIOSPageSource(xmlContent: string): UIElement[] {
           id: name,
           accessibilityId: name || label,
           text: displayText,
+          ...(value ? { value } : {}),
           type: typeName,
           bounds: `[${x},${y}][${x + width},${y + height}]`,
           center: [centerX, centerY],
@@ -105,31 +127,42 @@ export function parseIOSPageSource(xmlContent: string): UIElement[] {
           checked: isChecked,
           focused: isFocused,
           selected: isSelected,
+          visible: isVisible,
+          password: isPassword,
           scrollable: isScrollable,
           longClickable: false, // iOS doesn't expose this in XML
           hint: node['@_placeholderValue'] ?? '',
           action: suggestedAction,
           parent: parentLabel,
           depth,
+          treeId,
+          ...(parentTreeId ? { parentTreeId } : {}),
+          ancestorTreeIds,
           platform: 'ios',
         });
       }
 
-      walkChildren(node, nodeLabel, depth + 1);
+      walkChildren(node, nodeLabel, depth + 1, treeId, [...ancestorTreeIds, treeId]);
       return;
     }
 
-    walkChildren(node, parentLabel, depth);
+    walkChildren(node, parentLabel, depth, parentTreeId, ancestorTreeIds);
   }
 
-  function walkChildren(node: any, parentLabel: string, depth: number): void {
+  function walkChildren(
+    node: any,
+    parentLabel: string,
+    depth: number,
+    parentTreeId?: string,
+    ancestorTreeIds: string[] = []
+  ): void {
     for (const key of Object.keys(node)) {
       if (key.startsWith('@_')) continue;
       const child = node[key];
       if (Array.isArray(child)) {
-        for (const item of child) walk(item, parentLabel, depth);
+        for (const item of child) walk(item, parentLabel, depth, parentTreeId, ancestorTreeIds);
       } else if (typeof child === 'object' && child !== null) {
-        walk(child, parentLabel, depth);
+        walk(child, parentLabel, depth, parentTreeId, ancestorTreeIds);
       }
     }
   }

--- a/packages/core/src/perception/types.ts
+++ b/packages/core/src/perception/types.ts
@@ -6,6 +6,8 @@ export interface UIElement {
   accessibilityId: string;
   /** Visible text (text/content-desc on Android, label on iOS) */
   text: string;
+  /** Current control value, kept separate from its label when exposed by the platform. */
+  value?: string;
   /** Element class name (e.g. "Button", "XCUIElementTypeButton") */
   type: string;
   /** Raw bounds string */
@@ -17,9 +19,14 @@ export interface UIElement {
   clickable: boolean;
   editable: boolean;
   enabled: boolean;
-  checked: boolean;
-  focused: boolean;
-  selected: boolean;
+  /** Optional state means the platform/control did not expose that property. */
+  checked?: boolean;
+  focused?: boolean;
+  selected?: boolean;
+  /** Whether the platform reports the node as displayed. */
+  visible?: boolean;
+  /** Secure inputs mask their value in selector diagnostics. */
+  password?: boolean;
   scrollable: boolean;
   longClickable: boolean;
   /** Hint/placeholder text */
@@ -30,6 +37,10 @@ export interface UIElement {
   parent: string;
   /** Depth in the element tree */
   depth: number;
+  /** Stable within a single page-source snapshot; used for tree relations. */
+  treeId?: string;
+  parentTreeId?: string;
+  ancestorTreeIds?: string[];
   /** Source platform */
   platform: 'android' | 'ios';
 }

--- a/packages/core/src/report/renderer.ts
+++ b/packages/core/src/report/renderer.ts
@@ -626,6 +626,7 @@ interface ClientStep {
   img?: string;
   offsetMs?: number;
   tap?: { x: number; y: number; w?: number; h?: number };
+  selectorDiagnostics?: StepArtifact['selectorDiagnostics'];
 }
 
 function stepDescription(s: StepArtifact): string {
@@ -667,6 +668,7 @@ function buildRunData(manifest: RunManifest): {
             h: s.deviceScreenSize?.height ?? s.screenshotSize?.height,
           }
         : undefined,
+      selectorDiagnostics: s.selectorDiagnostics,
     };
   });
   const video = manifest.videoPath
@@ -831,6 +833,15 @@ function renderInspector(s){
   if(s.phase)rows.push(['Phase',esc(s.phase),'mono']);
   rows.push(['Duration',fmt(s.durationMs),'mono']);
   if(s.message)rows.push(['Message',esc(s.message),'']);
+  if(s.selectorDiagnostics){
+    var d=s.selectorDiagnostics;
+    rows.push(['Selector',esc(JSON.stringify(d.selector)),'mono']);
+    rows.push(['Matched',esc(String(d.matchedCount)),'mono']);
+    if(d.expectedProperties)rows.push(['Expected properties',esc(JSON.stringify(d.expectedProperties)),'mono']);
+    if(d.expectedCount!==undefined)rows.push(['Expected count',esc(JSON.stringify(d.expectedCount)),'mono']);
+    if(d.matched&&d.matched.length)rows.push(['Matched elements',esc(JSON.stringify(d.matched)),'mono']);
+    if(d.failures&&d.failures.length)rows.push(['Selector failures',esc(d.failures.join('; ')),'']);
+  }
   if(s.tap)rows.push(['Tap point','['+s.tap.x+', '+s.tap.y+']','mono']);
   document.getElementById('dt-insp').innerHTML=rows.map(function(r){
     var body=r[2]==='raw'?r[1]:'<div class="insp-val'+(r[2]==='mono'?' mono':'')+'">'+r[1]+'</div>';

--- a/packages/core/src/report/types.ts
+++ b/packages/core/src/report/types.ts
@@ -4,7 +4,7 @@
  * No database. Everything is stored as flat JSON files under `.appclaw/runs/`.
  */
 
-import type { FlowPhase, FlowMeta } from '../flow/types.js';
+import type { FlowPhase, FlowMeta, SelectorDiagnostics } from '../flow/types.js';
 
 /* ─── Per-step artifact ──────────────────────────────────── */
 
@@ -56,6 +56,8 @@ export interface StepArtifact {
    * follow-up if it proves useful enough to be a first-class badge.
    */
   cacheHit?: boolean;
+  /** Deterministic selector resolution and assertion details. */
+  selectorDiagnostics?: SelectorDiagnostics;
 }
 
 /* ─── Run manifest (per-run JSON) ────────────────────────── */

--- a/packages/core/src/report/writer.ts
+++ b/packages/core/src/report/writer.ts
@@ -25,6 +25,7 @@ import type {
   HookRecord,
 } from './types.js';
 import type { FlowMeta, FlowPhase } from '../flow/types.js';
+import type { SelectorDiagnostics } from '../flow/types.js';
 import type { RunYamlFlowResult } from '../flow/run-yaml-flow.js';
 
 /* ─── Helpers ────────────────────────────────────────────── */
@@ -93,6 +94,7 @@ export interface StepCollectorEntry {
    * users can see hit-rate during rollout.
    */
   cacheHit?: boolean;
+  selectorDiagnostics?: SelectorDiagnostics;
 }
 
 /**
@@ -236,6 +238,7 @@ export class RunArtifactCollector {
         screenshotSize: step.screenshotSize,
         videoOffsetMs: step.videoOffsetMs,
         cacheHit: step.cacheHit,
+        selectorDiagnostics: step.selectorDiagnostics,
       });
     }
 

--- a/packages/core/src/ui/step-printer.ts
+++ b/packages/core/src/ui/step-printer.ts
@@ -15,6 +15,8 @@
 import chalk from 'chalk';
 import { theme } from './terminal.js';
 import type { FlowStep } from '../flow/types.js';
+import { describeElementSelector } from '../flow/selector.js';
+import { redactSensitiveValues } from '../flow/variable-resolver.js';
 
 /** Short verb word for a step kind — fits in a fixed-width badge. */
 export function stepAction(step: FlowStep): string {
@@ -61,7 +63,7 @@ export function stepAction(step: FlowStep): string {
 }
 
 /** Human-readable target description for a step. */
-export function stepTarget(step: FlowStep): string {
+function rawStepTarget(step: FlowStep): string {
   switch (step.kind) {
     case 'launchApp':
       return 'app';
@@ -76,15 +78,17 @@ export function stepTarget(step: FlowStep): string {
     case 'longPress':
       return `"${step.label}"${step.duration != null ? ` (${step.duration}ms)` : ''}`;
     case 'type':
-      return `"${step.text}"${step.target ? ` → ${step.target}` : ''}`;
+      return `"${step.text}"${step.selector ? ` → selector(${describeElementSelector(step.selector)})` : step.target ? ` → ${step.target}` : ''}`;
     case 'swipe':
-      return step.direction;
+      return `${step.direction}${step.selector ? ` from selector(${describeElementSelector(step.selector)})` : ''}`;
     case 'zoom':
-      return `${step.scale >= 1 ? 'in' : 'out'} (${step.scale}x)${step.target ? ` on "${step.target}"` : ''}`;
+      return `${step.scale >= 1 ? 'in' : 'out'} (${step.scale}x)${step.selector ? ` on selector(${describeElementSelector(step.selector)})` : step.target ? ` on "${step.target}"` : ''}`;
     case 'wait':
       return `${step.seconds}s`;
     case 'waitUntil':
       if (step.condition === 'screenLoaded') return `screen loaded (${step.timeoutSeconds}s)`;
+      if (step.selector)
+        return `selector(${describeElementSelector(step.selector)}) ${step.condition === 'gone' ? 'gone' : 'visible'} (${step.timeoutSeconds}s)`;
       if (step.condition === 'gone') return `"${step.text}" gone (${step.timeoutSeconds}s)`;
       return `"${step.text}" visible (${step.timeoutSeconds}s)`;
     case 'enter':
@@ -94,9 +98,15 @@ export function stepTarget(step: FlowStep): string {
     case 'home':
       return '';
     case 'assert':
-      return `"${step.text}"`;
+      return step.selector
+        ? `selector(${describeElementSelector(step.selector)})`
+        : `"${step.text ?? ''}"`;
     case 'scrollAssert':
-      return `"${step.text}" ${step.direction} ×${step.maxScrolls}${step.target ? ` on "${step.target}"` : ''}`;
+      return `${
+        step.selector
+          ? `selector(${describeElementSelector(step.selector)})`
+          : `"${step.text ?? ''}"`
+      } ${step.direction} ×${step.maxScrolls}${step.target ? ` on "${step.target}"` : ''}`;
     case 'drag':
       return `"${step.from}" → "${step.to}"`;
     case 'getInfo':
@@ -104,6 +114,10 @@ export function stepTarget(step: FlowStep): string {
     case 'done':
       return step.message ?? '';
   }
+}
+
+export function stepTarget(step: FlowStep): string {
+  return redactSensitiveValues(rawStepTarget(step), step.sensitiveValues);
 }
 
 /**

--- a/packages/runner/src/suite-report.ts
+++ b/packages/runner/src/suite-report.ts
@@ -468,6 +468,7 @@ interface ClientStep {
    * already live in the screenshot's pixel space).
    */
   tap?: { x: number; y: number; w?: number; h?: number };
+  selectorDiagnostics?: StepArtifact['selectorDiagnostics'];
 }
 interface ClientHook {
   kind: string;
@@ -534,6 +535,7 @@ function buildData(tests: ReportTest[]): ClientTest[] {
             h: s.deviceScreenSize?.height ?? s.screenshotSize?.height,
           }
         : undefined,
+      selectorDiagnostics: s.selectorDiagnostics,
     })),
   }));
 }
@@ -1198,6 +1200,15 @@ function renderInspector(s){
   if(s.phase)rows.push(['Phase',esc(s.phase),'mono']);
   rows.push(['Duration',fmt(s.durationMs),'mono']);
   if(s.message)rows.push(['Message',esc(s.message),'']);
+  if(s.selectorDiagnostics){
+    var d=s.selectorDiagnostics;
+    rows.push(['Selector',esc(JSON.stringify(d.selector)),'mono']);
+    rows.push(['Matched',esc(String(d.matchedCount)),'mono']);
+    if(d.expectedProperties)rows.push(['Expected properties',esc(JSON.stringify(d.expectedProperties)),'mono']);
+    if(d.expectedCount!==undefined)rows.push(['Expected count',esc(JSON.stringify(d.expectedCount)),'mono']);
+    if(d.matched&&d.matched.length)rows.push(['Matched elements',esc(JSON.stringify(d.matched)),'mono']);
+    if(d.failures&&d.failures.length)rows.push(['Selector failures',esc(d.failures.join('; ')),'']);
+  }
   if(s.tap)rows.push(['Tap point','['+s.tap.x+', '+s.tap.y+']','mono']);
   document.getElementById('dt-insp').innerHTML=rows.map(function(r){
     var body=r[2]==='raw'?r[1]:'<div class="insp-val'+(r[2]==='mono'?' mono':'')+'">'+r[1]+'</div>';

--- a/tests/flow/android-parser.test.ts
+++ b/tests/flow/android-parser.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'vitest';
+import { parseAndroidPageSource } from '@appclaw/core/perception/android-parser';
+
+describe('parseAndroidPageSource', () => {
+  test('keeps an id-only node even when Android reports clickable=false', () => {
+    const elements = parseAndroidPageSource(`
+      <hierarchy rotation="0">
+        <android.widget.FrameLayout
+          class="android.widget.FrameLayout"
+          resource-id="com.smile.gifmaker:id/merchant_ai_container"
+          text=""
+          content-desc=""
+          clickable="false"
+          enabled="true"
+          bounds="[427,2205][652,2352]" />
+      </hierarchy>
+    `);
+
+    expect(elements).toHaveLength(1);
+    expect(elements[0]).toMatchObject({
+      id: 'com.smile.gifmaker:id/merchant_ai_container',
+      accessibilityId: 'merchant_ai_container',
+      clickable: false,
+      action: 'read',
+      center: [539, 2278],
+    });
+  });
+
+  test('still filters empty non-interactive layout nodes without an id', () => {
+    const elements = parseAndroidPageSource(`
+      <hierarchy rotation="0">
+        <android.widget.FrameLayout
+          class="android.widget.FrameLayout"
+          text=""
+          content-desc=""
+          clickable="false"
+          enabled="true"
+          bounds="[0,0][1080,2400]" />
+      </hierarchy>
+    `);
+
+    expect(elements).toEqual([]);
+  });
+});

--- a/tests/flow/ios-textview-editable.test.ts
+++ b/tests/flow/ios-textview-editable.test.ts
@@ -43,6 +43,23 @@ describe('iOS XCUIElementTypeTextView inputs', () => {
     expect(resolveEditableForTarget(elements, 'kitchen-composer-text-input').el).toBe(input);
   });
 
+  test('can retain hidden nodes for exists versus visible assertions', () => {
+    const hiddenSource = krnComposerSource.replace(
+      'visible="true"\n      accessible="true"\n      x="35"',
+      'visible="false"\n      accessible="true"\n      x="35"'
+    );
+    expect(
+      parseIOSPageSource(hiddenSource).find(
+        (element) => element.id === 'kitchen-composer-text-input'
+      )
+    ).toBeUndefined();
+    expect(
+      parseIOSPageSource(hiddenSource, { includeHidden: true }).find(
+        (element) => element.id === 'kitchen-composer-text-input'
+      )
+    ).toMatchObject({ visible: false });
+  });
+
   test('DOM trimmer marks a TextView editable and includes it in editableCount', () => {
     const result = trimDOM(krnComposerSource, 'ios');
 

--- a/tests/flow/parse-yaml-flow.test.ts
+++ b/tests/flow/parse-yaml-flow.test.ts
@@ -220,3 +220,157 @@ describe('parseFlowYamlString — errors', () => {
     await expect(parseFlowYamlString('- [unclosed')).rejects.toThrow();
   });
 });
+
+describe('parseFlowYamlString — structured selectors and property assertions', () => {
+  test('parses structured action targets, waits, assertions, and counts', async () => {
+    const yaml = `
+steps:
+  - tap:
+      target:
+        id: login_button
+        enabled: true
+  - type:
+      value: user@example.com
+      into:
+        accessibilityId: email_input
+  - waitUntil:
+      visible:
+        id: dashboard
+      timeout: 12
+assertions:
+  - assert:
+      target:
+        id: remember_me
+      properties:
+        visible: true
+        checked: true
+        width:
+          gte: 40
+  - assert:
+      target:
+        type: Cell
+      count:
+        gte: 1
+  - scrollAssert:
+      target:
+        id: footer
+      direction: down
+      maxScrolls: 4
+`;
+    const result = await parseFlowYamlString(yaml);
+    expect(result.steps[0]).toMatchObject({
+      kind: 'tap',
+      selector: { id: 'login_button', enabled: true },
+    });
+    expect(result.steps[1]).toMatchObject({
+      kind: 'type',
+      text: 'user@example.com',
+      selector: { accessibilityId: 'email_input' },
+    });
+    expect(result.steps[2]).toMatchObject({
+      kind: 'waitUntil',
+      condition: 'visible',
+      selector: { id: 'dashboard' },
+      timeoutSeconds: 12,
+    });
+    expect(result.steps[3]).toMatchObject({
+      kind: 'assert',
+      selector: { id: 'remember_me' },
+      properties: { visible: true, checked: true, width: { gte: 40 } },
+    });
+    expect(result.steps[4]).toMatchObject({
+      kind: 'assert',
+      selector: { type: 'Cell' },
+      count: { gte: 1 },
+    });
+    expect(result.steps[5]).toMatchObject({
+      kind: 'scrollAssert',
+      selector: { id: 'footer' },
+      direction: 'down',
+      maxScrolls: 4,
+    });
+  });
+
+  test('supports assertVisible/assertNotVisible and relation selectors', async () => {
+    const yaml = `
+- assertVisible:
+    id: submit_button
+- assertNotVisible:
+    id: loading_spinner
+- tap:
+    text: Submit
+    below:
+      id: password_input
+- longPress:
+    target:
+      accessibilityId: item_menu
+    duration: 1500
+`;
+    const result = await parseFlowYamlString(yaml);
+    expect(result.steps[0]).toMatchObject({
+      kind: 'assert',
+      selector: { id: 'submit_button' },
+      properties: { visible: true },
+    });
+    expect(result.steps[1]).toMatchObject({
+      kind: 'assert',
+      selector: { id: 'loading_spinner' },
+      properties: { visible: false },
+    });
+    expect(result.steps[2]).toMatchObject({
+      kind: 'tap',
+      selector: { text: 'Submit', below: { id: 'password_input' } },
+    });
+    expect(result.steps[3]).toMatchObject({
+      kind: 'longPress',
+      selector: { accessibilityId: 'item_menu' },
+      duration: 1500,
+    });
+  });
+
+  test('interpolates variables recursively inside selectors', async () => {
+    const yaml = `
+steps:
+  - tap:
+      target:
+        id: \${variables.login_id}
+`;
+    const result = await parseFlowYamlString(yaml, {
+      bindings: { variables: { login_id: 'login_button' } },
+    });
+    expect(result.steps[0]).toMatchObject({ selector: { id: 'login_button' } });
+  });
+
+  test('rejects unknown selector and property keys', async () => {
+    await expect(
+      parseFlowYamlString(`- tap:\n    target:\n      identifer: login`)
+    ).rejects.toThrow(/unknown selector key/i);
+    await expect(
+      parseFlowYamlString(
+        `- assert:\n    target:\n      id: login\n    properties:\n      enabledd: true`
+      )
+    ).rejects.toThrow(/unknown property key/i);
+  });
+
+  test('keeps legacy string actions unchanged', async () => {
+    const result = await parseFlowYamlString(`- tap: Login\n- assert: Dashboard`);
+    expect(result.steps[0]).toEqual({ kind: 'tap', label: 'Login' });
+    expect(result.steps[1]).toEqual({ kind: 'assert', text: 'Dashboard' });
+  });
+
+  test('rejects typos and conflicting keys around explicit structured targets', async () => {
+    await expect(
+      parseFlowYamlString(`- tap:\n    target:\n      id: submit\n    enabld: true`)
+    ).rejects.toThrow(/unknown key.*enabld/i);
+    await expect(
+      parseFlowYamlString(
+        `- type:\n    value: hello\n    into:\n      id: field\n    target:\n      id: other`
+      )
+    ).rejects.toThrow(/cannot combine into and target/i);
+    await expect(
+      parseFlowYamlString(
+        `- assert:\n    target:\n      id: submit\n    propertees:\n      enabled: true`
+      )
+    ).rejects.toThrow(/unknown key.*propertees/i);
+  });
+});

--- a/tests/flow/structured-selector-runtime.test.ts
+++ b/tests/flow/structured-selector-runtime.test.ts
@@ -103,6 +103,21 @@ describe('structured selector runtime', () => {
     });
   });
 
+  test('keeps structured scroll assertions compatible with anchored scroll targets', async () => {
+    const result = await run({
+      kind: 'scrollAssert',
+      selector: { id: 'com.demo:id/submit' },
+      direction: 'down',
+      maxScrolls: 2,
+      target: 'Item',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.message).toContain('selector(id="com.demo:id/submit")');
+    expect(result.selectorDiagnostics).toMatchObject({ matchedCount: 1 });
+    expect(calls.some((call) => call.name === 'appium_gesture')).toBe(false);
+  });
+
   test('redacts resolved secrets from messages and nested diagnostics', async () => {
     const result = await run({
       kind: 'type',

--- a/tests/flow/structured-selector-runtime.test.ts
+++ b/tests/flow/structured-selector-runtime.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import type { MCPClient } from '@appclaw/core/mcp/types';
+import { executeStep } from '@appclaw/core/flow/run-yaml-flow';
+import type { FlowStep } from '@appclaw/core/flow/types';
+
+const PAGE_SOURCE = `<?xml version="1.0" encoding="UTF-8"?>
+<hierarchy rotation="0">
+  <android.widget.FrameLayout class="android.widget.FrameLayout" bounds="[0,0][1080,1920]" enabled="true">
+    <android.widget.Button class="android.widget.Button" text="Submit" resource-id="com.demo:id/submit" content-desc="submit_button" clickable="true" enabled="true" bounds="[100,200][500,320]" />
+    <android.widget.Button class="android.widget.Button" text="Item" resource-id="com.demo:id/item" clickable="true" enabled="true" bounds="[100,400][500,520]" />
+    <android.widget.Button class="android.widget.Button" text="Item" resource-id="com.demo:id/item" clickable="true" enabled="true" bounds="[100,600][500,720]" />
+    <android.widget.EditText class="android.widget.EditText" text="runtime-secret" resource-id="com.demo:id/password" password="true" clickable="true" enabled="true" bounds="[100,800][700,920]" />
+  </android.widget.FrameLayout>
+</hierarchy>`;
+
+interface ToolCall {
+  name: string;
+  args: Record<string, unknown>;
+}
+
+let calls: ToolCall[];
+
+function mockMcp(): MCPClient {
+  return {
+    callTool: vi.fn(async (name: string, args: Record<string, unknown> = {}) => {
+      calls.push({ name, args });
+      if (name === 'appium_get_page_source') {
+        return { content: [{ type: 'text' as const, text: PAGE_SOURCE }] };
+      }
+      return { content: [{ type: 'text' as const, text: 'OK' }] };
+    }),
+    listTools: vi.fn(async () => []),
+    close: vi.fn(async () => {}),
+  };
+}
+
+async function run(step: FlowStep) {
+  return executeStep(mockMcp(), step, {}, undefined, { maxAttempts: 1, intervalMs: 1 });
+}
+
+beforeEach(() => {
+  calls = [];
+});
+
+describe('structured selector runtime', () => {
+  test('taps the exact resolved element and returns selector diagnostics', async () => {
+    const result = await run({
+      kind: 'tap',
+      label: 'structured target',
+      selector: { accessibilityId: 'submit_button', enabled: true },
+    });
+
+    expect(result.success).toBe(true);
+    expect(
+      calls.find((call) => call.name === 'appium_gesture' && call.args.action === 'tap')?.args
+    ).toMatchObject({ x: 300, y: 260 });
+    expect(result.selectorDiagnostics).toMatchObject({ matchedCount: 1 });
+  });
+
+  test('fails ambiguous actions instead of silently choosing an element', async () => {
+    const result = await run({
+      kind: 'tap',
+      label: 'ambiguous target',
+      selector: { id: 'com.demo:id/item' },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.message).toMatch(/ambiguous.*matched 2/i);
+    expect(calls.some((call) => call.name === 'appium_gesture')).toBe(false);
+    expect(result.selectorDiagnostics?.matchedCount).toBe(2);
+  });
+
+  test('evaluates properties through executeStep with expected/actual diagnostics', async () => {
+    const result = await run({
+      kind: 'assert',
+      selector: { id: 'com.demo:id/submit' },
+      properties: { enabled: false, width: 400 },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.selectorDiagnostics?.failures?.join(' ')).toMatch(/enabled.*false.*true/i);
+    expect(result.selectorDiagnostics?.expectedProperties).toEqual({
+      enabled: false,
+      width: 400,
+    });
+  });
+
+  test('redacts resolved secrets from messages and nested diagnostics', async () => {
+    const result = await run({
+      kind: 'type',
+      text: 'runtime-secret',
+      selector: { id: 'com.demo:id/password', value: 'runtime-secret' },
+      sensitive: true,
+      sensitiveValues: ['runtime-secret'],
+    });
+
+    expect(result.success).toBe(true);
+    expect(JSON.stringify(result)).not.toContain('runtime-secret');
+    expect(result.message).toContain('***');
+    expect(result.selectorDiagnostics?.matched[0].value).toBe('***');
+  });
+});

--- a/tests/flow/structured-selector-runtime.test.ts
+++ b/tests/flow/structured-selector-runtime.test.ts
@@ -10,6 +10,7 @@ const PAGE_SOURCE = `<?xml version="1.0" encoding="UTF-8"?>
     <android.widget.Button class="android.widget.Button" text="Item" resource-id="com.demo:id/item" clickable="true" enabled="true" bounds="[100,400][500,520]" />
     <android.widget.Button class="android.widget.Button" text="Item" resource-id="com.demo:id/item" clickable="true" enabled="true" bounds="[100,600][500,720]" />
     <android.widget.EditText class="android.widget.EditText" text="runtime-secret" resource-id="com.demo:id/password" password="true" clickable="true" enabled="true" bounds="[100,800][700,920]" />
+    <android.view.ViewGroup class="android.view.ViewGroup" text="" content-desc="" resource-id="com.demo:id/merchant_ai_container" clickable="false" enabled="true" bounds="[427,1700][652,1847]" />
   </android.widget.FrameLayout>
 </hierarchy>`;
 
@@ -55,6 +56,23 @@ describe('structured selector runtime', () => {
       calls.find((call) => call.name === 'appium_gesture' && call.args.action === 'tap')?.args
     ).toMatchObject({ x: 300, y: 260 });
     expect(result.selectorDiagnostics).toMatchObject({ matchedCount: 1 });
+  });
+
+  test('taps an id-only container even when the node itself is not marked clickable', async () => {
+    const result = await run({
+      kind: 'tap',
+      label: 'id-only structured target',
+      selector: { id: 'com.demo:id/merchant_ai_container' },
+    });
+
+    expect(result.success).toBe(true);
+    expect(
+      calls.find((call) => call.name === 'appium_gesture' && call.args.action === 'tap')?.args
+    ).toMatchObject({ x: 539, y: 1773 });
+    expect(result.selectorDiagnostics).toMatchObject({
+      matchedCount: 1,
+      matched: [expect.objectContaining({ clickable: false })],
+    });
   });
 
   test('fails ambiguous actions instead of silently choosing an element', async () => {

--- a/tests/flow/structured-selector.test.ts
+++ b/tests/flow/structured-selector.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, test } from 'vitest';
+import type { UIElement } from '@appclaw/core/perception/types';
+import {
+  evaluateStructuredAssertion,
+  parseElementSelector,
+  parseNumericExpectation,
+  resolveElementSelector,
+} from '@appclaw/core/flow/selector';
+
+function element(
+  text: string,
+  center: [number, number],
+  size: [number, number] = [100, 40],
+  extra: Partial<UIElement> = {}
+): UIElement {
+  return {
+    id: '',
+    accessibilityId: '',
+    text,
+    type: 'TextView',
+    bounds: `[${center[0] - size[0] / 2},${center[1] - size[1] / 2}]`,
+    center,
+    size,
+    clickable: false,
+    editable: false,
+    enabled: true,
+    scrollable: false,
+    longClickable: false,
+    hint: '',
+    action: 'read',
+    parent: 'root',
+    depth: 0,
+    platform: 'android',
+    visible: true,
+    ...extra,
+  };
+}
+
+describe('structured selector matching', () => {
+  const login = element('Login', [100, 400], [160, 60], {
+    id: 'com.demo:id/login',
+    accessibilityId: 'login_button',
+    type: 'Button',
+    clickable: true,
+  });
+  const loginHelp = element('Login help', [100, 500]);
+
+  test('string shorthand is exact while contains and regex are explicit', () => {
+    expect(resolveElementSelector([login, loginHelp], { text: 'Login' }).matches).toEqual([login]);
+    expect(
+      resolveElementSelector([login, loginHelp], {
+        text: { value: 'Login', match: 'contains' },
+      }).matches
+    ).toEqual([login, loginHelp]);
+    expect(
+      resolveElementSelector([login, loginHelp], {
+        text: { value: '^login\\s+help$', match: 'regex' },
+      }).matches
+    ).toEqual([loginHelp]);
+  });
+
+  test('combines stable identifiers and state with AND semantics', () => {
+    const disabled = { ...login, enabled: false };
+    expect(
+      resolveElementSelector([disabled, loginHelp], {
+        accessibilityId: 'login_button',
+        enabled: false,
+      }).matches
+    ).toEqual([disabled]);
+  });
+
+  test('does not confuse unavailable boolean state with false', () => {
+    expect(
+      resolveElementSelector([loginHelp], { text: 'Login help', checked: false }).matches
+    ).toEqual([]);
+    const unchecked = { ...loginHelp, type: 'CheckBox', checked: false };
+    expect(
+      resolveElementSelector([unchecked], { text: 'Login help', checked: false }).matches
+    ).toEqual([unchecked]);
+  });
+
+  test('index is applied after filtering', () => {
+    const first = element('Add', [100, 100]);
+    const second = element('Add', [100, 200]);
+    const result = resolveElementSelector([first, second], { text: 'Add', index: 1 });
+    expect(result.allMatches).toHaveLength(2);
+    expect(result.matches).toEqual([second]);
+  });
+
+  test('strict parser rejects typos and invalid regexes', () => {
+    expect(() => parseElementSelector({ enableded: true }, 'selector')).toThrow(/unknown/i);
+    expect(() =>
+      parseElementSelector({ text: { value: '[', match: 'regex' } }, 'selector')
+    ).toThrow(/regular expression/i);
+    expect(() => parseNumericExpectation({ tolerance: 2 }, 'count')).toThrow(
+      /tolerance requires equals/i
+    );
+  });
+});
+
+describe('structured selector relations', () => {
+  const form = element('Form', [300, 300], [500, 500], {
+    treeId: 'form',
+    type: 'View',
+  });
+  const password = element('Password', [300, 300], [300, 60], {
+    treeId: 'password',
+    parentTreeId: 'form',
+    ancestorTreeIds: ['form'],
+    editable: true,
+  });
+  const submit = element('Submit', [300, 430], [200, 70], {
+    treeId: 'submit',
+    parentTreeId: 'form',
+    ancestorTreeIds: ['form'],
+    clickable: true,
+  });
+  const icon = element('Arrow', [220, 430], [30, 30], {
+    treeId: 'arrow',
+    parentTreeId: 'submit',
+    ancestorTreeIds: ['form', 'submit'],
+  });
+
+  test('supports geometric relations', () => {
+    const screen = [form, password, submit, icon];
+    expect(resolveElementSelector(screen, { text: 'Submit', below: 'Password' }).matches).toEqual([
+      submit,
+    ]);
+    expect(resolveElementSelector(screen, { text: 'Arrow', within: 'Form' }).matches).toEqual([
+      icon,
+    ]);
+    expect(resolveElementSelector([form], { text: 'Form', within: 'Form' }).matches).toEqual([]);
+  });
+
+  test('supports immediate-child and descendant relations', () => {
+    const screen = [form, password, submit, icon];
+    expect(resolveElementSelector(screen, { text: 'Submit', childOf: 'Form' }).matches).toEqual([
+      submit,
+    ]);
+    expect(
+      resolveElementSelector(screen, { text: 'Arrow', descendantOf: { text: 'Form' } }).matches
+    ).toEqual([icon]);
+    expect(resolveElementSelector(screen, { text: 'Arrow', childOf: 'Form' }).matches).toEqual([]);
+  });
+});
+
+describe('structured assertions', () => {
+  const switchElement = element('Notifications', [300, 400], [240, 80], {
+    id: 'notifications_switch',
+    type: 'Switch',
+    checked: false,
+    selected: false,
+    value: 'off',
+    clickable: true,
+  });
+
+  test('checks value, state, and dimensions with actionable diagnostics', () => {
+    const result = evaluateStructuredAssertion(
+      [switchElement],
+      { id: 'notifications_switch' },
+      {
+        visible: true,
+        checked: false,
+        value: 'off',
+        width: { gte: 200, lte: 260 },
+        height: 80,
+      }
+    );
+    expect(result.success).toBe(true);
+    expect(result.diagnostics.matchedCount).toBe(1);
+    expect(result.diagnostics.matched[0].bounds).toBeTruthy();
+  });
+
+  test('reports expected and actual property values', () => {
+    const result = evaluateStructuredAssertion(
+      [switchElement],
+      { id: 'notifications_switch' },
+      { checked: true }
+    );
+    expect(result.success).toBe(false);
+    expect(result.diagnostics.failures?.join(' ')).toMatch(/checked.*true.*false/);
+  });
+
+  test('supports count assertions', () => {
+    const items = [
+      element('Item', [100, 100], [100, 40], { type: 'Cell' }),
+      element('Item', [100, 200], [100, 40], { type: 'Cell' }),
+      element('Item', [100, 300], [100, 40], { type: 'Cell' }),
+    ];
+    expect(
+      evaluateStructuredAssertion(items, { type: 'Cell' }, undefined, { gte: 2 }).success
+    ).toBe(true);
+    expect(evaluateStructuredAssertion(items, { type: 'Cell' }, undefined, 2).success).toBe(false);
+  });
+
+  test('absence satisfies visible=false and exists=false', () => {
+    expect(evaluateStructuredAssertion([], { id: 'spinner' }, { visible: false }).success).toBe(
+      true
+    );
+    expect(evaluateStructuredAssertion([], { id: 'spinner' }, { exists: false }).success).toBe(
+      true
+    );
+  });
+
+  test('masks secure values in diagnostics', () => {
+    const password = element('Password', [100, 100], [200, 50], {
+      id: 'password',
+      type: 'SecureTextField',
+      password: true,
+      value: 'super-secret',
+      editable: true,
+    });
+    const result = evaluateStructuredAssertion([password], { id: 'password' }, { value: 'wrong' });
+    expect(result.success).toBe(false);
+    expect(JSON.stringify(result.diagnostics)).not.toContain('super-secret');
+    expect(result.diagnostics.matched[0].value).toBe('***');
+  });
+});

--- a/tests/flow/variable-resolver.test.ts
+++ b/tests/flow/variable-resolver.test.ts
@@ -8,6 +8,7 @@ import {
   interpolate,
   hasPlaceholders,
   interpolateStep,
+  redactSensitiveData,
   loadEnvironmentFile,
   loadInlineBindings,
   mergeBindings,
@@ -141,6 +142,29 @@ describe('interpolateStep', () => {
     const result = interpolateStep(step, bindings);
     expect(result.text).toBe('p4ss');
     expect(result.verbatim).toBe('type "***"');
+    expect(result.sensitive).toBe(true);
+    expect(result.sensitiveValues).toEqual(['p4ss']);
+  });
+
+  test('interpolates and tracks secrets inside nested selectors', () => {
+    const step = {
+      kind: 'assert' as const,
+      selector: { id: 'password', value: '${secrets.__TEST_PASS}' },
+      properties: { value: '${secrets.__TEST_PASS}' },
+    };
+    const result = interpolateStep(step, bindings);
+    expect(result.selector.value).toBe('p4ss');
+    expect(result.properties.value).toBe('p4ss');
+    expect(result.sensitiveValues).toEqual(['p4ss']);
+    expect(
+      redactSensitiveData(
+        { message: 'expected p4ss', selector: result.selector },
+        result.sensitiveValues
+      )
+    ).toEqual({
+      message: 'expected ***',
+      selector: { id: 'password', value: '***' },
+    });
   });
 
   test('returns same object when bindings are empty and no secrets', () => {

--- a/tests/sdk/device-session.test.ts
+++ b/tests/sdk/device-session.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test, vi } from 'vitest';
+import type { MCPClient } from '@appclaw/core/mcp/types';
+import { createPlatformSession } from '@appclaw/core/device/session';
+
+interface ToolCall {
+  name: string;
+  args: Record<string, unknown>;
+}
+
+function makeConfig() {
+  return {
+    CAPABILITIES_FILE: '',
+    CLOUD_PROVIDER: '',
+    APP_PATH: '',
+    APPIUM_MJPEG_SCREENSHOT_URL: '',
+    APPIUM_MJPEG_SERVER_PORT: 0,
+  } as any;
+}
+
+function makeMcp(calls: ToolCall[], settingsResult = 'Successfully updated driver settings.') {
+  return {
+    callTool: vi.fn(async (name: string, args: Record<string, unknown> = {}) => {
+      calls.push({ name, args });
+      if (name === 'appium_session_management') {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: 'ANDROID session created successfully with ID: device-session-123',
+            },
+          ],
+        };
+      }
+      if (name === 'appium_driver_settings') {
+        return { content: [{ type: 'text' as const, text: settingsResult }] };
+      }
+      if (name === 'appium_mobile_device_info') {
+        return { content: [{ type: 'text' as const, text: '{"realDisplaySize":"1080x2400"}' }] };
+      }
+      if (name === 'appium_get_window_size') {
+        return { content: [{ type: 'text' as const, text: '{"width":390,"height":844}' }] };
+      }
+      return { content: [] };
+    }),
+    listTools: vi.fn(async () => []),
+    close: vi.fn(async () => {}),
+  } satisfies MCPClient;
+}
+
+describe('createPlatformSession driver settings', () => {
+  test('updates Android driver settings before device probing', async () => {
+    const calls: ToolCall[] = [];
+
+    await createPlatformSession(makeMcp(calls), makeConfig(), 'android');
+
+    expect(calls.map((call) => call.name)).toEqual([
+      'appium_session_management',
+      'appium_driver_settings',
+      'appium_mobile_device_info',
+    ]);
+    expect(calls[1].args).toEqual({
+      sessionId: 'device-session-123',
+      action: 'update',
+      settings: {
+        actionAcknowledgmentTimeout: 0,
+        waitForIdleTimeout: 0,
+        waitForSelectorTimeout: 0,
+      },
+    });
+  });
+
+  test('does not apply Android-only settings to iOS sessions', async () => {
+    const calls: ToolCall[] = [];
+
+    await createPlatformSession(makeMcp(calls), makeConfig(), 'ios');
+
+    expect(calls.some((call) => call.name === 'appium_driver_settings')).toBe(false);
+  });
+
+  test('fails session initialization when driver settings are rejected', async () => {
+    const calls: ToolCall[] = [];
+
+    await expect(
+      createPlatformSession(
+        makeMcp(calls, 'Failed to update driver settings. Error: unsupported setting'),
+        makeConfig(),
+        'android'
+      )
+    ).rejects.toThrow('Failed to update driver settings. Error: unsupported setting');
+
+    expect(calls.some((call) => call.name === 'appium_mobile_device_info')).toBe(false);
+    expect(calls.at(-1)).toEqual({
+      name: 'appium_session_management',
+      args: { action: 'delete', sessionId: 'device-session-123' },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds a deterministic accessibility-tree lane to YAML flows while preserving the existing natural-language/vision lane:

- select elements by exact/contains/regex `text`, `id`, `accessibilityId`, `type`, `hint`, or `value`
- disambiguate by state, index, spatial relations, and accessibility-tree relations
- use structured targets from tap, type, wait, swipe, scroll, and assertion steps
- assert element presence, state, content, count, dimensions, and coordinates with actionable selector diagnostics
- retain selector diagnostics in reports, including redaction for password values

Structured targets fail deterministically when the accessibility tree cannot resolve them; they do not silently fall back to vision. Existing semantic string targets remain backward compatible.

```yaml
- tap:
    target:
      id: com.example:id/search
      enabled: true
      clickable: true

- assert:
    target:
      id: com.example:id/submit
      rightOf:
        id: com.example:id/editor
    properties:
      visible: true
      enabled: true
      width:
        gte: 120
```

## Android stability fixes

Real-device validation exposed two Android-specific gaps that are included here:

- keep stable resource-id nodes even when UiAutomator2 reports them as non-clickable or without accessible text
- apply UiAutomator2 idle/selector/action timeouts through the post-session settings endpoint instead of invalid session capabilities

This makes id-only child containers addressable and prevents dynamic apps from waiting for an idle accessibility tree before each page-source read.

## Compatibility

- preserves the v2.2.0 anchored `scrollAssert` target/target-proximity behavior from #55
- adds a focused regression for `scrollAssert` using both a structured selector and an anchored target
- keeps legacy string YAML syntax and semantic/vision execution unchanged

## Documentation

- README examples and feature overview
- `docs/structured-selectors.md` selector/assertion reference and migration guidance
- `docs/runner-architecture.md` Android hierarchy and post-session settings details
- OpenSpec change `fix-android-structured-selector-device-stability`

## Validation

- `npm run typecheck`
- `npm test` — 24 files, 448 tests passed
- `npm run format:check`
- `openspec validate fix-android-structured-selector-device-stability --strict`
- focused flow compatibility suite — 44 tests passed
- Android physical device, OnePlus 8T / Android 14 / Kuaishou `com.smile.gifmaker`: 8/8 steps passed; compound selectors, state/geometry assertions, and `rightOf` relation verified (`20260811T091013-9f73ee`)
- iOS physical device, iPhone 16 Plus / iOS 26.2.1 / Kuaishou `com.kwai.gif.qmk.edge`: two 8/8 structured-flow runs passed before the v2.2.0 rebase (`20260811T083033-e6c872`, `20260811T083117-0a7d83`)

The post-rebase range-diff retains the Android fix unchanged; the only integration delta is preserving both the upstream anchored-scroll arguments and the new structured selector, covered by the focused compatibility test above.
